### PR TITLE
[Fix] Pulse editor gui 

### DIFF
--- a/src/qudi/gui/pulsed/pulse_editors.py
+++ b/src/qudi/gui/pulsed/pulse_editors.py
@@ -488,15 +488,18 @@ class BlockEditor(QtWidgets.QTableView):
         self.setItemDelegateForColumn(
             1, ScienDSpinBoxItemDelegate(self, increment_item_dict, self.model().incrementRole))
 
+        self.setItemDelegateForColumn(
+            2, CheckBoxItemDelegate(self, self.model().laserRole))
+
         # If any digital channels are present, set item delegate (custom multi-CheckBox widget)
         # for digital channels column.
         if len(self.model().digital_channels) > 0:
             chnl_labels = natural_sort(chnl.split('d_ch')[1] for chnl in self.model().digital_channels)
             self.setItemDelegateForColumn(
-                2, MultipleCheckboxItemDelegate(self, chnl_labels, self.model().digitalStateRole))
-            offset_index = 3  # to indicate which column comes next.
+                3, MultipleCheckboxItemDelegate(self, chnl_labels, self.model().digitalStateRole))
+            offset_index = 4  # to indicate which column comes next.
         else:
-            offset_index = 2  # to indicate which column comes next.
+            offset_index = 3  # to indicate which column comes next.
 
         # loop through all analog channels and set two item delegates for each channel.
         # First a ComboBox delegate for the analog shape column and second a custom


### PR DESCRIPTION
## Description
The pulse editor gui was not showing digital channels correctly in its tabular view. The fix reverts changes made during the port; potentially by mistake.

## Screenshots (only if appropriate, delete if not):
Working again:
![image](https://user-images.githubusercontent.com/5861249/145248574-0ce462dd-3cf4-4420-b9a0-d7a78134d6a4.png)

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [ ] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
