### PR TITLE
Scanner customnametag

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.
 - Improved support for Stanford Research Systems signal generators
 - Expanded documentation of the microwave interface
+- Added option to specify custom save file name in scanning GUI
 
 ### Bugfixes
 - Old ODMR fits are now removed when starting a new measurement

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@
 - Re-introduced tilt correction (from old core) to the scanning probe toolchain.
 - Improved support for Stanford Research Systems signal generators
 - Expanded documentation of the microwave interface
-- Added option to specify custom save file name in scanning GUI
+- Added option to specify custom save file name in scanning GUI (PR #148)
 
 ### Bugfixes
 - Old ODMR fits are now removed when starting a new measurement

--- a/src/qudi/gui/scanning/scan_widget.py
+++ b/src/qudi/gui/scanning/scan_widget.py
@@ -33,6 +33,7 @@ from qudi.util.widgets.plotting.plot_item import XYPlotItem
 from qudi.util.widgets.plotting.interactive_curve import CursorPositionLabel
 from qudi.util.paths import get_artwork_dir
 from qudi.interface.scanning_probe_interface import ScanData, ScannerAxis, ScannerChannel
+from qudi.util.widgets.scientific_spinbox import ScienDSpinBox
 
 
 class _BaseScanWidget(QtWidgets.QWidget):
@@ -77,12 +78,23 @@ class _BaseScanWidget(QtWidgets.QWidget):
             QtWidgets.QComboBox.AdjustToContentsOnFirstShow
         )
 
+        # Create QLineEdit for save tag
+        self.save_nametag_lineedit = QtWidgets.QLineEdit()
+        self.save_nametag_lineedit.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
+                                                 QtWidgets.QSizePolicy.Fixed)
+        self.save_nametag_lineedit.setMinimumWidth(
+            QtGui.QFontMetrics(ScienDSpinBox().font()).width(75 * ' ')  # roughly 75 chars shown
+        )
+        self.save_nametag_lineedit.setToolTip('Enter a nametag to include in saved file name')
+
         layout.addWidget(self.toggle_scan_button, 0, 0)
         layout.addWidget(self.save_scan_button, 0, 1)
-        layout.addWidget(self.channel_selection_label, 0, 2)
-        layout.addWidget(self.channel_selection_combobox, 0, 3)
+        layout.addWidget(self.save_nametag_lineedit, 0, 2)
+        layout.addWidget(self.channel_selection_label, 0, 3)
+        layout.addWidget(self.channel_selection_combobox, 0, 4)
         layout.setColumnStretch(2, 1)
         layout.setColumnStretch(3, 1)
+        layout.setColumnStretch(4, 1)
 
         self._scan_data = None
 
@@ -113,7 +125,7 @@ class Scan1DWidget(_BaseScanWidget):
         self.plot_widget.setLabel('bottom', text=axes[0].name.title(), units=axes[0].unit)
         self.plot_widget.setLabel('left', text=channels[0].name, units=channels[0].unit)
 
-        self.layout().addWidget(self.plot_widget, 1, 0, 1, 4)
+        self.layout().addWidget(self.plot_widget, 1, 0, 1, 5)
 
         # disable buggy pyqtgraph 'Export..' context menu
         self.plot_widget.getPlotItem().vb.scene().contextMenu[0].setVisible(False)
@@ -234,8 +246,8 @@ class Scan2DWidget(_BaseScanWidget):
         self.image_widget.set_axis_label('left', label=axes[1].name.title(), unit=axes[1].unit)
         self.image_widget.set_data_label(label=channels[0].name, unit=channels[0].unit)
 
-        self.layout().addWidget(self.image_widget, 1, 0, 1, 4)
-        self.layout().addWidget(self.position_label, 2, 0, 1, 4)
+        self.layout().addWidget(self.image_widget, 1, 0, 1, 5)
+        self.layout().addWidget(self.position_label, 2, 0, 1, 5)
 
         # disable buggy pyqtgraph 'Export..' context menu
         self.image_widget.plot_widget.getPlotItem().vb.scene().contextMenu[0].setVisible(False)

--- a/src/qudi/gui/scanning/scannergui.py
+++ b/src/qudi/gui/scanning/scannergui.py
@@ -130,7 +130,7 @@ class ScannerGui(GuiBase):
     sigToggleScan = QtCore.Signal(bool, tuple, object)
     sigOptimizerSettingsChanged = QtCore.Signal(dict)
     sigToggleOptimize = QtCore.Signal(bool)
