### PR TITLE
Refactor scalar constraint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,17 @@
 
 ## Pre-Release
 ### Breaking Changes
+None
+
 ### Bugfixes
+None
+
 ### New Features
+None
+
 ### Other
+- Bumped `qudi-core` package minimum version requirement to v1.3.0
+- Got rid of deprecated `qudi.core.interface` module usage
 
 ## Version 0.4.0
 ### Breaking Changes

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_namespace_packages
 
 
 unix_dep = [
-    'qudi-core>=1.2.0',
+    'qudi-core>=1.3.0',
     'entrypoints>=0.4',
     'fysom>=2.1.6',
     'lmfit>=1.0.3',
@@ -21,7 +21,7 @@ unix_dep = [
 ]
 
 windows_dep = [
-    'qudi-core>=1.2.0',
+    'qudi-core>=1.3.0',
     'entrypoints>=0.4',
     'fysom>=2.1.6',
     'lmfit>=1.0.3',

--- a/src/qudi/hardware/dummy/data_instream_dummy.py
+++ b/src/qudi/hardware/dummy/data_instream_dummy.py
@@ -160,7 +160,7 @@ class InStreamDummy(DataInStreamInterface):
         )
 
         self.__sample_rate = self._constraints.combined_sample_rate.minimum
-        self.__data_type = np.float64
+        self.__data_type = self._constraints.data_type
         self.__stream_length = 0
         self.__buffer_size = 1000
         self.__use_circular_buffer = False

--- a/src/qudi/hardware/dummy/data_instream_dummy.py
+++ b/src/qudi/hardware/dummy/data_instream_dummy.py
@@ -129,33 +129,37 @@ class InStreamDummy(DataInStreamInterface):
                                            enumerate(self._analog_channels, 1)]
 
         # Create constraints
-        self._constraints = DataInStreamConstraints()
-        self._constraints.digital_channels = tuple(
-            StreamChannel(name=ch, type=StreamChannelType.DIGITAL, unit='counts') for ch in
-            self._digital_channels)
-        self._constraints.analog_channels = tuple(
-            StreamChannel(name=ch, type=StreamChannelType.ANALOG, unit='V') for ch in
-            self._analog_channels)
-        self._constraints.analog_sample_rate.min = 1
-        self._constraints.analog_sample_rate.max = 2**31-1
-        self._constraints.analog_sample_rate.step = 1
-        self._constraints.analog_sample_rate.unit = 'Hz'
-        self._constraints.digital_sample_rate.min = 1
-        self._constraints.digital_sample_rate.max = 2**31-1
-        self._constraints.digital_sample_rate.step = 1
-        self._constraints.digital_sample_rate.unit = 'Hz'
-        self._constraints.combined_sample_rate = self._constraints.analog_sample_rate
+        self._constraints = DataInStreamConstraints(
+            digital_channels=tuple(
+                StreamChannel(name=ch, type=StreamChannelType.DIGITAL, unit='counts') for ch in
+                self._digital_channels
+            ),
+            analog_channels=tuple(
+                StreamChannel(name=ch, type=StreamChannelType.ANALOG, unit='V') for ch in
+                self._analog_channels
+            ),
+            analog_sample_rate={'default'    : 1,
+                                'bounds'     : (1, 2 ** 31 - 1),
+                                'increment'  : 1,
+                                'enforce_int': True},
+            digital_sample_rate={'default'    : 1,
+                                 'bounds'     : (1, 2 ** 31 - 1),
+                                 'increment'  : 1,
+                                 'enforce_int': True},
+            combined_sample_rate={'default'    : 1,
+                                  'bounds'     : (1, 2 ** 31 - 1),
+                                  'increment'  : 1,
+                                  'enforce_int': True},
+            read_block_size={'default'    : 1,
+                             'bounds'     : (1, 1_000_000),
+                             'increment'  : 1,
+                             'enforce_int': True},
+            streaming_modes=(StreamingMode.CONTINUOUS,),  # TODO: Implement FINITE streaming mode
+            data_type=np.float64,
+            allow_circular_buffer=True
+        )
 
