### PR TITLE
Fixed some bugs in laserquantum_laser hardware file

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@
 
 ### Bugfixes
 - "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
+- Fixed typo in `LaserQuantumLaser` when returning the `ShutterState`
+- Removed `PSUTypes.FPU` if statement in `LaserQuantumLaser` as it is not an existing `PSUTypes`
+- Fixed `LaserQuantumLaser.get_power_setpoint` to return last set power instead of current power
 
 ### New Features
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.

--- a/src/qudi/hardware/laser/laserquantum_laser.py
+++ b/src/qudi/hardware/laser/laserquantum_laser.py
@@ -61,6 +61,9 @@ class LaserQuantumLaser(SimpleLaserInterface):
         """
         self.psu = PSUTypes[self.psu_type]
         self.connect_laser(self.serial_interface)
+        # initialize the last set power as is, if the laser is still running
+        # or set it to 0 if the laser is off
+        self._last_set_power = self.get_power()
 
     def on_deactivate(self):
         """ Deactivate module.
@@ -150,8 +153,7 @@ class LaserQuantumLaser(SimpleLaserInterface):
 
         @return float: laser power setpoint in watts
         """
-        # FIXME: This is just wrong
-        return self.get_power()
+        return self._last_set_power
 
     def get_power_range(self):
         """ Get laser power range.
@@ -165,6 +167,7 @@ class LaserQuantumLaser(SimpleLaserInterface):
 
         @param float power: desired laser power in watts
         """
+        self._last_set_power = power
         self.inst.query('POWER={0:f}'.format(power*1000))
 
     def get_current_unit(self):
@@ -216,7 +219,7 @@ class LaserQuantumLaser(SimpleLaserInterface):
 
         @return ShutterState: laser shutter state
         """
-        return ShutterState.NOSHUTTER
+        return ShutterState.NO_SHUTTER
 
     def set_shutter_state(self, state):
         """ Set the desired laser shutter state.
@@ -338,9 +341,6 @@ class LaserQuantumLaser(SimpleLaserInterface):
         extra = ''
         extra += '\n'.join(self.get_firmware_version())
         extra += '\n'
-        if self.psu == PSUTypes.FPU:
-            extra += '\n'.join(self.dump())
-            extra += '\n'
         extra += '\n'.join(self.timers())
         extra += '\n'
         return extra


### PR DESCRIPTION
## Description

- When loading the laser toolchain with the laserquantum laser it will fail upon activation. I fixed a typo when querying the shutter state `get_shutter_state` . 
- I removed the `PSUTypes.FPU` in `get_extra_info` as it is not present in `PSUTypes` and I could not find a matching power supply on laserquantums website
- Fixed the return value of `get_power_setpoint`. Upon setting the power a variable `_last_set_power` will be set that stores the last setpoint. When querying the power setpoint this will be returned instead of the current power, which made the setpoint spinbox in the gui unusable. Upon module activation the currently set power will be retrieved. This will be close to 0 W if the laser is off or it will be the currently set output power.

## Motivation and Context
- First two changes prohibit the use of the laser toolchain with the `laserquantum_laser` hardware file
- The command that was previously sent to the hardware within the if statement that I removed is not documented in the manuals for the different PSU types and returns an Error if sent to the device. Thus I removed it as no information can be gained by this query.
- Setting the currently displayed setpoint to the current output power will result in an unusable setpoint spinbox, which constantly fluctuates in value.

## How Has This Been Tested?
I tested it on my setup using a laserquantum gem laser with SMD12 PSU.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [x] Breaking change (Causes existing functionality to not work as expected) (If anybody relied on the extra information output)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
