### PR TITLE
fix: not-fulfilled switch interface

### DIFF
--- a/src/qudi/hardware/spincore/pulse_blaster_esrpro.py
+++ b/src/qudi/hardware/spincore/pulse_blaster_esrpro.py
@@ -1096,7 +1096,7 @@ class PulseBlasterESRPRO(SwitchInterface, PulserInterface):
         """
         return len(self._switch_states)
 
-    def _get_witch_state(self, switch_num):
+    def _get_switch_state(self, switch_num):
         """ Gives state of switch.
 
         @param int switch_num: number of switch, numbering starts with 0
@@ -2037,7 +2037,7 @@ class PulseBlasterESRPRO(SwitchInterface, PulserInterface):
         @return str: The current switch state
         """
 
-        return self._get_witch_state(self._switch_name_to_num(switch))
+        return self._get_switch_state(self._switch_name_to_num(switch))
 
     def set_state(self, switch, state):
         """ Query state of single switch by name

--- a/src/qudi/hardware/spincore/pulse_blaster_esrpro.py
+++ b/src/qudi/hardware/spincore/pulse_blaster_esrpro.py
@@ -21,6 +21,7 @@ If not, see <https://www.gnu.org/licenses/>.
 """
 
 import ctypes
+from ctypes.util import find_library
 import platform
 import numpy as np
 
@@ -225,7 +226,7 @@ class PulseBlasterESRPRO(SwitchInterface, PulserInterface):
 
 
         # check at first the config option, whether a correct library was found
-        lib_path = ctypes.util.find_library(self._library_path)
+        lib_path = find_library(self._library_path)
 
         if lib_path is None:
             # Check the platform architecture:
@@ -244,7 +245,7 @@ class PulseBlasterESRPRO(SwitchInterface, PulserInterface):
             # (= *.so) file muss be within the same directory, where the file
             # is situated.
 
-            lib_path = ctypes.util.find_library(libname)
+            lib_path = find_library(libname)
 
         if lib_path is None:
             self.log.error('No library could be loaded for the PulseBlaster '
@@ -2003,3 +2004,38 @@ class PulseBlasterESRPRO(SwitchInterface, PulserInterface):
         @return: bool, True for yes, False for no.
         """
         return False
+
+    @property
+    def name(self):
+        """ Name of the hardware as string.
+
+        @return str: The name of the hardware
+        """
+        raise NotImplemented
+
+    @property
+    def available_states(self):
+        """ Names of the states as a dict of tuples.
+
+        The keys contain the names for each of the switches. The values are tuples of strings
+        representing the ordered names of available states for each switch.
+
+        @return dict: Available states per switch in the form {"switch": ("state1", "state2")}
+        """
+        raise NotImplemented
+
+    def get_state(self, switch):
+        """ Query state of single switch by name
+
+        @param str switch: name of the switch to query the state for
+        @return str: The current switch state
+        """
+        raise NotImplemented
+
+    def set_state(self, switch, state):
+        """ Query state of single switch by name
+
+        @param str switch: name of the switch to change
+        @param str state: name of the state to set
+        """
+        raise NotImplemented


### PR DESCRIPTION
PulseBlaster was broken before due to not fulfilled SwitchInterface.
Fixed with dummy implemntations.

## How Has This Been Tested?
On real setup (M26/4219)

## Screenshots (only if appropriate, delete if not):

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
