### PR TITLE
Bug fix to ODMR scan power

### DIFF
--- a/src/qudi/gui/odmr/odmr_control_dockwidget.py
+++ b/src/qudi/gui/odmr/odmr_control_dockwidget.py
@@ -108,6 +108,7 @@ class OdmrScanControlDockWidget(AdvancedDockWidget):
     sigRangeCountChanged = QtCore.Signal(int)
     sigRangeChanged = QtCore.Signal(float, float, int, int)
     sigRuntimeChanged = QtCore.Signal(float)
+    sigPowerChanged = QtCore.Signal(float)
     sigAveragedScansChanged = QtCore.Signal(int)
     sigDataSelectionChanged = QtCore.Signal(str, int)
 
@@ -152,6 +153,7 @@ class OdmrScanControlDockWidget(AdvancedDockWidget):
         self.scan_power_spinbox.setMinimumWidth(_min_spinbox_width)
         self.scan_power_spinbox.setDecimals(6)
         self.scan_power_spinbox.setSuffix('dBm')
+        self.scan_power_spinbox.valueChanged.connect(self._scan_power_cb)
         self.scan_power_spinbox.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                                               QtWidgets.QSizePolicy.Fixed)
         if power_range is not None:
@@ -352,6 +354,10 @@ class OdmrScanControlDockWidget(AdvancedDockWidget):
     @QtCore.Slot()
     def _runtime_changed_cb(self):
         self.sigRuntimeChanged.emit(self.runtime_spinbox.value())
+
+    @QtCore.Slot()
+    def _scan_power_cb(self):
+        self.sigPowerChanged.emit(self.scan_power_spinbox.value())
 
     @QtCore.Slot()
     def _add_frequency_clicked_cb(self):

--- a/src/qudi/gui/odmr/odmrgui.py
+++ b/src/qudi/gui/odmr/odmrgui.py
@@ -175,6 +175,9 @@ class OdmrGui(GuiBase):
         self._scan_control_dockwidget.sigRuntimeChanged.connect(
             logic.set_runtime, QtCore.Qt.QueuedConnection
         )
+        self._scan_control_dockwidget.sigPowerChanged.connect(
+            logic.set_scan_power, QtCore.Qt.QueuedConnection
+        )
         self._scan_control_dockwidget.sigAveragedScansChanged.connect(
             logic.set_scans_to_average, QtCore.Qt.QueuedConnection
         )

--- a/src/qudi/logic/odmr_logic.py
+++ b/src/qudi/logic/odmr_logic.py
@@ -290,6 +290,27 @@ class OdmrLogic(LogicBase):
             self.sigScanParametersUpdated.emit({'run_time': self._run_time})
 
     @property
+    def scan_power(self):
+        return self._scan_power
+
+    @scan_power.setter
+    def scan_power(self, value):
+        self.set_scan_power(value)
+
+    @QtCore.Slot(object)
+    def set_scan_power(self, scan_power):
+        """ Sets the runtime for ODMR measurement
+
+        @param float scan_power: desired power for scans in dBm
+        """
+        with self._threadlock:
+            try:
+                self._scan_power = float(scan_power)
+            except (TypeError, ValueError):
+                self.log.exception('scan_power failed:')
+            self.sigScanParametersUpdated.emit({'scan_power': self._scan_power})
+
+    @property
     def frequency_ranges(self):
         return self._scan_frequency_ranges.copy()
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
ODMR scan power was just not handed through from GUI to the hardware file.

## Description
<!--- Describe your changes in detail -->
The gui element was declared but never connected to anything. So the fix was to simply hand through the value from the gui to the logic and it worked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug Fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Win10 21H1 with pure python 3.8.10 on dummy hardware. The debug message now shows the correct value.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
