### PR TITLE
Small fixes

### DIFF
--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -27,6 +27,7 @@ import time
 import copy
 import traceback
 import datetime
+import re
 
 from PySide2 import QtCore
 from qudi.core.statusvariable import StatusVar
@@ -325,15 +326,15 @@ class SequenceGeneratorLogic(LogicBase):
         name_list = list(asset_names.values())
         if asset_type == 'waveform' and len(name_list) > 0:
             return_type = 'PulseBlockEnsemble'
-            return_name = name_list[0].rsplit('_', 1)[0]
+            return_name = self._strip_ch_extension(name_list[0])
             for name in name_list:
-                if name.rsplit('_', 1)[0] != return_name:
+                if self._strip_ch_extension(name) != return_name:
                     return '', ''
         elif asset_type == 'sequence' and len(name_list) > 0:
             return_type = 'PulseSequence'
-            return_name = name_list[0].rsplit('_', 1)[0]
+            return_name = self._strip_ch_extension(name_list[0])
             for name in name_list:
-                if name.rsplit('_', 1)[0] != return_name:
+                if self._strip_ch_extension(name) != return_name:
                     return '', ''
         else:
             return '', ''
@@ -2119,6 +2120,22 @@ class SequenceGeneratorLogic(LogicBase):
                 self.pulsegenerator().delete_sequence(seq)
         self.sigAvailableSequencesUpdated.emit(self.sampled_sequences)
         return
+
+    def _strip_ch_extension(self, wave_name):
+        """
+        :param wave_name: with (rabi_ch1) or without (rabi) channel extension.
+        :return: stripped name (rabi)
+        """
+        pattern = ".*_ch[0-9]+?"
+        has_ch_ext = True if re.match(pattern, wave_name) is not None else False
+
+        if has_ch_ext:
+            pattern_split = '_ch[0-9]+?'
+            return re.split(pattern_split, wave_name)[0]
+        else:
+            # unsafer, because name including '_' will break
+            return wave_name.rsplit('_', 1)[0]
+
 
     @QtCore.Slot()
     def run_pg_benchmark(self, t_goal=10):

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -2120,7 +2120,8 @@ class SequenceGeneratorLogic(LogicBase):
                 self.pulsegenerator().delete_sequence(seq)
         self.sigAvailableSequencesUpdated.emit(self.sampled_sequences)
         return
-
+    
+    @staticmethod
     def _strip_ch_extension(self, wave_name):
         """
         :param wave_name: with (rabi_ch1) or without (rabi) channel extension.

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -2122,7 +2122,7 @@ class SequenceGeneratorLogic(LogicBase):
         return
     
     @staticmethod
-    def _strip_ch_extension(self, wave_name):
+    def _strip_ch_extension(wave_name):
         """
         :param wave_name: with (rabi_ch1) or without (rabi) channel extension.
         :return: stripped name (rabi)


### PR DESCRIPTION
1. Code cleanup in Fastcomtech code.
2. Maybe more controversial: It seems like some pulser do not strictly add a channel extension to their waveform and sometimes sequence names (eg. 'rabi_ch1'). Currently, this yields wrong results for loaded_assets. This fix is more foregiving, by first checking if the channel extension is used. Alternatively, one could make sure that all devices strictly follow the intended behavior.