### PR TITLE
Fastcomtec get sweeps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
 
 ### New Features
+- Get current sweeps and runtime of fastcomtec fastcounter MCS6 when pulling the data trace. 
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.
 - Improved support for Stanford Research Systems signal generators
 - Expanded documentation of the microwave interface

--- a/src/qudi/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/src/qudi/hardware/fastcomtec/fastcomtecmcs6.py
@@ -386,6 +386,14 @@ class FastComtec(FastCounterInterface):
         self.dll.GetSettingData(ctypes.byref(setting), 0)
         N = setting.range
 
+        status = AcqStatus()
+        self.dll.GetStatusData(ctypes.byref(status), 0)
+        elapsed_sweeps = status.stevents
+        elapsed_time = status.runtime
+
+        info_dict = {'elapsed_sweeps': elapsed_sweeps,
+                     'elapsed_time': elapsed_time}
+
         if self.is_gated():
             bsetting=BOARDSETTING()
             self.dll.GetMCSSetting(ctypes.byref(bsetting), 0)
@@ -405,8 +413,8 @@ class FastComtec(FastCounterInterface):
         if self.gated and self.timetrace_tmp != []:
             time_trace = time_trace + self.timetrace_tmp
 
-        info_dict = {'elapsed_sweeps': None,
-                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
+        info_dict = {'elapsed_sweeps': elapsed_sweeps,
+                     'elapsed_time': elapsed_time}
         return time_trace, info_dict
 
 

--- a/src/qudi/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/src/qudi/hardware/fastcomtec/fastcomtecmcs6.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This file contains the Qudi hardware file implementation for FastComtec p7887 .
+This file contains the Qudi hardware file implementation for FastComtec MCS6.
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
@@ -158,7 +158,7 @@ class BOARDSETTING(ctypes.Structure):
 
 
 class FastComtec(FastCounterInterface):
-    """ Hardware Class for the FastComtec Card.
+    """ Hardware Class for the FastComtec Card MCS6.
 
     stable: Jochen Scheuer, Simon Schmitt
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Get the current number of sweeps and runtime of the FastComtec MCS6 while running a measurement. 

## Description
<!--- Describe your changes in detail -->
The FastComtec counter model MCS6 has the possibility to read the number of sweeps and runtime when a measurement is performed. This has not been implemented so far and is added with this PR. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The info_dict when getting the data trace returns `None`. Also when the measurement is saved the information about the elapsed sweeps will not be saved. By simply querying the sweeps and runtime of the fastcounter the values are available for the user especially once the measurement is saved. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on my setup with real hardware MCS6A. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
