### PR TITLE
Windfreak synthHD documentation for falling trigger edges

### DIFF
--- a/src/qudi/hardware/microwave/mw_source_windfreak_synthhdpro.py
+++ b/src/qudi/hardware/microwave/mw_source_windfreak_synthhdpro.py
@@ -31,6 +31,10 @@ from qudi.util.enums import SamplingOutputMode
 class MicrowaveSynthHDPro(MicrowaveInterface):
     """ Hardware class to controls a SynthHD Pro.
 
+    Important note: This MW source is low active. Using it together with trigger signals make sure
+    to use falling trigger edges. For the ni_x_series_finite_sampling_input there is the
+    `trigger_edge` option. You can change the default value (RISING) to FALLING.
+
     Example config for copy-paste:
 
     mw_source_synthhd:


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
Added documentation that the MW source is low active and needs a falling edge when using triggers. Using the `ni_x_series_finite_sampling_input` one can change the config option for the trigger edge. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users have run into this problem. First the option to change the trigger edge has beed added with PR #122. After that users still ran into the same problem because the necessity to change the trigger edge is not stated in the hardware file. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested, only change in the docstring. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
