### PR TITLE
Qdplotter bugfix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,15 @@
 # Changelog
 
+Note: Newer changes are at the top of the item lists. 
+
 ## Pre-Release
 
 ### Breaking Changes
 
 ### Bugfixes
-- "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
-- Fixed `QDPlotterGui` example config
 - Fixed missing `plot_index` when calling `QDPlotLogic._remove_plot` in `QDPlotLogic._set_plot_count`
+- Fixed `QDPlotterGui` example config
+- "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
 
 ### New Features
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,15 +1,13 @@
 # Changelog
 
-Note: Newer changes are at the top of the item lists. 
-
 ## Pre-Release
 
 ### Breaking Changes
 
 ### Bugfixes
-- Fixed missing `plot_index` when calling `QDPlotLogic._remove_plot` in `QDPlotLogic._set_plot_count`
-- Fixed `QDPlotterGui` example config
 - "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
+- Fixed `QDPlotterGui` example config
+- Fixed missing `plot_index` when calling `QDPlotLogic._remove_plot` in `QDPlotLogic._set_plot_count`
 
 ### New Features
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ### Bugfixes
 - "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
+- Fixed `QDPlotterGui` example config
+- Fixed missing `plot_index` when calling `QDPlotLogic._remove_plot` in `QDPlotLogic._set_plot_count`
 
 ### New Features
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.

--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -57,7 +57,7 @@ class QDPlotterGui(GuiBase):
     Example config for copy-paste:
 
     qdplotter:
-        module.Class: 'qdplotter.qdplotter_gui.QDPlotterGui'
+        module.Class: 'qdplot.qdplot_gui.QDPlotterGui'
         options:
             pen_color_list: [[100, 100, 100], 'c', 'm', 'g']
         connect:

--- a/src/qudi/logic/qdplot_logic.py
+++ b/src/qudi/logic/qdplot_logic.py
@@ -372,7 +372,7 @@ class QDPlotLogic(LogicBase):
         while self.plot_count < plot_count:
             self._add_plot()
         while self.plot_count > plot_count:
-            self._remove_plot()
+            self._remove_plot(0)
 
     def get_data(self, plot_index: int) -> QDPlotDataSet:
         with self._thread_lock:

--- a/src/qudi/logic/qdplot_logic.py
+++ b/src/qudi/logic/qdplot_logic.py
@@ -258,11 +258,11 @@ class QDPlotFitContainer(FitContainer):
 
 class QDPlotLogic(LogicBase):
     """ This logic module helps display user data in plots, and makes it easy to save.
-    
-    There are phythonic setters and getters for each of the parameter and data. 
+
+    There are phythonic setters and getters for each of the parameter and data.
     They can be called by "plot_<plot_number>_parameter". plot_number ranges from 1 to 3.
     Parameters are: x_limits, y_limits, x_label, y_label, x_unit, y_unit, x_data, y_data, clear_old_data
-    
+
     All parameters and data can also be interacted with by calling get_ and set_ functions.
 
     Example config for copy-paste:
@@ -372,7 +372,7 @@ class QDPlotLogic(LogicBase):
         while self.plot_count < plot_count:
             self._add_plot()
         while self.plot_count > plot_count:
-            self._remove_plot(0)
+            self._remove_plot(-1)
 
     def get_data(self, plot_index: int) -> QDPlotDataSet:
         with self._thread_lock:


### PR DESCRIPTION
## Description

- Fixed the example config for copy and paste to link to the correct module.
- Fixed missing `plot_index` when calling `QDPlotLogic._remove_plot` in `QDPlotLogic._set_plot_count`. I chose to remove the oldest (lowest index = 0) plot.

## Motivation and Context

- Copy paste config was not correct before
- `QDPlotLogic._remove_plot` will raise an exception when `QDPlotLogic._set_plot_count` is called, making the function unusable

## How Has This Been Tested?
Tested it by loading the module and calling `QDPlotLogic.set_plot_count`

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
