### PR TITLE
Fiy null bytes in Keysight module

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - Resolved some issues with QDPlot GUI layouts and improved overall QDPlot GUI code quality
+- catching null bytes in Keysight M3202A module
 
 ### New Features
 - support for Zaber (linear) motorized stages (in hardware/motor/zaber_motion)

--- a/src/qudi/hardware/awg/keysight_M3202A.py
+++ b/src/qudi/hardware/awg/keysight_M3202A.py
@@ -152,10 +152,10 @@ class M3202A(PulserInterface):
             self.awg.close()
             raise Exception('AWG Error: {0} {1}'.format(aouID, ksd1.SD_Error.getErrorMessage(aouID)))
 
-        self.ser = self.awg.getSerialNumber()
-        self.model = self.awg.getProductName()
-        self.fwver = self.awg.getFirmwareVersion()
-        self.hwver = self.awg.getHardwareVersion()
+        self.ser = self.awg.getSerialNumber().rstrip('\x00')
+        self.model = self.awg.getProductName().rstrip('\x00')
+        self.fwver = self.awg.getFirmwareVersion().rstrip('\x00')
+        self.hwver = self.awg.getHardwareVersion().rstrip('\x00')
         self.chassis = self.awg.getChassis()
         self.ch_slot = self.awg.getSlot()
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
The keysight sometimes returns a null byte at the end of the string which crashes the manager GUI, so we strip it proactively.

Null bytes are a big NONO in python and should be avoided at all costs.

## Description
<!--- Describe your changes in detail -->
The origin of the null byte is the keysight hardware module, which we do not have access to, so we need to implement the fix null byte post call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid a crash of qudi by catching unwanted null bytes from the hardware.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Testes on Hardware with current qudi core in anaconda on python 3.8.12.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
