### PR TITLE
improved support for SRS signal generators

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 ### Bugfixes
 
 ### New Features
+- Improved support for Stanford Research Systems signal generators
 
 ### Other
 

--- a/src/qudi/hardware/microwave/mw_source_srssg.py
+++ b/src/qudi/hardware/microwave/mw_source_srssg.py
@@ -102,7 +102,7 @@ class MicrowaveSRSSG(MicrowaveInterface):
             power_limits=(-110, 16.5),
             frequency_limits=freq_limits,
             scan_size_limits=(2, 2000),
-            sample_rate_limits=(0.1, 100),  # FIXME: Look up the proper specs for sample rate
+            sample_rate_limits=(1e-6, 50e3),
             scan_modes=(SamplingOutputMode.JUMP_LIST,)
         )
 

--- a/src/qudi/hardware/microwave/mw_source_srssg.py
+++ b/src/qudi/hardware/microwave/mw_source_srssg.py
@@ -25,8 +25,12 @@ If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-import pyvisa as visa
-from pyvisa.resources import MessageBasedResource
+try:
+    import pyvisa as visa
+    from pyvisa.resources import MessageBasedResource
+except ImportError:
+    import visa
+    from visa.resources import MessageBasedResource
 import time
 import numpy as np
 

--- a/src/qudi/hardware/microwave/mw_source_srssg.py
+++ b/src/qudi/hardware/microwave/mw_source_srssg.py
@@ -207,8 +207,9 @@ class MicrowaveSRSSG(MicrowaveInterface):
 
             # disable modulation:
             self._device.write('MODL 0')
-            # and the subtype (analog,)
-            self._device.write('STYP 0')
+            if self._is_vector_sg:
+                # set the modulation subtype to analog
+                self._device.write('STYP 0')
             self._device.write(f'FREQ {frequency:e}')
             self._device.write(f'AMPR {power:f}')
 
@@ -304,7 +305,8 @@ class MicrowaveSRSSG(MicrowaveInterface):
 
         for ii, freq in enumerate(self._scan_frequencies):
             self._device.write(
-                f'LSTP {ii:d},{freq:e},N,N,N,{self._scan_power:f},N,N,N,N,N,N,N,N,N,N'
+                # cycle the frequency, set the power, display the frequency
+                f'LSTP {ii:d},{freq:e},N,N,N,{self._scan_power:f},2,N,N,N,N,N,N,N,N,N'
             )
         # the commands contains 15 entries, which are related to the
         # following commands (in brackets the explanation), if parameter is
@@ -375,6 +377,7 @@ class MicrowaveSRSSG(MicrowaveInterface):
         #  13 = Offset of clock output
         #  14 = Amplitude of HF (RF doubler output)
         #  15 = Offset of rear DC
+
         # enable the created list:
         self._device.write('LSTE 1')
 

--- a/src/qudi/hardware/microwave/mw_source_srssg.py
+++ b/src/qudi/hardware/microwave/mw_source_srssg.py
@@ -301,7 +301,11 @@ class MicrowaveSRSSG(MicrowaveInterface):
         self._device.write('LSTD')
 
         # ask for a new list
-        self._device.query(f'LSTC? {len(self._scan_frequencies):d}')
+        success = self._device.query(f'LSTC? {len(self._scan_frequencies):d}')
+        if success:
+            self.log.debug('Successfully created a new list.')
+        else:
+            raise RuntimeError('List creation was unsuccessful.')
 
         for ii, freq in enumerate(self._scan_frequencies):
             self._device.write(

--- a/src/qudi/hardware/microwave/mw_source_srssg.py
+++ b/src/qudi/hardware/microwave/mw_source_srssg.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 """
-This file contains the Qudi hardware file to control SRS SG devices.
+This file contains the Qudi hardware file to control Stanford Research Systems signal generators.
+Both basic (SG382, SG384, SG386) and vector generators (SG392, SG394, SG396) should work with this module.
+Manual and technical specifications can be found here:
+    - https://www.thinksrs.com/products/sg380.html (basic RF generators)
+    - https://www.thinksrs.com/products/sg390.html (vector signal generators)
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces improvements to the microwave hardware file for Stanford Research Systems (SRS) signal generators.

- support for all current SRS signal generators (see [manufacturer website](https://www.thinksrs.com/products/test.html))
- proper matching of the model identifier to supported functions and hardware constraints
- check for error after every write command
- display current frequency during scan
- type annotations and documentation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are using a non-vector SRS signal generator in our lab. It was not compatible with the current hardware file due to the usage of commands which are defined exclusively for vector models.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on real hardware (SG384) with the ODMR toolchain.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [X] My code follows the code style of this project.
- [X] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [X] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
