### PR TITLE
Fix pulsed labels

### DIFF
--- a/src/qudi/hardware/dummy/fast_counter_dummy.py
+++ b/src/qudi/hardware/dummy/fast_counter_dummy.py
@@ -54,11 +54,10 @@ class FastCounterDummy(FastCounterInterface):
             self.log.info('{0}: {1}'.format(key,config[key]))
 
         if self.trace_path is None:
-            print(__file__)
             self.trace_path = os.path.abspath(os.path.join(__file__,
                                                            '..',
                                                            'FastComTec_demo_timetrace.asc'))
-            print(self.trace_path)
+            self.log.debug(f"Loading dummy fastcounter trace: {self.trace_path}")
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -1608,7 +1608,7 @@ class PulsedMeasurementLogic(LogicBase):
 
         if with_error:
             ax1.errorbar(x=x_axis_scaled, y=self.signal_data[1],
-                         yerr=self.measurement_error[1], fmt='-o',
+                         yerr=self.measurement_error[1],
                          linestyle=':', linewidth=0.5, color=colors[0],
                          ecolor=colors[1], capsize=3, capthick=0.9,
                          elinewidth=1.2, label='data trace 1')
@@ -1620,7 +1620,7 @@ class PulsedMeasurementLogic(LogicBase):
                              ecolor=colors[4],  capsize=3, capthick=0.7,
                              elinewidth=1.2, label='data trace 2')
         else:
-            ax1.plot(x_axis_scaled, self.signal_data[1], '-o', color=colors[0],
+            ax1.plot(x_axis_scaled, self.signal_data[1], color=colors[0],
                      linestyle=':', linewidth=0.5, label='data trace 1')
 
             if self._alternating:

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -1569,7 +1569,20 @@ class PulsedMeasurementLogic(LogicBase):
             else:
                 return fit.success and np.sum(np.abs(fit.high_res_best_fit[1])) > 0
 
+        def _subscript_html_2_tex(text_str):
+            if "$" in text_str:
+                self.log.warning("Latex character '$' in string; expect wrong text rendering."
+                                 " Please use rich text html instead.")
+            else:
+                # transform to math expression, use non-italic font
+                text_str = r"$\mathrm{" + text_str + "}$"
 
+            # handle subscript
+            text_str = text_str.replace("<sub>","_{").replace("</sub>","}")
+            # handle white space
+            text_str = text_str.replace(" ", "\ ")
+
+            return text_str
 
         # Prepare the figure to save as a "data thumbnail"
         plt.style.use(QudiMatplotlibStyle.style)
@@ -1652,28 +1665,34 @@ class PulsedMeasurementLogic(LogicBase):
 
                 ft_label = '{0} of data traces'.format(self._alternative_data_type)
 
-            ax2.plot(x_axis_ft_scaled, self.signal_alt_data[1], '-o',
+            ax2.plot(x_axis_ft_scaled, self.signal_alt_data[1],
                      linestyle=':', linewidth=0.5, color=colors[0],
                      label=ft_label)
             if self._alternating and len(self.signal_alt_data) > 2:
-                ax2.plot(x_axis_ft_scaled, self.signal_alt_data[2], '-D',
+                ax2.plot(x_axis_ft_scaled, self.signal_alt_data[2],
                          linestyle=':', linewidth=0.5, color=colors[3],
                          label=ft_label.replace('1', '2'))
 
-            ax2.set_xlabel(x_axis_ft_label)
-            ax2.set_ylabel(y_axis_ft_label)
+            data_ft_label_tex = [_subscript_html_2_tex(x_axis_ft_label),
+                                 _subscript_html_2_tex(y_axis_ft_label)]
+
+            ax2.set_xlabel(data_ft_label_tex[0])
+            ax2.set_ylabel(data_ft_label_tex[1])
             ax2.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
                        mode="expand", borderaxespad=0.)
 
             if _is_fit_available(use_alternative_data=True):
                 _plot_fit(axis=ax2, use_alternative_data=True)
 
+        data_label_tex = [_subscript_html_2_tex(self._data_labels[0]),
+                          _subscript_html_2_tex(self._data_labels[1])]
+
         ax1.set_xlabel(
-            '{0} ({1}{2})'.format(self._data_labels[0], counts_prefix, self._data_units[0]))
+            '{0} ({1}{2})'.format(data_label_tex[0], counts_prefix, self._data_units[0]))
         if self._data_units[1]:
-            ax1.set_ylabel('{0} ({1})'.format(self._data_labels[1], self._data_units[1]))
+            ax1.set_ylabel('{0} ({1})'.format(data_label_tex[1], self._data_units[1]))
         else:
-            ax1.set_ylabel('{0}'.format(self._data_labels[1]))
+            ax1.set_ylabel('{0}'.format(data_label_tex[1]))
 
         fig.tight_layout()
         ax1.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,


### PR DESCRIPTION
Fixes the x axis of exported pulsed thumbnails from html tags (`<sub>`). 

## Description
While the pulsed gui (based on pyqtgraph) supports html tags for the labels, the thumbnail export via matplotlib does not.
This fix transforms (only) html superscript `<sub>` tags to the required Latex format. Currently, `<sub>` is the only html tag used in predefined methods.

## How Has This Been Tested?
Dummy mode.

## Screenshots (only if appropriate, delete if not):
Buggy:
![image](https://user-images.githubusercontent.com/5861249/141747465-c79850f4-4ba3-4cda-9ca3-83307512ff5a.png)
Fixed:
![image](https://user-images.githubusercontent.com/5861249/141747513-a28e6449-0f98-4f35-aa6c-3bbe02bdf870.png)

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
