### PR TITLE
Label for qdplotter

### DIFF
--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -375,7 +375,6 @@ class QDPlotterGui(GuiBase):
 
         dockwidget = self._plot_dockwidgets[plot_index]
         dockwidget.plot_widget.clear()
-        legend = dockwidget.plot_widget.addLegend()
 
         self._pen_colors[plot_index] = cycle(self._pen_color_list)
         self._plot_curves[plot_index] = list()
@@ -394,11 +393,6 @@ class QDPlotterGui(GuiBase):
             self._plot_curves[plot_index][-1].setData(x=xd, y=yd)
             self._fit_curves[plot_index].append(dockwidget.plot_widget.plot())
             self._fit_curves[plot_index][-1].setPen('r')
-
-        if len(x_data) > 1:
-            legend.setVisible(True)
-        else:
-            legend.setVisible(False)
 
     @QtCore.Slot(int)
     @QtCore.Slot(int, dict)

--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -359,8 +359,8 @@ class QDPlotterGui(GuiBase):
             self._mw.resizeDocks(
                 self._plot_dockwidgets, [1] * len(self._plot_dockwidgets), QtCore.Qt.Horizontal)
 
-    @QtCore.Slot(int, list, list, bool)
-    def update_data(self, plot_index, x_data=None, y_data=None, clear_old=None):
+    @QtCore.Slot(int, list, list, list)
+    def update_data(self, plot_index, x_data=None, y_data=None, data_labels=None):
         """ Function creates empty plots, grabs the data and sends it to them. """
         if not (0 <= plot_index < len(self._plot_dockwidgets)):
             self.log.warning('Tried to update plot with invalid index {0:d}'.format(plot_index))
@@ -370,14 +370,14 @@ class QDPlotterGui(GuiBase):
             x_data = self._plot_logic.get_x_data(plot_index)
         if y_data is None:
             y_data = self._plot_logic.get_y_data(plot_index)
-        if clear_old is None:
-            clear_old = self._plot_logic.clear_old_data(plot_index)
+        if data_labels is None:
+            data_labels = self._plot_logic.get_data_labels(plot_index)
 
         dockwidget = self._plot_dockwidgets[plot_index]
-        if clear_old:
-            dockwidget.plot_widget.clear()
-            self._pen_colors[plot_index] = cycle(self._pen_color_list)
+        dockwidget.plot_widget.clear()
+        legend = dockwidget.plot_widget.addLegend()
 
+        self._pen_colors[plot_index] = cycle(self._pen_color_list)
         self._plot_curves[plot_index] = list()
         self._fit_curves[plot_index] = list()
 
@@ -388,10 +388,17 @@ class QDPlotterGui(GuiBase):
                 pen=mkColor(pen_color),
                 symbol='d',
                 symbolSize=6,
-                symbolBrush=mkColor(pen_color)))
+                symbolBrush=mkColor(pen_color),
+                name=data_labels[line]
+            ))
             self._plot_curves[plot_index][-1].setData(x=xd, y=yd)
             self._fit_curves[plot_index].append(dockwidget.plot_widget.plot())
             self._fit_curves[plot_index][-1].setPen('r')
+
+        if len(x_data) > 1:
+            legend.setVisible(True)
+        else:
+            legend.setVisible(False)
 
     @QtCore.Slot(int)
     @QtCore.Slot(int, dict)

--- a/src/qudi/gui/qdplot/qdplot_plot_dockwidget.py
+++ b/src/qudi/gui/qdplot/qdplot_plot_dockwidget.py
@@ -132,6 +132,7 @@ class PlotDockWidget(AdvancedDockWidget):
                                                     'left': CustomAxis(orientation='left')})
         self.plot_widget.getAxis('bottom').nudge = 0
         self.plot_widget.getAxis('left').nudge = 0
+        self.plot_widget.addLegend()
 
         plot_display_layout.addWidget(self.plot_widget, 1, 0, 1, -1, QtCore.Qt.AlignHCenter)
         self.plot_widget.setSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.MinimumExpanding)

--- a/src/qudi/logic/qdplot_logic.py
+++ b/src/qudi/logic/qdplot_logic.py
@@ -285,7 +285,7 @@ class QDPlotLogic(LogicBase):
                     if label is not None:
                         self.log.warning(f'length of label is {len(label)} '
                                          f'but needs to be the number of data sets ({len(x)}).')
-                    label = ['Dataset ' + i for i in list(range(len(x)))]
+                    label = ['Dataset ' + str(i) for i in range(len(x))]
                 if clear_old:
                     self._x_data[plot_index] = list(x)
                     self._y_data[plot_index] = list(y)
