### PR TITLE
Bugfix typo in MW smbv

### DIFF
--- a/src/qudi/hardware/microwave/mw_source_smbv.py
+++ b/src/qudi/hardware/microwave/mw_source_smbv.py
@@ -288,7 +288,7 @@ class MicrowaveSmbv(MicrowaveInterface):
         """
         with self._thread_lock:
             if self.module_state() != 'idle':
-                if not self._in_cw_mode:
+                if not self._in_cw_mode():
                     return
                 raise RuntimeError('Unable to start frequency scan. CW microwave output is active.')
             assert self._scan_frequencies is not None, \
@@ -309,7 +309,7 @@ class MicrowaveSmbv(MicrowaveInterface):
         with self._thread_lock:
             if self.module_state() == 'idle':
                 return
-            if self._in_cw_mode:
+            if self._in_cw_mode():
                 raise RuntimeError('Can not reset frequency scan. CW microwave output active.')
 
             self._command_wait(':ABOR:SWE')

--- a/src/qudi/hardware/microwave/mw_source_smbv.py
+++ b/src/qudi/hardware/microwave/mw_source_smbv.py
@@ -80,7 +80,7 @@ class MicrowaveSmbv(MicrowaveInterface):
         self._command_wait('*RST')
 
         # Generate constraints
-        if self.model == 'SMB100A':
+        if self._model == 'SMB100A':
             freq_limits = (9e3, 3.2e9)
         else:
             freq_limits = (9e3, 6e9)
@@ -242,7 +242,7 @@ class MicrowaveSmbv(MicrowaveInterface):
             self._scan_sample_rate = sample_rate
             self._scan_power = power
             self._scan_frequencies = np.asarray(frequencies, dtype=np.float64)
-            self._write_list()
+            self._write_sweep()
             self._set_trigger_edge()
 
     def off(self):

--- a/src/qudi/logic/odmr_logic.py
+++ b/src/qudi/logic/odmr_logic.py
@@ -48,6 +48,8 @@ class OdmrLogic(LogicBase):
         connect:
             microwave: <microwave_name>
             data_scanner: <data_scanner_name>
+        options:
+            default_scan_mode: 'JUMP_LIST'  # optional
     """
 
     # declare connectors


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Quick bugfix of some typos in `mw_source_smbv`. 

## Description
<!--- Describe your changes in detail -->
Fixing four typing errors in the hardware file of mw generator Rohde&Schwarz SMB series as discovered and reported in [discussion #72](https://github.com/Ulm-IQO/qudi-core/discussions/72) in qudi-core. 
Additionally, add `default_scan_mode` ConfigOption in the example configuration in the docstring of the `odmr_logic`. This should show the user that the scan mode `JUMP_LIST` or `EQUIDISTANT_SWEEP` can be configured. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Obvious typos are fixed. See also [discussion #72](https://github.com/Ulm-IQO/qudi-core/discussions/72) in qudi-core. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Currently not tested with one of our hardware as it is not available. According to the author of the discussion, it should work. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