-    sigSaveScan = QtCore.Signal(object, object)
+    sigSaveScan = QtCore.Signal(object, object, str)
     sigSaveFinished = QtCore.Signal()
     sigShowSaveDialog = QtCore.Signal(bool)
 
@@ -548,7 +548,13 @@ class ScannerGui(GuiBase):
                     cbar_range = self.scan_2d_dockwidgets[ax].scan_widget.image_widget.levels
                 except KeyError:
                     cbar_range = None
-                self.sigSaveScan.emit(ax, cbar_range)
+                if ax in self.scan_1d_dockwidgets:
+                    tag = self.scan_1d_dockwidgets[ax].scan_widget.save_nametag_lineedit.text()
+                elif ax in self.scan_2d_dockwidgets:
+                    tag = self.scan_2d_dockwidgets[ax].scan_widget.save_nametag_lineedit.text()
+                else:
+                    tag = None
+                self.sigSaveScan.emit(ax, cbar_range, tag)
         finally:
             pass
 

--- a/src/qudi/logic/scanning_data_logic.py
+++ b/src/qudi/logic/scanning_data_logic.py
@@ -287,7 +287,7 @@ class ScanningDataLogic(LogicBase):
                         arrowprops={'facecolor': '#17becf', 'shrink': 0.05})
         return fig
 
-    def save_scan(self, scan_data, color_range=None):
+    def save_scan(self, scan_data, color_range=None, custom_tag=None):
         with self._thread_lock:
             if self.module_state() != 'idle':
                 self.log.error('Unable to save 2D scan. Saving still in progress...')
@@ -335,7 +335,10 @@ class ScanningDataLogic(LogicBase):
                 for channel, data in scan_data.data.items():
                     # data
                     # nametag = '{0}_{1}{2}_image_scan'.format(channel, *scan_data.scan_axes)
-                    tag = self.create_tag_from_scan_data(scan_data, channel)
+                    if custom_tag:
+                        tag = custom_tag
+                    else:
+                        tag = self.create_tag_from_scan_data(scan_data, channel)
                     file_path, _, _ = ds.save_data(data,
                                                    metadata=parameters,
                                                    nametag=tag,
@@ -356,10 +359,10 @@ class ScanningDataLogic(LogicBase):
                 self.sigSaveStateChanged.emit(False)
             return
 
-    def save_scan_by_axis(self, scan_axes=None, color_range=None):
+    def save_scan_by_axis(self, scan_axes=None, color_range=None, custom_tag=None):
         # wrapper for self.save_scan. Avoids copying scan_data through QtSignals
         scan = self.get_current_scan_data(scan_axes=scan_axes)
-        self.save_scan(scan, color_range=color_range)
+        self.save_scan(scan, color_range=color_range, custom_tag=custom_tag)
 
     def create_tag_from_scan_data(self, scan_data, channel):
         axes = scan_data.scan_axes

--- a/src/qudi/logic/scanning_data_logic.py
+++ b/src/qudi/logic/scanning_data_logic.py
@@ -293,12 +293,13 @@ class ScanningDataLogic(LogicBase):
                 self.log.error('Unable to save 2D scan. Saving still in progress...')
                 return
 
-            if scan_data is None:
-                raise ValueError('Unable to save 2D scan. No data available.')
-
             self.sigSaveStateChanged.emit(True)
             self.module_state.lock()
             try:
+                if scan_data is None:
+                    self.log.error('Unable to save 2D scan. No data available.')
+                    raise ValueError('Unable to save 2D scan. No data available.')
+
                 ds = TextDataStorage(root_dir=self.module_default_data_dir)
                 timestamp = datetime.datetime.now()
 


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
Added a UI element in the scanner GUI for the user to specify a custom save file name for saved scans. Note that this is only appended to the default nametag that is generated which contains the timestamp.

## Motivation and Context
Some users do multiple confocal scans and it is difficult to keep track of the scans since they are only saved with timestamps in the file name.

## How Has This Been Tested?
Tested on Ubuntu 22.04.4LTS with dummy modules and on Windows 10 (custom config for experiments) and it works fine in both. Note that the UI changes made here were based on those in the ODMR GUI.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