-        self._constraints.read_block_size.min = 1
-        self._constraints.read_block_size.max = 1000000
-        self._constraints.read_block_size.step = 1
-
-        # TODO: Implement FINITE streaming mode
-        self._constraints.streaming_modes = (StreamingMode.CONTINUOUS,)  # , StreamingMode.FINITE)
-        self._constraints.data_type = np.float64
-        self._constraints.allow_circular_buffer = True
-
-        self.__sample_rate = self._constraints.combined_sample_rate.min
+        self.__sample_rate = self._constraints.combined_sample_rate.minimum
         self.__data_type = np.float64
         self.__stream_length = 0
         self.__buffer_size = 1000
@@ -195,11 +199,11 @@ class InStreamDummy(DataInStreamInterface):
         if self._check_settings_change():
             if not self._clk_frequency_valid(rate):
                 if self._analog_channels:
-                    min_val = self._constraints.combined_sample_rate.min
-                    max_val = self._constraints.combined_sample_rate.max
+                    min_val = self._constraints.combined_sample_rate.minimum
+                    max_val = self._constraints.combined_sample_rate.maximum
                 else:
-                    min_val = self._constraints.digital_sample_rate.min
-                    max_val = self._constraints.digital_sample_rate.max
+                    min_val = self._constraints.digital_sample_rate.minimum
+                    max_val = self._constraints.digital_sample_rate.maximum
                 self.log.warning(
                     'Sample rate requested ({0:.3e}Hz) is out of bounds. Please choose '
                     'a value between {1:.3e}Hz and {2:.3e}Hz. Value will be clipped to '
@@ -642,11 +646,11 @@ class InStreamDummy(DataInStreamInterface):
     # =============================================================================================
     def _clk_frequency_valid(self, frequency):
         if self._analog_channels:
-            max_rate = self._constraints.combined_sample_rate.max
-            min_rate = self._constraints.combined_sample_rate.min
+            max_rate = self._constraints.combined_sample_rate.maximum
+            min_rate = self._constraints.combined_sample_rate.minimum
         else:
-            max_rate = self._constraints.digital_sample_rate.max
-            min_rate = self._constraints.digital_sample_rate.min
+            max_rate = self._constraints.digital_sample_rate.maximum
+            min_rate = self._constraints.digital_sample_rate.minimum
         return min_rate <= frequency <= max_rate
 
     def _init_buffer(self):

--- a/src/qudi/interface/data_instream_interface.py
+++ b/src/qudi/interface/data_instream_interface.py
@@ -24,7 +24,7 @@ import numpy as np
 from enum import Enum
 from abc import abstractmethod
 from qudi.core.module import Base
-from qudi.core.interface import ScalarConstraint
+from qudi.util.constraints import ScalarConstraint
 
 
 class DataInStreamInterface(Base):
@@ -372,32 +372,32 @@ class DataInStreamConstraints:
             self.analog_channels = tuple(ch.copy() for ch in analog_channels)
 
         if isinstance(analog_sample_rate, ScalarConstraint):
-            self.analog_sample_rate = ScalarConstraint(**vars(analog_sample_rate))
+            self.analog_sample_rate = analog_sample_rate.copy()
         elif isinstance(analog_sample_rate, dict):
             self.analog_sample_rate = ScalarConstraint(**analog_sample_rate)
         else:
-            self.analog_sample_rate = ScalarConstraint(min=1, max=np.inf, step=1, default=1)
+            self.analog_sample_rate = ScalarConstraint(default=1, bounds=(1, np.inf), increment=1)
 
         if isinstance(digital_sample_rate, ScalarConstraint):
-            self.digital_sample_rate = ScalarConstraint(**vars(digital_sample_rate))
+            self.digital_sample_rate = digital_sample_rate.copy()
         elif isinstance(digital_sample_rate, dict):
             self.digital_sample_rate = ScalarConstraint(**digital_sample_rate)
         else:
-            self.digital_sample_rate = ScalarConstraint(min=1, max=np.inf, step=1, default=1)
+            self.digital_sample_rate = ScalarConstraint(default=1, bounds=(1, np.inf), increment=1)
 
         if isinstance(combined_sample_rate, ScalarConstraint):
-            self.combined_sample_rate = ScalarConstraint(**vars(combined_sample_rate))
+            self.combined_sample_rate = combined_sample_rate.copy()
         elif isinstance(combined_sample_rate, dict):
             self.combined_sample_rate = ScalarConstraint(**combined_sample_rate)
         else:
-            self.combined_sample_rate = ScalarConstraint(min=1, max=np.inf, step=1, default=1)
+            self.combined_sample_rate = ScalarConstraint(default=1, bounds=(1, np.inf), increment=1)
 
         if isinstance(read_block_size, ScalarConstraint):
-            self.read_block_size = ScalarConstraint(**vars(read_block_size))
+            self.read_block_size = read_block_size.copy()
         elif isinstance(read_block_size, dict):
             self.read_block_size = ScalarConstraint(**read_block_size)
         else:
-            self.read_block_size = ScalarConstraint(min=1, max=np.inf, step=1, default=1)
+            self.read_block_size = ScalarConstraint(default=1, bounds=(1, np.inf), increment=1)
 
         if streaming_modes is None:
             self.streaming_modes = (StreamingMode.CONTINUOUS, StreamingMode.FINITE)

--- a/src/qudi/interface/pulser_interface.py
+++ b/src/qudi/interface/pulser_interface.py
@@ -23,7 +23,7 @@ If not, see <https://www.gnu.org/licenses/>.
 from enum import Enum
 from abc import abstractmethod
 from qudi.core.module import Base
-from qudi.core.interface import ScalarConstraint
+from qudi.util.constraints import ScalarConstraint
 
 
 class PulserInterface(Base):
@@ -558,22 +558,33 @@ class SequenceOption(Enum):
 class PulserConstraints:
     def __init__(self):
         # sample rate, i.e. the time base of the pulser
-        self.sample_rate = ScalarConstraint(unit='Hz')
+        self.sample_rate = ScalarConstraint(default=1, bounds=(0.1, 1e9))
+        self.sample_rate.unit = 'Hz'
         # The peak-to-peak amplitude and voltage offset of the analog channels
-        self.a_ch_amplitude = ScalarConstraint(unit='Vpp')
-        self.a_ch_offset = ScalarConstraint(unit='V')
+        self.a_ch_amplitude = ScalarConstraint(default=0, bounds=(0, 0))
+        self.a_ch_amplitude.unit = 'Vpp'
+        self.a_ch_offset = ScalarConstraint(default=0, bounds=(0, 0))
+        self.a_ch_offset.unit = 'V'
         # Low and high voltage level of the digital channels
-        self.d_ch_low = ScalarConstraint(unit='V')
-        self.d_ch_high = ScalarConstraint(unit='V')
+        self.d_ch_low = ScalarConstraint(default=0, bounds=(0, 0))
+        self.d_ch_low.unit = 'V'
+        self.d_ch_high = ScalarConstraint(default=0, bounds=(0, 0))
+        self.d_ch_high.unit = 'V'
         # length of the created waveform in samples
-        self.waveform_length = ScalarConstraint(unit='Samples')
+        self.waveform_length = ScalarConstraint(default=1, bounds=(1, 1))
+        self.waveform_length.unit = 'Samples'
         # number of waveforms/sequences to put in a single asset (sequence mode)
-        self.waveform_num = ScalarConstraint(unit='#')
-        self.sequence_num = ScalarConstraint(unit='#')
-        self.subsequence_num = ScalarConstraint(unit='#')
+        self.waveform_num = ScalarConstraint(default=0, bounds=(0, 0))
+        self.waveform_num.unit = '#'
+        self.sequence_num = ScalarConstraint(default=0, bounds=(0, 0))
+        self.sequence_num.unit = '#'
+        self.subsequence_num = ScalarConstraint(default=0, bounds=(0, 0))
+        self.subsequence_num.unit = '#'
         # Sequence parameters
-        self.sequence_steps = ScalarConstraint(unit='#', min=0)
-        self.repetitions = ScalarConstraint(unit='#')
+        self.sequence_steps = ScalarConstraint(default=0, bounds=(0, 0))
+        self.sequence_steps.unit = '#'
+        self.repetitions = ScalarConstraint(default=0, bounds=(0, 0))
+        self.repetitions.unit = '#'
         self.event_triggers = list()
         self.flags = list()
 

--- a/src/qudi/logic/time_series_reader_logic.py
+++ b/src/qudi/logic/time_series_reader_logic.py
@@ -336,14 +336,14 @@ class TimeSeriesReaderLogic(LogicBase):
                                    '(received: {0:d}).'.format(new_val))
                 else:
                     if self.has_active_analog_channels and self.has_active_digital_channels:
