### PR TITLE
POI manager auto-find fix

### DIFF
--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -1265,7 +1265,7 @@ class PoiManagerLogic(LogicBase):
 
     def _local_max(self, scan):
         scan = np.asarray(scan, order="C")  # scan has to be a 2-D array
-        filter_size = self._spot_filter(scan)
+        filter_size = max(self._spot_filter(scan), 1)
         scan_m = scan.mean()
         mid_f = int(filter_size / 2)
         xc = []
@@ -1275,14 +1275,15 @@ class PoiManagerLogic(LogicBase):
                 local_arr = scan[i:i + filter_size, j:j + filter_size]
                 local_arr = np.asarray(local_arr)
                 arr_threshold = scan_m * self._poi_threshold * 0.5
-                if scan[i + mid_f][j + mid_f] == local_arr.max() and self._is_spot_shape(
-                        local_arr) and local_arr.mean() > arr_threshold:
+                if (scan[i + mid_f][j + mid_f] == local_arr.max()
+                        and self._is_spot_shape(local_arr)
+                        and local_arr.mean() > arr_threshold):
                     xc.append(i + mid_f)
                     yc.append(j + mid_f)
         return xc, yc
 
     def auto_catch_poi(self):
-        scan_image = self.roi_scan_image.T
+        scan_image = self.roi_scan_image
         x_range = self.roi_scan_image_extent[0]
         y_range = self.roi_scan_image_extent[1]
         x_axis = np.arange(x_range[0], x_range[1], (x_range[1] - x_range[0]) / len(scan_image))


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

POI manager auto-find fix

## Description
<!--- Describe your changes in detail -->

When running the (cool) auto-find feature in the POI manager, the POIs did not match the bright spots but appeared to be rotated by 90°. The issue seemed to stem from an unnecessary transpose operation on the image data, which has now been removed. Additionally, if the POI diameter was smaller than the image step size, an exception was thrown due to a filter size of 0. This has been resolved by ensuring that the filter size is at least 1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After these changes the feature seems to run as expected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested only with dummy configuration, which should not matter

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
