### PR TITLE
Increase Keysight AWG sample rate precision 

### DIFF
--- a/src/qudi/hardware/awg/keysight_m819x.py
+++ b/src/qudi/hardware/awg/keysight_m819x.py
@@ -453,7 +453,7 @@ class AWGM819X(PulserInterface):
               further processing.
         """
         sample_rate_GHz = (sample_rate * self._sample_rate_div) / 1e9
-        self.write(':FREQ:RAST {0:.4G}GHz\n'.format(sample_rate_GHz))
+        self.write(':FREQ:RAST {0:.13G}GHz\n'.format(sample_rate_GHz))
         while int(self.query('*OPC?')) != 1:
             time.sleep(0.25)
         time.sleep(0.2)


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Keysight AWG allows a sample rate precision of 10mHz. So far the sample rate can only be set with 10MHz precision.

## Description
<!--- Describe your changes in detail -->
One line change to increase the number of digits where the sample rate is written to the AWG. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The AWG allows for a higher resolution of sample rates than is used in Qudi so far. People might want (including at least me) to set the sample rate with higher precision. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with Keysight AWG M8195A on my setup. 
Might require testing with model 8190A (@timoML?). 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
