### PR TITLE
Ni interfuse data polling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 - Resolved some issues with QDPlot GUI layouts and improved overall QDPlot GUI code quality
 - catching null bytes in Keysight M3202A module
+- The NiScanningProbeInterfuse now polls data in chunks and independent of logic calls, as it should be.
 
 ### New Features
 - support for Zaber (linear) motorized stages (in hardware/motor/zaber_motion)

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -116,7 +116,6 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         self._default_timer_interval_ms = -1
         self._interval_time_stamp = None
 
-        self.__read_pos = -1
         self.__scan_stopped = False
 
         self._thread_lock_cursor = Mutex()
@@ -412,7 +411,6 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
             first_scan_position = {ax: pos[0] for ax, pos
                                    in zip(self.scan_settings['axes'], self.scan_settings['range'])}
             self._move_to_and_start_scan(first_scan_position)
-            self.__read_pos = 0
 
             return 0  # FIXME Bool indicators deprecated
 

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -527,11 +527,14 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
 
     def _fetch_data_chunk(self):
         try:
-            self.log.debug(f'fetch chunk: {self._ni_finite_sampling_io().samples_in_buffer}, {self.is_scan_running}')
-            chunk_size = self._scan_data.scan_resolution[0] + self.__backwards_line_resolution
-            # chunk_size = 10  # FIXME Don't hard code chunk size? The above does not work with 1D scans. Why?
+            # self.log.debug(f'fetch chunk: {self._ni_finite_sampling_io().samples_in_buffer}, {self.is_scan_running}')
+            # chunk_size = self._scan_data.scan_resolution[0] + self.__backwards_line_resolution
+            chunk_size = 10  # TODO Hardcode or go line by line as commented out above?
+            # Request a minimum of chunk_size samples per loop
             try:
-                samples_dict = self._ni_finite_sampling_io().get_buffered_samples(chunk_size)
+                samples_dict = self._ni_finite_sampling_io().get_buffered_samples(chunk_size) \
+                    if self._ni_finite_sampling_io().samples_in_buffer < chunk_size\
+                    else self._ni_finite_sampling_io().get_buffered_samples()
             except ValueError:  # ValueError is raised, when more samples are requested then pending or still to get
                 # after HW stopped
                 samples_dict = self._ni_finite_sampling_io().get_buffered_samples()

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -440,6 +440,7 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         """
         try:
             # self.log.debug("Stopping scan...")
+            self._start_scan_after_cursor = False  # Ensure Scan HW is not started after movement
             if self._ao_setpoint_channels_active:
                 self._abort_cursor_movement()
                 # self.log.debug("Move aborted")

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -170,6 +170,7 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         self.__ni_ao_write_timer.timeout.connect(self.__ao_cursor_write_loop, QtCore.Qt.QueuedConnection)
 
         self._target_pos = self.get_position()  # get voltages/pos from ni_ao
+        self._toggle_ao_setpoint_channels(False)  # And free ao resources after that
 
         self.sigNextDataChunk.connect(self._fetch_data_chunk, QtCore.Qt.QueuedConnection)
 
@@ -463,9 +464,12 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
     def get_scan_data(self):
         """
 
-        @return (bool, ScanData): Failure indicator (fail=True), ScanData instance used in the scan
+        @return (ScanData): ScanData instance used in the scan
         #  TODO change interface
         """
+
+        if self._scan_data is None:
+            raise RuntimeError('ScanData is not yet configured, please call "configure_scan" first')
         try:
             with self._thread_lock_data:
                 return self._scan_data.copy()

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -270,9 +270,10 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
                         position_feedback_axes=None
                     )
                     self.raw_data_container = RawDataContainer(self._scan_data.channels,
-                                                     resolution[1] if self._scan_data.scan_dimension == 2 else 1,
-                                                     resolution[0],
-                                                     self.__backwards_line_resolution)
+                                                               resolution[
+                                                                   1] if self._scan_data.scan_dimension == 2 else 1,
+                                                               resolution[0],
+                                                               self.__backwards_line_resolution)
                     # self.log.debug(f"New scanData created: {self._scan_data.data}")
 
                 except:
@@ -440,7 +441,7 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         # FIXME Fix the mess of bool indicators, int return values etc in toolchain
         """
         try:
-            #self.log.debug("Stopping scan...")
+            # self.log.debug("Stopping scan...")
             if self._ao_setpoint_channels_active:
                 self._abort_cursor_movement()
                 # self.log.debug("Move aborted")
