### PR TITLE
[Hotfix] Tek 70k asset name

### DIFF
--- a/src/qudi/hardware/awg/tektronix_awg70k.py
+++ b/src/qudi/hardware/awg/tektronix_awg70k.py
@@ -708,7 +708,6 @@ class AWG70K(PulserInterface):
                     self.log.error('Unable to determine loaded assets.')
                     return dict(), ''
                 current_type = 'sequence'
-                asset_name += '_' + splitted[1]
             else:
                 if current_type is not None and current_type != 'waveform':
                     self.log.error('Unable to determine loaded assets.')


### PR DESCRIPTION
Fixes a bug that prevented a correct pulsed asset name (and thus auto-invocation of pulsed settings) in sequence mode. 
The bug was introduced by [this commit](https://github.com/Ulm-IQO/qudi-iqo-modules/commit/8cc9f78c6ebff583be0943d0c6e5e1ee9e9aa42b), as it improved the postfix handling. However, now splitting the "_ch" postfix only when occuring at the end of the asset, this improvement broke due the additional postfix in sequence mode. This PR removes this additional sequence mode postfix.