### PR TITLE
Introducing cursor position in Scan2DWidget

### DIFF
--- a/src/qudi/gui/scanning/scan_widget.py
+++ b/src/qudi/gui/scanning/scan_widget.py
@@ -207,18 +207,22 @@ class Scan2DWidget(_BaseScanWidget):
                  axes: Tuple[ScannerAxis, ScannerAxis],
                  channels: Sequence[ScannerChannel],
                  parent: Optional[QtWidgets.QWidget] = None,
-                 xy_region_min_size_percentile: Optional[float] = None
+                 xy_region_min_size_percentile: Optional[float] = None,
+                 max_mouse_pos_update_rate: Optional[float] = 20.
                  ) -> None:
         super().__init__(channels, parent=parent)
          
         self.position_label = CursorPositionLabel()
-        self.image_widget = RubberbandZoomSelectionImageWidget(allow_tracking_outside_data=True,
-                                                               max_mouse_pos_update_rate=20.,
-                                                               xy_region_selection_crosshair=True,
-                                                               xy_region_selection_handles=False,
-                                                               xy_region_min_size_percentile=xy_region_min_size_percentile)
+        self.position_label.setAlignment(QtCore.Qt.AlignVCenter | QtCore.Qt.AlignRight)
+        self.position_label.set_units(axes[0].unit, axes[1].unit)
+        self.image_widget = RubberbandZoomSelectionImageWidget(
+            allow_tracking_outside_data=True,
+            max_mouse_pos_update_rate=max_mouse_pos_update_rate,
+            xy_region_selection_crosshair=True,
+            xy_region_selection_handles=False,
+            xy_region_min_size_percentile=xy_region_min_size_percentile
+        )
         self.image_widget.sigMouseMoved.connect(self.position_label.update_position)
-        self.image_widget.setMouseTracking(True)
         self.image_widget.set_selection_mutable(True)
         self.image_widget.add_region_selection(span=((-0.5, 0.5), (-0.5, 0.5)),
                                                mode=self.image_widget.SelectionMode.XY)
@@ -231,7 +235,7 @@ class Scan2DWidget(_BaseScanWidget):
         self.image_widget.set_data_label(label=channels[0].name, unit=channels[0].unit)
 
         self.layout().addWidget(self.image_widget, 1, 0, 1, 4)
-        self.layout().addWidget(self.position_label, 2, 1, 2, 5)
+        self.layout().addWidget(self.position_label, 2, 0, 1, 4)
 
         # disable buggy pyqtgraph 'Export..' context menu
         self.image_widget.plot_widget.getPlotItem().vb.scene().contextMenu[0].setVisible(False)

--- a/src/qudi/gui/scanning/scan_widget.py
+++ b/src/qudi/gui/scanning/scan_widget.py
@@ -30,6 +30,7 @@ from typing import Optional, List
 from qudi.util.widgets.plotting.plot_widget import RubberbandZoomSelectionPlotWidget
 from qudi.util.widgets.plotting.image_widget import RubberbandZoomSelectionImageWidget
 from qudi.util.widgets.plotting.plot_item import XYPlotItem
+from qudi.util.widgets.plotting.interactive_curve import CursorPositionLabel
 from qudi.util.paths import get_artwork_dir
 from qudi.interface.scanning_probe_interface import ScanData, ScannerAxis, ScannerChannel
 
@@ -209,11 +210,15 @@ class Scan2DWidget(_BaseScanWidget):
                  xy_region_min_size_percentile: Optional[float] = None
                  ) -> None:
         super().__init__(channels, parent=parent)
-
+         
+        self.position_label = CursorPositionLabel()
         self.image_widget = RubberbandZoomSelectionImageWidget(allow_tracking_outside_data=True,
+                                                               max_mouse_pos_update_rate=20.,
                                                                xy_region_selection_crosshair=True,
                                                                xy_region_selection_handles=False,
                                                                xy_region_min_size_percentile=xy_region_min_size_percentile)
+        self.image_widget.sigMouseMoved.connect(self.position_label.update_position)
+        self.image_widget.setMouseTracking(True)
         self.image_widget.set_selection_mutable(True)
         self.image_widget.add_region_selection(span=((-0.5, 0.5), (-0.5, 0.5)),
                                                mode=self.image_widget.SelectionMode.XY)
@@ -226,6 +231,7 @@ class Scan2DWidget(_BaseScanWidget):
         self.image_widget.set_data_label(label=channels[0].name, unit=channels[0].unit)
 
         self.layout().addWidget(self.image_widget, 1, 0, 1, 4)
+        self.layout().addWidget(self.position_label, 2, 1, 2, 5)
 
         # disable buggy pyqtgraph 'Export..' context menu
         self.image_widget.plot_widget.getPlotItem().vb.scene().contextMenu[0].setVisible(False)


### PR DESCRIPTION
There is now another label in the Scan2DWidget showing you 
the position of the mouse cursor.

<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is additional information allowing one to get the exact position of e.g. a colorcenter
without actually moving the scanner.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Only on dummy for now
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):
![image](https://github.com/Ulm-IQO/qudi-iqo-modules/assets/11192737/82aea5f5-ca42-4bd4-9a29-eadb7e7aed8e)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

We should probably check performance across different setups
and find a sensible default for the polling rate of the cursor position.

