### PR TITLE
Pulsed double gate pr

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ modules implementing any of the interfaces contained in `qudi.interface.process_
 dependency option for `process_control_dummy` to simulate PID control
 - support for Thorlabs power meters using the TLPM driver
 - pulsed toolchain: generation parameters of sequence saved as meta data
+- pulsed toolchain: partial gatings are implemented
 
 ### Other
 - Bumped `qudi-core` package minimum version requirement to v1.2.0

--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -156,6 +156,7 @@ class PredefinedMethodsAdvancedOptionsDialog(QtWidgets.QDialog):
         """
         Call the parameters from the StatusVar in the logic.
         """
+        self.gate_type_comboBox.addItems(self._pmal().sequencegeneratorlogic()._pog.gate_options)
         self.update_advanced_generation_parameters(self._pmal().sequencegeneratorlogic().advanced_generation_parameters)
         return
 
@@ -171,13 +172,13 @@ class PredefinedMethodsAdvancedOptionsDialog(QtWidgets.QDialog):
         return
 
     def connect_signals(self):
-        self.double_gate_checkBox.stateChanged.connect(self.apply_advanced_generation_parameters)
+        self.gate_type_comboBox.currentIndexChanged.connect(self.apply_advanced_generation_parameters)
         self.gate_length1_ScienDSpinBox.editingFinished.connect(self.apply_advanced_generation_parameters)
         self.gate_length2_ScienDSpinBox.editingFinished.connect(self.apply_advanced_generation_parameters)
         return
 
     def disconnect_signals(self):
-        self.double_gate_checkBox.stateChanged.disconnect()
+        self.gate_type_comboBox.currentIndexChanged.disconnect()
         self.gate_length1_ScienDSpinBox.editingFinished.disconnect()
         self.gate_length2_ScienDSpinBox.editingFinished.disconnect()
         return
@@ -188,7 +189,7 @@ class PredefinedMethodsAdvancedOptionsDialog(QtWidgets.QDialog):
         apply the gui parameters to those in the logic.
         """
         stg_dict = dict()
-        stg_dict['double_gate'] = self.double_gate_checkBox.isChecked()
+        stg_dict['gate_type'] = self.gate_type_comboBox.currentText()
         stg_dict['gate_length1'] = self.gate_length1_ScienDSpinBox.value()
         stg_dict['gate_length2'] = self.gate_length2_ScienDSpinBox.value()
         self._pmal().sequencegeneratorlogic().set_advanced_generation_parameters(stg_dict)
@@ -199,14 +200,14 @@ class PredefinedMethodsAdvancedOptionsDialog(QtWidgets.QDialog):
         update the gui parameters with those in the logic(e.g. StatusVars).
         """
         self._toggle_block_signals(True)
-        self.double_gate_checkBox.setChecked(settings_dict['double_gate'])
+        self.gate_type_comboBox.setCurrentText(settings_dict['gate_type'])
         self.gate_length1_ScienDSpinBox.setValue(settings_dict['gate_length1'])
         self.gate_length2_ScienDSpinBox.setValue(settings_dict['gate_length2'])
         self._toggle_block_signals(False)
         return
 
     def _toggle_block_signals(self, bool):
-        self.double_gate_checkBox.blockSignals(bool)
+        self.gate_type_comboBox.blockSignals(bool)
         self.gate_length1_ScienDSpinBox.blockSignals(bool)
         self.gate_length2_ScienDSpinBox.blockSignals(bool)
         return

--- a/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
+++ b/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Pulse Generator Settings</string>
+   <string>Predefined Methods Advanced Options</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
+++ b/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>444</width>
+    <height>409</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Pulse Generator Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="double_gating_groupBox">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="title">
+      <string>Double gating</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="3" column="0">
+       <widget class="QLabel" name="gate_length1_label">
+        <property name="text">
+         <string>gate_length1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="gate_length2_label">
+        <property name="text">
+         <string>gate_length2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <layout class="QGridLayout" name="gridLayout_6">
+        <item row="0" column="0">
+         <widget class="QLabel" name="double_gate_label">
+          <property name="text">
+           <string>double_gate</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="double_gate_checkBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="ScienDSpinBox" name="gate_length2_ScienDSpinBox">
+        <property name="suffix">
+         <string>s</string>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.000001000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ScienDSpinBox" name="gate_length1_ScienDSpinBox">
+        <property name="suffix">
+         <string>s</string>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.000001000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScienDSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qudi.util.widgets.scientific_spinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
+++ b/src/qudi/gui/pulsed/ui_pulsed_main_gui_settings_predefined_advenced_options.ui
@@ -46,22 +46,15 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <layout class="QGridLayout" name="gridLayout_6">
+       <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="double_gate_label">
+         <widget class="QLabel" name="gate_type_label">
           <property name="text">
-           <string>double_gate</string>
+           <string>gate_type</string>
           </property>
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="double_gate_checkBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
       </item>
       <item row="3" column="3">
        <widget class="ScienDSpinBox" name="gate_length2_ScienDSpinBox">
@@ -72,10 +65,10 @@
          <number>3</number>
         </property>
         <property name="maximum">
-         <double>1.000000000000000</double>
+         <double>1000.000000000000000</double>
         </property>
         <property name="singleStep">
-         <double>0.000001000000000</double>
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -88,12 +81,15 @@
          <number>3</number>
         </property>
         <property name="maximum">
-         <double>1.000000000000000</double>
+         <double>1000.000000000000000</double>
         </property>
         <property name="singleStep">
-         <double>0.000001000000000</double>
+         <double>1.000000000000000</double>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="gate_type_comboBox"/>
       </item>
      </layout>
     </widget>

--- a/src/qudi/gui/pulsed/ui_pulsed_maingui.ui
+++ b/src/qudi/gui/pulsed/ui_pulsed_maingui.ui
@@ -58,6 +58,7 @@
      <string>Se&amp;ttings</string>
     </property>
     <addaction name="action_Predefined_Methods_Config"/>
+    <addaction name="action_Predefined_Methods_Advanced_Options"/>
     <addaction name="separator"/>
     <addaction name="action_Settings_Analysis"/>
     <addaction name="action_FitSettings"/>
@@ -225,6 +226,15 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
+   </property>
+  </action>
+  <action name="action_Predefined_Methods_Advanced_Options">
+   <property name="icon">
+    <iconset>
+     <normaloff>../../../../../qudi-core/src/qudi/artwork/icons/configure.svg</normaloff>../../../../../qudi-core/src/qudi/artwork/icons/configure.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Predefined Methods Advanced options</string>
    </property>
   </action>
  </widget>

--- a/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -48,7 +48,81 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    ################################################################################################
+    def generate_readout_subblock(self):
+        """
+        Readout subblock is a collection of laser element, delay element and waiting element.
+        """
+        if 'normal' in self.gate_type:
+            readout_subblock = self._generate_normal_readout_subblock()
+        elif 'partial' in self.gate_type:
+            readout_subblock = self._generate_partial_gate_readout_subblock()
+        elif 'double' in self.gate_type:
+            readout_subblock = self._generate_double_gate_readout_subblock()
+        else:
+            self.log.warning('unknown gate type. Normal gate is used instead.')
+            readout_subblock = self._generate_normal_readout_subblock()
+
+        return readout_subblock
+
+    def _generate_normal_readout_subblock(self):
+        """
+        Normal readout consists of laser element, delay element and waiting element
+        for triggered and gated acquisition.
+        For gated acquisition, delay element is used to extend the gate length.
+        """
+        laser_element = self._get_laser_gate_element(length=self.laser_length,
+                                                     increment=0)
+        delay_element = self._get_delay_gate_element()
+        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
+
+        readout_subblock = PulseBlock(name='readout')
+        readout_subblock.append(laser_element)
+        readout_subblock.append(delay_element)
+        readout_subblock.append(waiting_element)
+
+        return readout_subblock
+
+    def _generate_partial_gate_readout_subblock(self):
+        """
+        Only the beggining of the pulse is partially gated.
+        If the laser delay time is given, it is added to the waiting time.
+        """
+        laser_gate_element = self._get_laser_gate_element(length=self.gate_length1, increment=0)
+        laser_element = self._get_laser_element(length=self.laser_length - self.gate_length1, increment=0)
+        waiting_element = self._get_idle_element(length=self.laser_delay + self.wait_time, increment=0)
+
+        readout_subblock = PulseBlock(name='readout')
+        readout_subblock.append(laser_gate_element)
+        readout_subblock.append(laser_element)
+        readout_subblock.append(waiting_element)
+
+        return readout_subblock
+
+    def _generate_double_gate_readout_subblock(self):
+        """
+        Double gate readout gives two gates at the beggining and end of the pulse, respectively.
+        """
+        len1_laser_gate1 = self.gate_length1
+        len2_laser_ungated = self.laser_length - self.gate_length1 - self.gate_length2
+        len3_laser_gate2 = self.gate_length2 - self.laser_delay
+        len4_delay_gate2 = self.laser_delay
+
+        laser_gate_element1 = self._get_laser_gate_element(length=len1_laser_gate1, increment=0)
+        laser_element = self._get_laser_element(length=len2_laser_ungated, increment=0)
+        laser_gate_element2 = self._get_laser_gate_element(length=len3_laser_gate2, increment=0)
+        delay_element = self._get_delay_gate_element()
+        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
+
+        readout_subblock = PulseBlock(name='readout')
+        readout_subblock.append(laser_gate_element1)
+        readout_subblock.append(laser_element)
+        readout_subblock.append(laser_gate_element2)
+        readout_subblock.append(delay_element)
+        readout_subblock.append(waiting_element)
+
+        return readout_subblock
+
+        ################################################################################################
     #                             Generation methods for waveforms                                 #
     ################################################################################################
     def generate_laser_on(self, name='laser_on', length=3.0e-6):
@@ -207,16 +281,12 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                           phase=0)
         waiting_element = self._get_idle_element(length=self.wait_time,
                                                  increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         rabi_block = PulseBlock(name=name)
         rabi_block.append(mw_element)
-        rabi_block.append(laser_element)
-        rabi_block.append(delay_element)
-        rabi_block.append(waiting_element)
+        rabi_block.append_subblock(readout_subblock)
         created_blocks.append(rabi_block)
 
         # Create block ensemble
@@ -252,12 +322,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         # Create frequency array
         freq_array = freq_start + np.arange(num_of_points) * freq_step
 
-        # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time,
-                                                 increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         pulsedodmr_block = PulseBlock(name=name)
@@ -268,9 +333,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                               freq=mw_freq,
                                               phase=0)
             pulsedodmr_block.append(mw_element)
-            pulsedodmr_block.append(laser_element)
-            pulsedodmr_block.append(delay_element)
-            pulsedodmr_block.append(waiting_element)
+            pulsedodmr_block.append_subblock(readout_subblock)
         created_blocks.append(pulsedodmr_block)
 
         # Create block ensemble
@@ -308,11 +371,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         tau_pspacing_start = self.tau_2_pulse_spacing(tau_start)
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time,
-                                                 increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
                                               amp=self.microwave_amplitude,
@@ -333,21 +391,19 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                    phase=0)
         tau_element = self._get_idle_element(length=tau_pspacing_start, increment=tau_step)
 
+        readout_subblock = self.generate_readout_subblock()
+
         # Create block and append to created_blocks list
         ramsey_block = PulseBlock(name=name)
         ramsey_block.append(pihalf_element)
         ramsey_block.append(tau_element)
         ramsey_block.append(pihalf_element)
-        ramsey_block.append(laser_element)
-        ramsey_block.append(delay_element)
-        ramsey_block.append(waiting_element)
+        ramsey_block.append_subblock(readout_subblock)
         if alternating:
             ramsey_block.append(pihalf_element)
             ramsey_block.append(tau_element)
             ramsey_block.append(pi3half_element)
-            ramsey_block.append(laser_element)
-            ramsey_block.append(delay_element)
-            ramsey_block.append(waiting_element)
+            ramsey_block.append_subblock(readout_subblock)
         created_blocks.append(ramsey_block)
 
         # Create block ensemble
@@ -386,11 +442,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             tau_array = tau_list
         tau_pspacing_array = self.tau_2_pulse_spacing(tau_array)
 
-        waiting_element = self._get_idle_element(length=self.wait_time,
-                                                 increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
         # get pihalf element
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
@@ -411,6 +462,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                        amp=self.microwave_amplitude,
                                                        freq=self.microwave_frequency,
                                                        phase=0)
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         ramsey_block = PulseBlock(name=name)
@@ -420,17 +472,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             ramsey_block.append(tau_element)
             ramsey_block.append(tau_element)
             ramsey_block.append(pihalf_element)
-            ramsey_block.append(laser_element)
-            ramsey_block.append(delay_element)
-            ramsey_block.append(waiting_element)
+            ramsey_block.append_subblock(readout_subblock)
 
             if alternating:
                 ramsey_block.append(pihalf_element)
                 ramsey_block.append(tau_element)
                 ramsey_block.append(pi3half_element)
-                ramsey_block.append(laser_element)
-                ramsey_block.append(delay_element)
-                ramsey_block.append(waiting_element)
+                ramsey_block.append_subblock(readout_subblock)
 
         created_blocks.append(ramsey_block)
 
@@ -499,6 +547,8 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                    phase=0)
         tau_element = self._get_idle_element(length=tau_pspacing_start, increment=tau_step)
 
+        readout_subblock = self.generate_readout_subblock()
+
         # Create block and append to created_blocks list
         hahn_block = PulseBlock(name=name)
         hahn_block.append(pihalf_element)
@@ -506,18 +556,14 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         hahn_block.append(pi_element)
         hahn_block.append(tau_element)
         hahn_block.append(pihalf_element)
-        hahn_block.append(laser_element)
-        hahn_block.append(delay_element)
-        hahn_block.append(waiting_element)
+        hahn_block.append_subblock(readout_subblock)
         if alternating:
             hahn_block.append(pihalf_element)
             hahn_block.append(tau_element)
             hahn_block.append(pi_element)
             hahn_block.append(tau_element)
             hahn_block.append(pi3half_element)
-            hahn_block.append(laser_element)
-            hahn_block.append(delay_element)
-            hahn_block.append(waiting_element)
+            hahn_block.append_subblock(readout_subblock)
         created_blocks.append(hahn_block)
 
         # Create block ensemble
@@ -561,11 +607,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         tau_pspacing_array = self.tau_2_pulse_spacing(tau_array)
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time,
-                                                 increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
                                               amp=self.microwave_amplitude,
@@ -589,6 +630,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                    amp=self.microwave_amplitude,
                                                    freq=self.microwave_frequency,
                                                    phase=0)
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         hahn_block = PulseBlock(name=name)
@@ -599,18 +641,14 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             hahn_block.append(pi_element)
             hahn_block.append(tau_element)
             hahn_block.append(pihalf_element)
-            hahn_block.append(laser_element)
-            hahn_block.append(delay_element)
-            hahn_block.append(waiting_element)
+            hahn_block.append_subblock(readout_subblock)
             if alternating:
                 hahn_block.append(pihalf_element)
                 hahn_block.append(tau_element)
                 hahn_block.append(pi_element)
                 hahn_block.append(tau_element)
                 hahn_block.append(pi3half_element)
-                hahn_block.append(laser_element)
-                hahn_block.append(delay_element)
-                hahn_block.append(waiting_element)
+                hahn_block.append_subblock(readout_subblock)
         created_blocks.append(hahn_block)
 
         # Create block ensemble
@@ -660,17 +698,16 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                               phase=0)
 
         tau_element = self._get_idle_element(length=tau_start, increment=tau_step)
+
+        readout_subblock = self.generate_readout_subblock()
+
         t1_block = PulseBlock(name=name)
         t1_block.append(tau_element)
-        t1_block.append(laser_element)
-        t1_block.append(delay_element)
-        t1_block.append(waiting_element)
+        t1_block.append_subblock(readout_subblock)
         if alternating:
             t1_block.append(pi_element)
             t1_block.append(tau_element)
-            t1_block.append(laser_element)
-            t1_block.append(delay_element)
-            t1_block.append(waiting_element)
+            t1_block.append_subblock(readout_subblock)
         created_blocks.append(t1_block)
 
         # Create block ensemble
@@ -711,30 +748,24 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             tau_array = np.geomspace(tau_start, tau_end, num_of_points)
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time,
-                                                 increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length,
-                                                     increment=0)
-        delay_element = self._get_delay_gate_element()
         if alternating:  # get pi element
             pi_element = self._get_mw_element(length=self.rabi_period / 2,
                                               increment=0,
                                               amp=self.microwave_amplitude,
                                               freq=self.microwave_frequency,
                                               phase=0)
+
+        readout_subblock = self.generate_readout_subblock()
+
         t1_block = PulseBlock(name=name)
         for tau in tau_array:
             tau_element = self._get_idle_element(length=tau, increment=0.0)
             t1_block.append(tau_element)
-            t1_block.append(laser_element)
-            t1_block.append(delay_element)
-            t1_block.append(waiting_element)
+            t1_block.append_subblock(readout_subblock)
             if alternating:
                 t1_block.append(pi_element)
                 t1_block.append(tau_element)
-                t1_block.append(laser_element)
-                t1_block.append(delay_element)
-                t1_block.append(waiting_element)
+                t1_block.append_subblock(readout_subblock)
         created_blocks.append(t1_block)
 
         # Create block ensemble
@@ -771,9 +802,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         amp_array = amp_start + np.arange(num_of_points) * amp_step
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
-        delay_element = self._get_delay_gate_element()
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
                                               amp=self.microwave_amplitude,
@@ -793,6 +821,8 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                    freq=self.microwave_frequency,
                                                    phase=0)
 
+        readout_subblock = self.generate_readout_subblock()
+
         # Create block and append to created_blocks list
         hhamp_block = PulseBlock(name=name)
         for sl_amp in amp_array:
@@ -804,16 +834,12 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             hhamp_block.append(pihalf_element)
             hhamp_block.append(sl_element)
             hhamp_block.append(pihalf_element)
-            hhamp_block.append(laser_element)
-            hhamp_block.append(delay_element)
-            hhamp_block.append(waiting_element)
+            hhamp_block.append_subblock(readout_subblock)
 
             hhamp_block.append(pi3half_element)
             hhamp_block.append(sl_element)
             hhamp_block.append(pihalf_element)
-            hhamp_block.append(laser_element)
-            hhamp_block.append(delay_element)
-            hhamp_block.append(waiting_element)
+            hhamp_block.append_subblock(readout_subblock)
         created_blocks.append(hhamp_block)
 
         # Create block ensemble
@@ -850,9 +876,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         tau_array = tau_start + np.arange(num_of_points) * tau_step
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
-        delay_element = self._get_delay_gate_element()
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
                                               amp=self.microwave_amplitude,
@@ -877,21 +900,19 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                           freq=self.microwave_frequency,
                                           phase=90)
 
+        readout_subblock = self.generate_readout_subblock()
+
         # Create block and append to created_blocks list
         hhtau_block = PulseBlock(name=name)
         hhtau_block.append(pihalf_element)
         hhtau_block.append(sl_element)
         hhtau_block.append(pihalf_element)
-        hhtau_block.append(laser_element)
-        hhtau_block.append(delay_element)
-        hhtau_block.append(waiting_element)
+        hhtau_block.append_subblock(readout_subblock)
 
         hhtau_block.append(pi3half_element)
         hhtau_block.append(sl_element)
         hhtau_block.append(pihalf_element)
-        hhtau_block.append(laser_element)
-        hhtau_block.append(delay_element)
-        hhtau_block.append(waiting_element)
+        hhtau_block.append_subblock(readout_subblock)
         created_blocks.append(hhtau_block)
 
         # Create block ensemble
@@ -928,9 +949,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         steps_array = np.arange(2 * polarization_steps)
 
         # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
-        delay_element = self._get_delay_gate_element()
         pihalf_element = self._get_mw_element(length=self.rabi_period / 4,
                                               increment=0,
                                               amp=self.microwave_amplitude,
@@ -955,14 +973,14 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                           freq=self.microwave_frequency,
                                           phase=90)
 
+        readout_subblock = self.generate_readout_subblock()
+
         # Create block for "up"-polarization and append to created_blocks list
         up_block = PulseBlock(name=name + '_up')
         up_block.append(pihalf_element)
         up_block.append(sl_element)
         up_block.append(pihalf_element)
-        up_block.append(laser_element)
-        up_block.append(delay_element)
-        up_block.append(waiting_element)
+        up_block.append_subblock(readout_subblock)
         created_blocks.append(up_block)
 
         # Create block for "down"-polarization and append to created_blocks list
@@ -970,9 +988,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         down_block.append(pi3half_element)
         down_block.append(sl_element)
         down_block.append(pi3half_element)
-        down_block.append(laser_element)
-        down_block.append(delay_element)
-        down_block.append(waiting_element)
+        down_block.append_subblock(readout_subblock)
         created_blocks.append(down_block)
 
         # Create block ensemble
@@ -1118,10 +1134,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         created_ensembles = list()
         created_sequences = list()
 
-        # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
-        delay_element = self._get_delay_gate_element()
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         chirpedodmr_block = PulseBlock(name=name)
@@ -1144,9 +1157,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                                      + freq_overlap),
                                                           phase=0)
             chirpedodmr_block.append(mw_element)
-            chirpedodmr_block.append(laser_element)
-            chirpedodmr_block.append(delay_element)
-            chirpedodmr_block.append(waiting_element)
+            chirpedodmr_block.append_subblock(readout_subblock)
         created_blocks.append(chirpedodmr_block)
 
         # Create block ensemble
@@ -1245,10 +1256,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         created_ensembles = list()
         created_sequences = list()
 
-        # create the elements
-        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
-        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
-        delay_element = self._get_delay_gate_element()
+        readout_subblock = self.generate_readout_subblock()
 
         # Create block and append to created_blocks list
         chirpedodmr_block = PulseBlock(name=name)
@@ -1272,9 +1280,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                                                       phase=0,
                                                       truncation_ratio=truncation_ratio)
             chirpedodmr_block.append(mw_element)
-            chirpedodmr_block.append(laser_element)
-            chirpedodmr_block.append(delay_element)
-            chirpedodmr_block.append(waiting_element)
+            chirpedodmr_block.append_subblock(readout_subblock)
         created_blocks.append(chirpedodmr_block)
 
         # Create block ensemble

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -1033,7 +1033,12 @@ class PredefinedGeneratorBase:
 
     @property
     def generation_parameters(self):
-        return self.__sequencegeneratorlogic.generation_parameters
+        """
+        Sum up the generation parameters defined in the sequence generator logic
+        """
+        generation_parameters = self.__sequencegeneratorlogic.generation_parameters
+        generation_parameters.update(self.__sequencegeneratorlogic.advanced_generation_parameters)
+        return generation_parameters
 
     @property
     def pulse_generator_constraints(self):

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -354,6 +354,12 @@ class PulseBlock(object):
         self.insert(position=len(self.element_list), element=element)
         return
 
+    def append_subblock(self, subblock):
+        for i in range(len(subblock)):
+            self.insert(position=len(self.element_list), element=subblock[i])
+        return
+
+
     def extend(self, iterable):
         for element in iterable:
             self.append(element=element)
@@ -998,6 +1004,7 @@ class PredefinedGeneratorBase:
     qudi module (e.g. self.log.error(...)).
     Also provides helper methods to simplify sequence/ensemble generation.
     """
+    gate_options = ['normal', 'partial', 'double']
 
     def __init__(self, sequencegeneratorlogic):
         # Keep protected reference to the SequenceGeneratorLogic
@@ -1105,6 +1112,18 @@ class PredefinedGeneratorBase:
     @property
     def rabi_period(self):
         return self.generation_parameters.get('rabi_period')
+
+    @property
+    def gate_type(self):
+        return self.generation_parameters.get('gate_type')
+
+    @property
+    def gate_length1(self):
+        return self.generation_parameters.get('gate_length1')
+
+    @property
+    def gate_length2(self):
+        return self.generation_parameters.get('gate_length2')
 
     @property
     def sample_rate(self):

--- a/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
+++ b/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
@@ -153,7 +153,10 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         # loop over all laser pulses and analyze them
         for ii, laser_arr in enumerate(laser_data):
             # calculate the mean of the data in the signal window
-            signal = laser_arr[signal_start_bin:signal_end_bin].mean()
+            try:
+                signal = laser_arr[signal_start_bin:signal_end_bin].mean()
+            except:
+                print('ii = {} laser_arr = {}'.format(ii, laser_arr))
             signal_sum = laser_arr[signal_start_bin:signal_end_bin].sum()
             signal_error = np.sqrt(signal_sum) / (signal_end_bin - signal_start_bin)
 

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -102,7 +102,15 @@ class SequenceGeneratorLogic(LogicBase):
                  'laser_length': 3e-6,
                  'laser_delay': 500e-9,
                  'wait_time': 1e-6,
-                 'analog_trigger_voltage': 0.0}
+                 'analog_trigger_voltage': 0.0
+                 }
+    )
+
+    _advanced_generation_parameters = StatusVar(
+        default={'double_gate': False,
+                 'gate_length1': 1e-6,
+                 'gate_length2': 1e-6
+                 }
     )
 
     # The created pulse objects (PulseBlock, PulseBlockEnsemble, PulseSequence) are saved in
@@ -662,6 +670,16 @@ class SequenceGeneratorLogic(LogicBase):
         return
 
     @property
+    def advanced_generation_parameters(self):
+        return self._advanced_generation_parameters.copy()
+
+    @advanced_generation_parameters.setter
+    def advanced_generation_parameters(self, advanced_settings_dict):
+        if isinstance(advanced_settings_dict, dict):
+            self.set_advanced_generation_parameters(advanced_settings_dict)
+        return
+
+    @property
     def saved_pulse_blocks(self):
         return self._saved_pulse_blocks
 
@@ -737,6 +755,10 @@ class SequenceGeneratorLogic(LogicBase):
 
         self.sigSamplingSettingsUpdated.emit(self.generation_parameters)
         return self.generation_parameters
+
+    def set_advanced_generation_parameters(self, advanced_settings_dict):
+        self._advanced_generation_parameters.update(advanced_settings_dict)
+        return self._advanced_generation_parameters
 
     def save_block(self, block):
         """ Saves a PulseBlock instance

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -107,7 +107,7 @@ class SequenceGeneratorLogic(LogicBase):
     )
 
     _advanced_generation_parameters = StatusVar(
-        default={'double_gate': False,
+        default={'gate_type': 'normal',
                  'gate_length1': 1e-6,
                  'gate_length2': 1e-6
                  }


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
Introduction of additional gating mode in pulsed measurement.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So far, the gating signal is given by the pulse length. However, you may not need the whole data of the pulse,
In this PR, two types of partial gating are introduced: Single partial gate and double gate.
The single partial gate mode gives gates only at the beginning of the pulse, while the double gate mode does at the beginning and the end of the pulse. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by checking with the pulse block editor.
The default config can be used by changing the gated option of the fast_counter_dummy as True.  

## Screenshots (only if appropriate, delete if not):
![pre defined methods advanced options](https://user-images.githubusercontent.com/58776486/214849060-f18e45fa-7498-424d-99ea-bf26cadd3af9.png)
![pre defined methods advanced options2](https://user-images.githubusercontent.com/58776486/214849117-a93304cd-01c3-4b91-bd18-0566fec5ade8.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