@@ -466,17 +467,8 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         @return (bool, ScanData): Failure indicator (fail=True), ScanData instance used in the scan
         #  TODO change interface
         """
-        # todo: get_scan data ussage for polling hw &iterating __read_pos seems sketchy
-        # => this hw file should implement it's own polling loop and provide updated ._scan_data
-        # when get_scan_data is called
         try:
-            if not self.is_scan_running or not self._ni_finite_sampling_io().is_running:
-                return self._scan_data
-            else:
-                # _stop_scan is called asynchronously. Thus .is_scan_running might be True, even if last data frame
-                # was already fetched. __scan_stopped is set by the polling thread, guaranteed to signal in time.
-                # if not self.__scan_stopped:
-                #     self._fetch_data_line()
+            with self._thread_lock_data:
                 return self._scan_data.copy()
         except:
             self.log.exception("")
@@ -793,7 +785,7 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
 
             if not self._ao_setpoint_channels_active:
                 self._toggle_ao_setpoint_channels(True)
-                #self.log.debug(f"AO activated")
+                # self.log.debug(f"AO activated")
 
             start_pos = self.get_position()
             constr = self.get_constraints()
@@ -839,7 +831,6 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
 
         except:
             self.log.exception("")
-
 
     def __start_ao_write_timer(self):
         # self.log.debug(f"ao start write timer in thread {self.thread()}, QT.QThread {QtCore.QThread.currentThread()} ")

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -517,6 +517,10 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         # not thread safe, call from thread_lock protected code only
         return all([values.size == 0 for values in self.__write_queue.values()])
 
+    def _check_scan_end_reached(self):
+        # not thread safe, call from thread_lock protected code only
+        return self.raw_data_container.is_full
+
     def _fetch_data_chunk(self):
         try:
             # self.log.debug(f'fetch chunk: {self._ni_finite_sampling_io().samples_in_buffer}, {self.is_scan_running}')
@@ -539,7 +543,7 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
                 self.raw_data_container.fill_container(new_data)
                 self._scan_data.data = self.raw_data_container.forwards_data()
 
-                if self.raw_data_container.is_full:
+                if self._check_scan_end_reached():
                     self.stop_scan()
                 elif not self.is_scan_running:
                     return

--- a/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
+++ b/src/qudi/hardware/interfuse/ni_scanning_probe_interfuse.py
@@ -172,6 +172,8 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
 
         self._target_pos = self.get_position()  # get voltages/pos from ni_ao
 
+        self.sigNextDataChunk.connect(self._fetch_data_chunk, QtCore.Qt.QueuedConnection)
+
     def _toggle_ao_setpoint_channels(self, enable: bool) -> None:
         ni_ao = self._ni_ao()
         for channel in ni_ao.constraints.setpoint_channels:
@@ -183,8 +185,6 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
         return all(
             state for ch, state in self._ni_ao().activity_states.items() if ch in mapped_channels
         )
-
-        self.sigNextDataChunk.connect(self._fetch_data_chunk, QtCore.Qt.QueuedConnection)
 
     def on_deactivate(self):
         """
@@ -537,8 +537,8 @@ class NiScanningProbeInterfuse(ScanningProbeInterface):
     def _fetch_data_chunk(self):
         try:
             self.log.debug(f'fetch chunk: {self._ni_finite_sampling_io().samples_in_buffer}, {self.is_scan_running}')
-            #chunk_size = self._scan_data.scan_resolution[0] + self.__backwards_line_resolution
-            chunk_size = 10  # FIXME Don't hard code chunk size? The above does not work with 1D scans. Why?
+            chunk_size = self._scan_data.scan_resolution[0] + self.__backwards_line_resolution
+            # chunk_size = 10  # FIXME Don't hard code chunk size? The above does not work with 1D scans. Why?
             try:
                 samples_dict = self._ni_finite_sampling_io().get_buffered_samples(chunk_size)
             except ValueError:  # ValueError is raised, when more samples are requested then pending or still to get

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_io.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_io.py
@@ -653,9 +653,8 @@ class NIXSeriesFiniteSamplingIO(FiniteSamplingIOInterface):
             pre_stop = not self.is_running
 
             if not samples_to_read <= self._number_of_pending_samples:
-                self.log.error(f"Requested {samples_to_read} samples, but not enough pending. "
-                               f"Premature stop: {pre_stop}. Returning empty data.")
-                samples_to_read = 0
+                raise ValueError(f"Requested {samples_to_read} samples, "
+                                 f"but only {self._number_of_pending_samples} enough pending.")
 
             if samples_to_read > 0 and self.is_running:
                 request_time = time.time()

--- a/src/qudi/interface/scanning_probe_interface.py
+++ b/src/qudi/interface/scanning_probe_interface.py
@@ -264,6 +264,12 @@ class ScanData:
     def data(self):
         return self._data
 
+    @data.setter
+    def data(self, data_dict):
+        assert tuple(data_dict.keys()) == self.channels
+        assert all([val.shape == self.scan_resolution for val in data_dict.values()])
+        self._data = data_dict
+
     @property
     def position_data(self):
         return self._position_data


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Rework of the data polling of the ni_scanning_interfuse.

## Description
<!--- Describe your changes in detail -->
The data poll now runs in a separate loop and the data poll is no longer triggered from the logic, as it should be. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before, a data poll was only executed upon request from the logic even though the hardware might have had more data ready. This has been fixed and the poll now requests a minimum number of "chunk_size" samples but also gathers more if they are already available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Win10 21H2 and a PCIe-6323 Ni Card connected to Galvo Scanner for x,y and an open loop piezo for z.
Tested with various clock frequencies and scan resolutions in 1D and 2D scans.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project. (Hopefully :wink:)
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