@@ -385,7 +385,7 @@ class QDPlotLogic(LogicBase):
                     tabbed_result = '\n  No Fit'
                 else:
                     tabbed_result = '\n  '.join(self._fit_container.formatted_result(fit_result).split('\n')[:-1])
-                result += 'data_set {0}:\n  {1}\n'.format(data_set, tabbed_result)
+                result += '{0}:\n  {1}\n'.format(self._data_labels[plot_index][data_set], tabbed_result)
 
             # convert list to np.ndarray to make handling it much more efficient
             fit_data = np.array(fit_data)

--- a/src/qudi/logic/qdplot_logic.py
+++ b/src/qudi/logic/qdplot_logic.py
@@ -50,7 +50,7 @@ class QDPlotLogic(LogicBase):
             fit_logic: 'fitlogic'
         default_plot_number: 3
     """
-    sigPlotDataUpdated = QtCore.Signal(int, list, list, bool)
+    sigPlotDataUpdated = QtCore.Signal(int, list, list, list)
     sigPlotParamsUpdated = QtCore.Signal(int, dict)
     sigPlotNumberChanged = QtCore.Signal(int)
     sigFitUpdated = QtCore.Signal(int, np.ndarray, str, str)
@@ -72,7 +72,6 @@ class QDPlotLogic(LogicBase):
         # locking for thread safety
         self.threadlock = RecursiveMutex()
 
-        self._clear_old = list()
         self._x_limits = list()
         self._y_limits = list()
         self._x_label = list()
@@ -81,6 +80,7 @@ class QDPlotLogic(LogicBase):
         self._y_unit = list()
         self._x_data = list()
         self._y_data = list()
+        self._data_labels = list()
 
         self._fit_data = list()
         self._fit_results = list()
@@ -101,7 +101,6 @@ class QDPlotLogic(LogicBase):
 
         # self._fit_logic = self.fit_logic()
 
-        self._clear_old = list()
         self._x_limits = list()
         self._y_limits = list()
         self._x_label = list()
@@ -110,6 +109,7 @@ class QDPlotLogic(LogicBase):
         self._y_unit = list()
         self._x_data = list()
         self._y_data = list()
+        self._data_labels = list()
         self._fit_data = list()
         self._fit_results = list()
         self._fit_method = list()
@@ -146,12 +146,11 @@ class QDPlotLogic(LogicBase):
     @property
     def number_of_plots(self):
         with self.threadlock:
-            return len(self._clear_old)
+            return len(self._x_label)
 
     @QtCore.Slot()
     def add_plot(self):
         with self.threadlock:
-            self._clear_old.append(True)
             self._x_limits.append([-0.5, 0.5])
             self._y_limits.append([-0.5, 0.5])
             self._x_label.append('X')
@@ -160,6 +159,7 @@ class QDPlotLogic(LogicBase):
             self._y_unit.append('a.u.')
             self._x_data.append([np.zeros(1)])
             self._y_data.append([np.zeros(1)])
+            self._data_labels.append(['Dataset 1'])
             self._fit_data.append(None)
             self._fit_results.append(None)
             self._fit_method.append('No Fit')
@@ -169,18 +169,18 @@ class QDPlotLogic(LogicBase):
             self.sigPlotDataUpdated.emit(plot_index,
                                          self._x_data[plot_index],
                                          self._y_data[plot_index],
-                                         self._clear_old[plot_index])
+                                         self._data_labels[plot_index])
             if self._fit_method[plot_index] != 'No Fit':
                 self.sigFitUpdated.emit(plot_index,
                                         self._fit_data[plot_index],
                                         self._fit_results[plot_index],
                                         self._fit_method[plot_index])
-            params = {'x_label': self._x_label[plot_index],
-                      'y_label': self._y_label[plot_index],
-                      'x_unit': self._x_unit[plot_index],
-                      'y_unit': self._y_unit[plot_index],
-                      'x_limits': self._x_limits[plot_index],
-                      'y_limits': self._y_limits[plot_index]}
+            params = {'x_label'    : self._x_label[plot_index],
+                      'y_label'    : self._y_label[plot_index],
+                      'x_unit'     : self._x_unit[plot_index],
+                      'y_unit'     : self._y_unit[plot_index],
+                      'x_limits'   : self._x_limits[plot_index],
+                      'y_limits'   : self._y_limits[plot_index]}
             self.sigPlotParamsUpdated.emit(plot_index, params)
 
     @QtCore.Slot()
@@ -191,7 +191,6 @@ class QDPlotLogic(LogicBase):
                 plot_index = -1
             elif not (0 <= plot_index < self.number_of_plots):
                 raise IndexError('Plot index {0:d} out of bounds.'.format(plot_index))
-            del self._clear_old[plot_index]
             del self._x_limits[plot_index]
             del self._y_limits[plot_index]
             del self._x_label[plot_index]
@@ -200,6 +199,7 @@ class QDPlotLogic(LogicBase):
             del self._y_unit[plot_index]
             del self._x_data[plot_index]
             del self._y_data[plot_index]
+            del self._data_labels[plot_index]
             del self._fit_data[plot_index]
             del self._fit_results[plot_index]
             del self._fit_method[plot_index]
@@ -207,14 +207,14 @@ class QDPlotLogic(LogicBase):
 
             update_range = (-1,) if plot_index == -1 else range(plot_index, self.number_of_plots)
             for i in update_range:
-                self.sigPlotDataUpdated.emit(i, self._x_data[i], self._y_data[i], self._clear_old[i])
+                self.sigPlotDataUpdated.emit(i, self._x_data[i], self._y_data[i], self._data_labels[i])
                 self.sigFitUpdated.emit(i, self._fit_data[i], self._fit_results[i], self._fit_method[i])
-                params = {'x_label': self._x_label[i],
-                          'y_label': self._y_label[i],
-                          'x_unit': self._x_unit[i],
-                          'y_unit': self._y_unit[i],
-                          'x_limits': self._x_limits[i],
-                          'y_limits': self._y_limits[i]}
+                params = {'x_label'    : self._x_label[i],
+                          'y_label'    : self._y_label[i],
+                          'x_unit'     : self._x_unit[i],
+                          'y_unit'     : self._y_unit[i],
+                          'x_limits'   : self._x_limits[i],
+                          'y_limits'   : self._y_limits[i]}
                 self.sigPlotParamsUpdated.emit(i, params)
 
     @QtCore.Slot(int)
@@ -256,11 +256,12 @@ class QDPlotLogic(LogicBase):
                            ''.format(plot_index))
             return [np.zeros(0)]
 
-    def set_data(self, x=None, y=None, clear_old=True, plot_index=0, adjust_scale=True):
+    def set_data(self, x=None, y=None, label=None, clear_old=True, plot_index=0, adjust_scale=True):
         """ Set the data to plot
 
         @param np.ndarray or list of np.ndarrays x: data of independents variable(s)
         @param np.ndarray or list of np.ndarrays y: data of dependent variable(s)
