### PR TITLE
add support for devices with voltage-high sensitive triggers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 ### Bugfixes
+- "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
 
 ### New Features
 - Improved support for Stanford Research Systems signal generators

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
@@ -74,7 +74,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
         name='external_sample_clock_frequency', default=None, missing='nothing')
 
     _physical_sample_clock_output = ConfigOption(name='sample_clock_output', default=None)
-    _trigger_edge = ConfigOption(name='trigger_edge', default=ni.constants.Edge.RISING,
+    _trigger_edge = ConfigOption(name='trigger_edge', default="RISING",
                                  constructor=lambda x: ni.constants.Edge[x.upper()], missing='warn')
 
     _adc_voltage_range = ConfigOption('adc_voltage_range', default=(-10, 10), missing='info')
@@ -507,7 +507,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                 task.co_channels.add_co_pulse_chan_freq(
                     '/{0}/{1}'.format(self._device_name, src),
                     freq=self._sample_rate,
-                    idle_state=ni.constants.Level.HIGH if self._trigger_edge == ni.constants.Edge.RISING else ni.constants.Level.LOW)
+                    idle_state=ni.constants.Level.HIGH if self._trigger_edge==ni.constants.Edge.FALLING else ni.constants.Level.LOW)
                 task.timing.cfg_implicit_timing(
                     sample_mode=ni.constants.AcquisitionType.FINITE,
                     samps_per_chan=self._frame_size + 1)

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_input.py
@@ -60,7 +60,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
             max_channel_samples_buffer: 10000000  # optional, default 10000000
             read_write_timeout: 10  # optional, default 10
             sample_clock_output: '/Dev1/PFI20'  # optional
-            invert_trigger_polarity: False  # optional
+            trigger_edge: RISING  # optional
 
     """
 
@@ -74,7 +74,8 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
         name='external_sample_clock_frequency', default=None, missing='nothing')
 
     _physical_sample_clock_output = ConfigOption(name='sample_clock_output', default=None)
-    _invert_trigger_polarity = ConfigOption(name='invert_trigger_polarity', default=False)
+    _trigger_edge = ConfigOption(name='trigger_edge', default=ni.constants.Edge.RISING,
+                                 constructor=lambda x: ni.constants.Edge[x.upper()], missing='warn')
 
     _adc_voltage_range = ConfigOption('adc_voltage_range', default=(-10, 10), missing='info')
     _max_channel_samples_buffer = ConfigOption(
@@ -506,7 +507,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                 task.co_channels.add_co_pulse_chan_freq(
                     '/{0}/{1}'.format(self._device_name, src),
                     freq=self._sample_rate,
-                    idle_state=ni.constants.Level.HIGH if self._invert_trigger_polarity else ni.constants.Level.LOW)
+                    idle_state=ni.constants.Level.HIGH if self._trigger_edge == ni.constants.Edge.RISING else ni.constants.Level.LOW)
                 task.timing.cfg_implicit_timing(
                     sample_mode=ni.constants.AcquisitionType.FINITE,
                     samps_per_chan=self._frame_size + 1)
@@ -594,7 +595,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                         min_val=0,
                         max_val=100000000,
                         units=ni.constants.TimeUnits.TICKS,
-                        edge=ni.constants.Edge.FALLING if self._invert_trigger_polarity else ni.constants.Edge.RISING)
+                        edge=self._trigger_edge)
                     # NOTE: The following two direct calls to C-function wrappers are a
                     # workaround due to a bug in some NIDAQmx.lib property getters. If one of
                     # these getters is called, it will mess up the task timing.
@@ -715,8 +716,7 @@ class NIXSeriesFiniteSamplingInput(FiniteSamplingInputInterface):
                                                     min_val=min(self._adc_voltage_range))
             ai_task.timing.cfg_samp_clk_timing(sample_freq,
                                                source=clock_channel,
-                                               active_edge=ni.constants.Edge.FALLING if self._invert_trigger_polarity \
-                                                   else ni.constants.Edge.RISING,
+                                               active_edge=self._trigger_edge,
                                                sample_mode=ni.constants.AcquisitionType.FINITE,
                                                samps_per_chan=self._frame_size)
         except ni.DaqError:


### PR DESCRIPTION
add support for devices with voltage-high sensitive triggers

## Description
Adds option for a config flag invert_trigger_polarity, that if checked, changes the idle_state of the NI output channels to HIGH instead of LOW and changes the edge types to FALLING instead of RISING edges

## Motivation and Context
Some devices, e.g. the microwave generators from the company Windfreak Technologies are LOW-sensitive, so trigger pulses have to consider that. A LOW idle state causes unwanted triggering. Also the edges have to be changed.
#105 

## How Has This Been Tested?
The fix has been tested by checking sweeps of the microwave signal with qudi's odmr module, using a Windfreak SynthNV Pro connected to an oscilloscope to check the output. With the fix, no unwanted triggering occurs anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
