### PR TITLE
Remove old odmr fits

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@
 - Improved support for Stanford Research Systems signal generators
 - Expanded documentation of the microwave interface
 
+### Bugfixes
+- Old ODMR fits are now removed when starting a new measurement
+
 ### Other
 
 ## Version 0.5.1

--- a/src/qudi/logic/odmr_logic.py
+++ b/src/qudi/logic/odmr_logic.py
@@ -546,7 +546,7 @@ class OdmrLogic(LogicBase):
                 self.sigScanStateUpdated.emit(False)
                 return
 
-            self.clear_old_fits()
+            self.clear_all_fits()
             self._elapsed_sweeps = 0
             self._elapsed_time = 0.0
             self.sigElapsedUpdated.emit(self._elapsed_time, self._elapsed_sweeps)
@@ -556,7 +556,7 @@ class OdmrLogic(LogicBase):
             self._start_time = time.time()
             self._sigNextLine.emit()
 
-    def clear_old_fits(self):
+    def clear_all_fits(self):
         for channel, range_data in self._raw_data.items():
             for range_index, _ in enumerate(range_data):
                 self._fit_results[channel][range_index] = None

--- a/src/qudi/logic/odmr_logic.py
+++ b/src/qudi/logic/odmr_logic.py
@@ -546,7 +546,7 @@ class OdmrLogic(LogicBase):
                 self.sigScanStateUpdated.emit(False)
                 return
 
-            # ToDo: Clear old fit
+            self.clear_old_fits()
             self._elapsed_sweeps = 0
             self._elapsed_time = 0.0
             self.sigElapsedUpdated.emit(self._elapsed_time, self._elapsed_sweeps)
@@ -555,6 +555,12 @@ class OdmrLogic(LogicBase):
             self.sigScanStateUpdated.emit(True)
             self._start_time = time.time()
             self._sigNextLine.emit()
+
+    def clear_old_fits(self):
+        for channel, range_data in self._raw_data.items():
+            for range_index, _ in enumerate(range_data):
+                self._fit_results[channel][range_index] = None
+                self.sigFitUpdated.emit(self._fit_results[channel][range_index], channel, range_index)
 
     @QtCore.Slot()
     def continue_odmr_scan(self):


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

Remove old fits when starting a new ODMR measurement

## Description
<!--- Describe your changes in detail -->

As discussed in https://github.com/Ulm-IQO/qudi-iqo-modules/discussions/137, all fits are removed when starting a new ODMR measurement.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Old fits were not removed when starting a new measurement, which could be annoying especially when the frequency range changed between the old and the new measurement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with dummy configuration, which should not matter

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