+        @param string or list of strings label: label of the added data set
         @param bool clear_old: clear old plots in GUI if True
         @param int plot_index: index of the plot in the range from 0 to 2
         @param bool adjust_scale: Whether auto-scale should be performed after adding data or not.
@@ -278,14 +279,38 @@ class QDPlotLogic(LogicBase):
                     'or add_plot() first.'.format(plot_index))
                 return -1
 
-            self._clear_old[plot_index] = clear_old
             # check if input is only an array (single plot) or a list of arrays (one or several plots)
             if isinstance(x[0], np.ndarray):  # if x is an array, type(x[0]) is a np.float
-                self._x_data[plot_index] = list(x)
-                self._y_data[plot_index] = list(y)
+                if label is None or len(label) != len(x):
+                    if label is not None:
+                        self.log.warning(f'length of label is {len(label)} '
+                                         f'but needs to be the number of data sets ({len(x)}).')
+                    label = ['Dataset ' + i for i in list(range(len(x)))]
+                if clear_old:
+                    self._x_data[plot_index] = list(x)
+                    self._y_data[plot_index] = list(y)
+                    self._data_labels[plot_index] = list(label)
+                else:
+                    self._x_data[plot_index].extend(list(x))
+                    self._y_data[plot_index].extend(list(y))
+                    self._data_labels[plot_index].extend(list(label))
             else:
-                self._x_data[plot_index] = [x]
-                self._y_data[plot_index] = [y]
+                if clear_old:
+                    self._x_data[plot_index] = [x]
+                    self._y_data[plot_index] = [y]
+                else:
+                    self._x_data[plot_index].append(x)
+                    self._y_data[plot_index].append(y)
+
+                if label is None or not isinstance(label, str):
+                    if label is not None:
+                        self.log.warning(f'label is {label} '
+                                         f'but needs to be a single string as name of the data set.')
+                    label = 'Dataset ' + str(len(self._x_data[plot_index]))
+                if clear_old:
+                    self._data_labels[plot_index] = [label]
+                else:
+                    self._data_labels[plot_index].append(label)
 
             # reset fit for this plot
             self._fit_data[plot_index] = None
