### PR TITLE
bug fix to qdplotter and benchmarking tool

### DIFF
--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -389,7 +389,7 @@ class QDPlotterGui(GuiBase):
                 symbol='d',
                 symbolSize=6,
                 symbolBrush=mkColor(pen_color)))
-            self._plot_curves[plot_index][-1].setData(x=xd, y=yd)
+            self._plot_curves[plot_index][-1].setData(x=list(xd), y=yd)
             self._fit_curves[plot_index].append(dockwidget.plot_widget.plot())
             self._fit_curves[plot_index][-1].setPen('r')
 

--- a/src/qudi/util/benchmark.py
+++ b/src/qudi/util/benchmark.py
@@ -17,7 +17,7 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-
+import sys
 from collections import deque
 import scipy
 import numpy as np
@@ -138,7 +138,7 @@ class BenchmarkTool(object):
         try:
             a, t0, _, _, da = scipy.stats.linregress(weighted_data[:, 1], weighted_data[:, 0])
         except Exception:
-            self.log.exception('Linear fit failed: ')
+            print('Linear fit failed: ', file=sys.stderr)
             return np.nan, np.nan, np.nan
 
         return a, t0, da


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
For some reason numpy can't do a `np.isfinite()` on its own data-types. Therefore we convert it to list first.

The benchmark called `self.log` although it wasn't a qudi module, causing an error. Replaced that by a `print`.

## Description
<!--- Describe your changes in detail -->
A bug in qdplotter showed up, if only one point was plotted and the x-axis is a ndarray.

Errors in stand-alone modules need to be printed and can't be posted via `self.log.error`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing bugs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with current core on NVision/LP1 running on Win 10 21H1

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
