### PR TITLE
Plugins to pulsed toolchain (clean)

### DIFF
--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -582,6 +582,8 @@ class PulsedMeasurementGui(GuiBase):
         for widget in self._global_param_widgets:
             if hasattr(widget, 'isChecked'):
                 widget.stateChanged.disconnect()
+            elif hasattr(widget, 'currentText'):
+                widget.currentTextChanged.disconnect()
             else:
                 widget.editingFinished.disconnect()
         return
@@ -1283,6 +1285,12 @@ class PulsedMeasurementGui(GuiBase):
                 widget = QtWidgets.QCheckBox()
                 widget.setChecked(value)
                 widget.stateChanged.connect(self.generation_parameters_changed)
+            elif issubclass(type(value), Enum):
+                widget = QtWidgets.QComboBox()
+                for option in type(value):
+                    widget.addItem(option.name, option)
+                widget.setCurrentText(value.name)
+                widget.currentTextChanged.connect(self.generation_parameters_changed)
 
             widget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
 
@@ -1609,6 +1617,8 @@ class PulsedMeasurementGui(GuiBase):
                     settings_dict[param_name] = widget.value()
                 elif hasattr(widget, 'text'):
                     settings_dict[param_name] = widget.text()
+                elif hasattr(widget, 'currentText'):
+                    settings_dict[param_name] = widget.currentData()
 
         self.pulsedmasterlogic().set_generation_parameters(settings_dict)
 
@@ -1656,6 +1666,9 @@ class PulsedMeasurementGui(GuiBase):
                         widget.setValue(settings_dict[param_name])
                     elif hasattr(widget, 'setText'):
                         widget.setText(settings_dict[param_name])
+                    elif hasattr(widget, 'currentText'):
+                        index = widget.findText(str(settings_dict[param_name].name))
+                        widget.setCurrentIndex(index)
                     widget.blockSignals(False)
 
         # unblock signals

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -27,7 +27,7 @@ import inspect
 import copy
 import logging
 import numpy as np
-from enum import Enum
+from enum import Enum, EnumMeta
 
 from qudi.util.helpers import iter_modules_recursive
 
@@ -219,6 +219,46 @@ class SamplingFunctions:
         if inspect.isclass(obj):
             return SamplingBase in inspect.getmro(obj) and object not in obj.__bases__
         return False
+
+
+class PulseEnvelopeTypeMeta(EnumMeta):
+    # hide special enum types containing '_'
+    def __iter__(self):
+        for x in super().__iter__():
+            if not '_' == x.value[0]:
+                yield x
+
+class PulseEnvelopeType(Enum, metaclass=PulseEnvelopeTypeMeta):
+
+    rectangle = 'rectangle'
+    sin_n = 'sin_n'
+    parabola = 'parabola'
+    optimal = 'optimal'
+    from_gen_settings = '_from_gen_settings'
+
+    def __init__(self, *args):
+        self._parameters = self.default_parameters
+
+    @property
+    def default_parameters(self):
+        defaults = {'rectangle': {},
+                    'parabola': {'order_P': 1},
+                    'optimal': {},
+                    'sin_n': {'order_n': 2},
+                    '_from_gen_settings': {}}
+
+        return defaults[self.value]
+
+    @property
+    def parameters(self):
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, param_dict):
+        self._parameters = param_dict
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.value}))"
 
 
 

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -215,6 +215,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         # Get instance of PulseObjectGenerator which takes care of collecting all predefined methods
         self._pog = PulseObjectGenerator(sequencegeneratorlogic=self)
+        self._pog.activate_plugins()
 
         self.__sequence_generation_in_progress = False
         return


### PR DESCRIPTION
This continues [PR70](https://github.com/Ulm-IQO/qudi-iqo-modules/pull/70), which I had to close to clean up the messed up branch.

## Description
This PR introduces small changes to the pulsed toolchain that allow loaded predefined_methods more flexibility.
- Custom predefined methods may inherit from `PredefinedGeneratorPlugin`, additionally to the existing `PredefinedGeneratorBase`.
- This enable to:
  1. Manipulate and even add their own `generation_parameters` (see screenshot)
  2. Invoke code after the `PulseObjectGenerator` is initialized. This allows for numerous possibilies, eg. to influence the helper methods in pulse_objects.py (like  _get_mw_element() ) that are used from all predefined methods.
- I also added the possibily to have enum like `generation_parameters` correctly handled by the gui.

## Motivation and Context

To see it working, use with this [iqo-sequences branch](https://github.com/Ulm-IQO/qudi-iqo-sequences/tree/shaped_methods).

## How Has This Been Tested?

## Screenshots:
Custom generation_parameters introduced by a predefined method plugin file.
![image](https://user-images.githubusercontent.com/5861249/216068913-fc3202f0-1357-4b60-a9d4-c24ac9bff8a8.png)


## Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [ ] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