@@ -299,10 +324,10 @@ class QDPlotLogic(LogicBase):
             self.sigPlotDataUpdated.emit(plot_index,
                                          self._x_data[plot_index],
                                          self._y_data[plot_index],
-                                         clear_old)
+                                         self._data_labels[plot_index])
             self.sigPlotParamsUpdated.emit(plot_index,
-                                           {'x_limits': self._x_limits[plot_index],
-                                            'y_limits': self._y_limits[plot_index]})
+                                           {'x_limits'   : self._x_limits[plot_index],
+                                            'y_limits'   : self._y_limits[plot_index]})
             if adjust_scale:
                 self.update_auto_range(plot_index, True, True)
             return 0
@@ -400,6 +425,7 @@ class QDPlotLogic(LogicBase):
             parameters['user-selected y-label'] = self._y_label[plot_index]
             parameters['user-selected x-unit'] = self._x_unit[plot_index]
             parameters['user-selected y-unit'] = self._y_unit[plot_index]
+            parameters['user-selected data-labels'] = self._data_labels[plot_index]
 
             # If there is a postfix then add separating underscore
             if postfix == '':
@@ -419,7 +445,8 @@ class QDPlotLogic(LogicBase):
                 ax1.plot(self._x_data[plot_index][data_set],
                          self._y_data[plot_index][data_set],
                          linestyle=':',
-                         linewidth=1)
+                         linewidth=1,
+                         label=self._data_labels[plot_index][data_set])
 
                 if self._fit_data[plot_index] is not None:
                     ax1.plot(self._fit_data[plot_index][data_set][0],
@@ -427,7 +454,7 @@ class QDPlotLogic(LogicBase):
                              color='r',
                              marker='None',
                              linewidth=1.5,
-                             label='fit')
+                             label='fit ' + self._data_labels[plot_index][data_set])
 
             # Do not include fit parameter if there is no fit calculated.
             if self._fit_data[plot_index] is not None:
@@ -480,6 +507,7 @@ class QDPlotLogic(LogicBase):
 
             ax1.set_xlim(self._x_limits[plot_index])
             ax1.set_ylim(self._y_limits[plot_index])
+            ax1.legend()
 
             fig.tight_layout()
 
@@ -642,6 +670,17 @@ class QDPlotLogic(LogicBase):
             self._y_label[plot_index] = str(value)
             self.sigPlotParamsUpdated.emit(plot_index, {'y_label': self._y_label[plot_index]})
 
+    def get_data_labels(self, plot_index=0):
+        """ Get the data set labels.
+
+        @param int plot_index: index of the plot in the range from 0 to 2
+        @return list(str): current labels of the data sets
+        """
+        with self.threadlock:
+            if not (0 <= plot_index < self.number_of_plots):
+                raise IndexError('Plot index {0:d} out of bounds.'.format(plot_index))
+            return self._data_labels[plot_index]
+
     def get_units(self, plot_index=0):
         with self.threadlock:
             return self.get_x_unit(plot_index), self.get_y_unit(plot_index)
@@ -696,17 +735,6 @@ class QDPlotLogic(LogicBase):
                 raise IndexError('Plot index {0:d} out of bounds.'.format(plot_index))
             self._y_unit[plot_index] = str(value)
             self.sigPlotParamsUpdated.emit(plot_index, {'y_unit': self._y_unit[plot_index]})
-
-    def clear_old_data(self, plot_index=0):
-        """ Get the information, if the previous plots in the windows are kept or not
-
-        @param int plot_index: index of the plot in the range from 0 to 2
-        @return bool: are the plots currently in the GUI kept or not
-        """
-        with self.threadlock:
-            if not (0 <= plot_index < self.number_of_plots):
-                raise IndexError('Plot index {0:d} out of bounds.'.format(plot_index))
-            return self._clear_old[plot_index]
 
     @QtCore.Slot(int, dict)
     def update_plot_parameters(self, plot_index, params):


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
The QDPlotter now supports labels for the datasets.

## Description
<!--- Describe your changes in detail -->
A Label is shown in the GUI to distinguish multiple data sets in one plot. Same is also implemented for the saved data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the process, the way the clear attribute was handled has changed. Before the old data was "lost" in the logic, now it is saved.

Backwards compatible, as the labels are created automatically if not specified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Win 10 Pro 21H2, python 3.8.10, qudi-core 1.0.1, qudi-iqo-modules 0.1.0, pyqtgraph 0.12.3

## Screenshots (only if appropriate, delete if not):
![grafik](https://user-images.githubusercontent.com/18718646/185102471-b587d6a8-2f35-4317-a186-8c261813815f.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
