### PR TITLE
Hotfix poimanagerlogic crash without image loaded 

### DIFF
--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -1088,7 +1088,7 @@ class PoiManagerLogic(LogicBase):
             parameters['roi_name'] = self.roi_name
             parameters['poi_nametag'] = '' if self.poi_nametag is None else self.poi_nametag
             parameters['roi_creation_time'] = self.roi_creation_time_as_str
-            if self.roi_scan_image:
+            if self.roi_scan_image is not None:
                 x_extent, y_extent = self.roi_scan_image_extent
                 parameters['scan_image_x_extent'] = '{0:.9e},{1:.9e}'.format(*x_extent)
                 parameters['scan_image_y_extent'] = '{0:.9e},{1:.9e}'.format(*y_extent)

--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -1082,15 +1082,16 @@ class PoiManagerLogic(LogicBase):
                 timestamp.strftime('%Y%m%d-%H%M-%S'), roi_name_no_blanks)
 
             # Metadata to save in both file headers
-            x_extent, y_extent = self.roi_scan_image_extent
             parameters = OrderedDict()
             if self.active_poi:
                 parameters['Active POI'] = self.active_poi
             parameters['roi_name'] = self.roi_name
             parameters['poi_nametag'] = '' if self.poi_nametag is None else self.poi_nametag
             parameters['roi_creation_time'] = self.roi_creation_time_as_str
-            parameters['scan_image_x_extent'] = '{0:.9e},{1:.9e}'.format(*x_extent)
-            parameters['scan_image_y_extent'] = '{0:.9e},{1:.9e}'.format(*y_extent)
+            if self.roi_scan_image:
+                x_extent, y_extent = self.roi_scan_image_extent
+                parameters['scan_image_x_extent'] = '{0:.9e},{1:.9e}'.format(*x_extent)
+                parameters['scan_image_y_extent'] = '{0:.9e},{1:.9e}'.format(*y_extent)
             parameters['data format'] = 'name   X (m)   Y (m)   Z (m)'
 
             ##################################

--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -1155,7 +1155,7 @@ class PoiManagerLogic(LogicBase):
         roi_name = None
         poi_nametag = None
         roi_creation_time = None
-        scan_extent = None
+        scan_extent, scan_x_extent, scan_y_extent = None, None, None
         if is_legacy_format:
             roi_name = filetag
         else:
@@ -1175,8 +1175,11 @@ class PoiManagerLogic(LogicBase):
                     elif line.startswith('# scan_image_y_extent='):
                         scan_y_extent = line.split('# scan_image_y_extent=', 1)[1].strip().split("'")[1].strip().split(
                             ',')
-            scan_extent = ((float(scan_x_extent[0]), float(scan_x_extent[1])),
-                           (float(scan_y_extent[0]), float(scan_y_extent[1])))
+
+            if scan_x_extent is not None and scan_y_extent is not None:
+                scan_extent = ((float(scan_x_extent[0]), float(scan_x_extent[1])),
+                               (float(scan_y_extent[0]), float(scan_y_extent[1])))
+
             poi_nametag = None if not poi_nametag else poi_nametag
 
         # Read ROI position history from binary file


### PR DESCRIPTION
One liner that fixes #87. This would crash with 

```
TypeError: cannot unpack non-iterable NoneType object
 in save_roi()
    x_extent, y_extent = self.roi_scan_image_extent
```

## How Has This Been Tested?
Tested on dummy.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
