### PR TITLE
wavemeter: don't stop measurement

### DIFF
--- a/src/qudi/hardware/wavemeter/high_finesse_proxy.py
+++ b/src/qudi/hardware/wavemeter/high_finesse_proxy.py
@@ -133,8 +133,6 @@ class HighFinesseProxy(Base):
         else:
             self._wm_has_switch = False
 
-        self._stop_measurement()
-
         self._set_up_watchdog()
 
     def on_deactivate(self) -> None:
@@ -168,7 +166,6 @@ class HighFinesseProxy(Base):
                 del self._connected_instream_modules[module]
                 if not self._connected_instream_modules:
                     self._stop_callback()
-                    self._stop_measurement()
                 else:
                     # deactivate channels that are not connected by other instreamers
                     for ch in (channels_disconnecting_instreamer - self.get_connected_channels()):
@@ -232,7 +229,6 @@ class HighFinesseProxy(Base):
         self.log.warning('Stopping all streams.')
         streamers = list(self._connected_instream_modules).copy()
         self._stop_callback()
-        self._stop_measurement()
         self._connected_instream_modules = {}
         for streamer in streamers:
             # stop all streams without them triggering the proxy disconnect
@@ -289,11 +285,6 @@ class HighFinesseProxy(Base):
         err = self._wavemeter_dll.Operation(high_finesse_constants.cCtrlStartMeasurement)
         if err:
             raise RuntimeError(f'Wavemeter error while starting measurement: {high_finesse_constants.ResultError(err)}')
-
-    def _stop_measurement(self) -> None:
-        err = self._wavemeter_dll.Operation(high_finesse_constants.cCtrlStopAll)
-        if err:
-            raise RuntimeError(f'Wavemeter error while stopping measurement: {high_finesse_constants.ResultError(err)}')
 
     def _set_up_watchdog(self) -> None:
         self._watchdog_thread = self._thread_manager.get_new_thread(THREAD_NAME_WATCHDOG)

--- a/src/qudi/hardware/wavemeter/high_finesse_proxy.py
+++ b/src/qudi/hardware/wavemeter/high_finesse_proxy.py
@@ -112,6 +112,10 @@ class HighFinesseProxy(Base):
                              'Please install a High Finesse wavemeter and try again.') from e
         else:
             v = [self._wavemeter_dll.GetWLMVersion(i) for i in range(4)]
+            if v[0] == high_finesse_constants.GetFrequencyError.ErrWlmMissing.value:
+                raise RuntimeError('The wavemeter application is not active. '
+                                   'Start the wavemeter application before activating the qudi module.')
+
             self.log.info(f'Successfully loaded wavemeter DLL of WS{v[0]} {v[1]},'
                           f' software revision {v[2]}, compilation number {v[3]}.')
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
The HighFinesse wavemeter has exposed start/stop measurement functions. They start/stop the hardware-internal measurement loop. If this is not running, no new values are acquired.

This PR changes the qudi behavior to make sure to start the measurement but not to bother about stopping it once no qudi module is active anymore.

It also adds a check to properly catch an error code which indicates that the wavemeter app is not running and passes it to the user as an exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In this way, other processes that need wavemeter data are not affected. The most prominent example is the built-in laser stabilization of the wavemeter application as pointed out by @Nick-Grimm .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested with a HighFinesse WS 7. Special testing with remote modules should not be necessary.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
