### PR TITLE
fix rotating frame in hahn_echo_exp

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,10 @@
 ### Breaking Changes
 
 ### Bugfixes
+- Now correct microwave phases in predefined method generate_hahnecho_exp()
 - "NFiniteSamplingInput supporting both trigger polarities via ConfigOption
+- Old ODMR fits are now removed when starting a new measurement
+
 
 ### New Features
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.
@@ -13,7 +16,6 @@
 - Expanded documentation of the microwave interface
 
 ### Bugfixes
-- Old ODMR fits are now removed when starting a new measurement
 
 ### Other
 

--- a/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -614,7 +614,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         created_blocks.append(hahn_block)
 
         # Create block ensemble
-        block_ensemble = PulseBlockEnsemble(name=name, rotating_frame=False)
+        block_ensemble = PulseBlockEnsemble(name=name, rotating_frame=True)
         block_ensemble.append((hahn_block.name, 0))
 
         # Create and append sync trigger block if needed


### PR DESCRIPTION
The current rotating_frame=False will brake the phases of MW pulses in the experiment.