### PR TITLE
Fixes issue with using same pfi channel on two different ni cards for NI instreamer

### DIFF
--- a/src/qudi/hardware/ni_x_series/ni_x_series_in_streamer.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_in_streamer.py
@@ -640,7 +640,7 @@ class NIXSeriesInStreamer(DataInStreamInterface):
             # Set up digital counting tasks
             for i, chnl in enumerate(digital_channels):
                 chnl_name = f'/{self._device_name}/{chnl}'
-                task_name = f'PeriodCounter_{chnl}'
+                task_name = f'PeriodCounter_{self._device_name}_{chnl}'
                 # Try to find available counter
                 for ctr in self.__all_counters:
                     ctr_name = f'/{self._device_name}/{ctr}'


### PR DESCRIPTION
## Description
If there are two NI cards connected and each has an analog input on the same pfi channel, then both counter GUIs cannot be run simultaneously because the task names are identical.

## Motivation and Context
For experiments using multiple NI cards, it is possible that the same pfi channel is used and it causes the new task to have the same name as the old task. This crashes the time series gui.

## How Has This Been Tested?
Tested scanner and time series gui on my two-foci confocal setup and it worked fine. Have not tested any other modules since I don't use anything else.
Also the old core did not have this problem because there was a check to make sure task names were unique: https://github.com/Ulm-IQO/qudi/blob/ac37d66a1a89afaef455bf67699fcc189c1b60b2/hardware/ni_x_series_in_streamer.py#L874-L882

## Types of changes
- [x] Bug fix
- [ ] New feature
- [x] Breaking change (possibly breaking, I have no idea if something else depends on the existing naming convention)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
