### PR TITLE
Qo fpga fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,8 @@
 ## Pre-Release
 
 ### Breaking Changes
-- `QDPlotLogic` has changed its public method signatures
+- `QDPlotLogic` has changed its public method signatures 
+- `OkFpgaPulser` now has a mandatory config option pointing towards a directory with the bitfiles necessary.
 
 ### Bugfixes
 - Resolved some issues with QDPlot GUI layouts and improved overall QDPlot GUI code quality

--- a/src/qudi/hardware/fpga_pulser/ok_fpga_pulser.py
+++ b/src/qudi/hardware/fpga_pulser/ok_fpga_pulser.py
@@ -26,7 +26,6 @@ import okfrontpanel as ok
 
 from qudi.core.configoption import ConfigOption
 from qudi.core.statusvariable import StatusVar
-from qudi.util.paths import get_appdata_dir
 from qudi.interface.pulser_interface import PulserInterface, PulserConstraints, SequenceOption
 
 
@@ -49,11 +48,13 @@ class OkFpgaPulser(PulserInterface):
     fpga_pulser_ok:
         module.Class: 'fpga_fastcounter.fast_pulser_qo.OkFpgaPulser'
         options:
+            path_to_bitfiles_dir: 'C:\\User\\<MyUserName>\\<path\\to\\my\\bitfiles>'
             fpga_serial: '143400058N'
             fpga_type: 'XEM6310_LX150'
 
     """
     _fpga_serial = ConfigOption(name='fpga_serial', missing='error')
+    _path_to_bitfiles_dir = ConfigOption('path_to_bitfiles_dir', missing='error')
     _fpga_type = ConfigOption(name='fpga_type', default='XEM6310_LX150', missing='warn')
 
     __current_waveform = StatusVar(name='current_waveform', default=np.zeros(32, dtype='uint8'))
@@ -355,7 +356,9 @@ class OkFpgaPulser(PulserInterface):
             self.__sample_rate = 950e6
             bitfile_name = 'pulsegen_8chnl_950MHz_{0}.bit'.format(self._fpga_type.split('_')[1])
 
-        bitfile_path = os.path.join(get_appdata_dir(True), 'thirdparty', 'qo_fpga', bitfile_name)
+        bitfile_path = os.path.join(self._path_to_bitfiles_dir, bitfile_name)
+
+        assert os.path.isfile(bitfile_path), f'Could not find bitfile {bitfile_name} in {bitfile_path}'
 
         self.fpga.ConfigureFPGA(bitfile_path)
         self.log.info('FPGA pulse generator configured with {0}'.format(bitfile_path))


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Fix broken QO Fpga Pulser

## Description
<!--- Describe your changes in detail -->
So far, the QO FPGA Pulser was relying on the core function get_appdata_dir, which restricted where to put the corresponding bitfiles. Now one can specify the directory where the bitfiles are residing via a mandatory config option, which also checks if the files exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes the module which so far was not tested since porting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testetd on a Win10 21H2 office PC with an FPGA connected.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
