### PR TITLE
Fix Counts per second in finite sampling input

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ docstrings.
 
 ### Bugfixes
 - Basic data saving in `TimeSeriesReaderLogic` works now.
+- Ni Finite Sampling Input module now returns digital input channel values in "clicks/counts" per second and not "clicks/counts" per clock cycle 
 
 ### New Features
 - New `qudi.interface.data_instream_interface.SampleTiming` Enum added to `DataInStreamInterface` 

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
@@ -210,6 +210,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
 
         # initialize default settings
         self._sample_rate = self._constraints.max_sample_rate
+        # TODO: Get real sample rate limits depending on specified channels (see NI FSIO), or include in "ni helper".
         self._frame_size = 0
 
         self.set_active_channels(digital_sources.union(analog_sources))

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
@@ -424,7 +424,9 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                     timeout=self._rw_timeout)
                 if read_samples != number_of_samples:
                     return data
-                data[reader._task.name.split('_')[-1]] = data_buffer
+                data[reader._task.name.split('_')[-1]] = data_buffer * self._sample_rate
+                # TODO Multiplication by self._sample_rate to convert to c/s, from counts/clock cycle
+                #  What if unit not c/s?
 
             # Read analog channels
             if self._ai_reader is not None:

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
@@ -425,9 +425,10 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                     timeout=self._rw_timeout)
                 if read_samples != number_of_samples:
                     return data
-                data[reader._task.name.split('_')[-1]] = data_buffer * self._sample_rate
+                data_buffer *= self._sample_rate
                 # TODO Multiplication by self._sample_rate to convert to c/s, from counts/clock cycle
                 #  What if unit not c/s?
+                data[reader._task.name.split('_')[-1]] = data_buffer
 
             # Read analog channels
             if self._ai_reader is not None:


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Fix values retrieved from Ni Finite Sampling input to be "counts/second"

## Description
<!--- Describe your changes in detail -->

So far the Finite Sampling Input hardware module of the NI returns digital values which corresponded to "counts per clock cycle" and not "counts per second", as it is expected to be (and also as stated in the default config)

## Motivation and Context
From the old qudi core, the unit of the values gotten from digital channels had typically been counts/second. So far the unit was and still is ignored completely. Maybe one should not even allow to configure this and always return the value in c/s? 

## How Has This Been Tested?
Tested on a simulated NI PCIe-6363 with up to date qudi-core.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