-                        min_val = constraints.combined_sample_rate.min
-                        max_val = constraints.combined_sample_rate.max
+                        min_val = constraints.combined_sample_rate.minimum
+                        max_val = constraints.combined_sample_rate.maximum
                     elif self.has_active_analog_channels:
-                        min_val = constraints.analog_sample_rate.min
-                        max_val = constraints.analog_sample_rate.max
+                        min_val = constraints.analog_sample_rate.minimum
+                        max_val = constraints.analog_sample_rate.maximum
                     else:
-                        min_val = constraints.digital_sample_rate.min
-                        max_val = constraints.digital_sample_rate.max
+                        min_val = constraints.digital_sample_rate.minimum
+                        max_val = constraints.digital_sample_rate.maximum
                     if not (min_val <= (new_val * data_rate) <= max_val):
                         if 'data_rate' in settings_dict:
                             self._oversampling_factor = new_val
@@ -385,14 +385,14 @@ class TimeSeriesReaderLogic(LogicBase):
                     self.log.error('Data rate must be float value > 0.')
                 else:
                     if self.has_active_analog_channels and self.has_active_digital_channels:
-                        min_val = constraints.combined_sample_rate.min
-                        max_val = constraints.combined_sample_rate.max
+                        min_val = constraints.combined_sample_rate.minimum
+                        max_val = constraints.combined_sample_rate.maximum
                     elif self.has_active_analog_channels:
-                        min_val = constraints.analog_sample_rate.min
-                        max_val = constraints.analog_sample_rate.max
+                        min_val = constraints.analog_sample_rate.minimum
+                        max_val = constraints.analog_sample_rate.maximum
                     else:
-                        min_val = constraints.digital_sample_rate.min
-                        max_val = constraints.digital_sample_rate.max
+                        min_val = constraints.digital_sample_rate.minimum
+                        max_val = constraints.digital_sample_rate.maximum
                     sample_rate = new_val * self.oversampling_factor
                     if not (min_val <= sample_rate <= max_val):
                         self.log.warning('Data rate to set ({0:.3e}Hz) would cause sampling rate '


### PR DESCRIPTION
## Description
Got rid of any import of deprecated module `qudi.core.interface`.
Only the pulsed and time series toolchain were impacted by this change.

## Motivation and Context
`qudi.core.interface.ScalarConstraint` has been deprecated and was replaced by the quite different `qudi.util.constraints.ScalarConstraint`.
The new object has properties in place to provide the same interface as the old one.

## How Has This Been Tested?
Only on dummy. Testing is needed with real hardware for pulse generators (not critical due to minimal changes) and NI instreamer (critical due to interface change).

## Types of changes
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
