### PR TITLE
bugfix on unsaved fit figure in QDPlotter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ Configuration for time series toolchain needs changes as well. See `default.cfg`
 docstrings.
 
 ### Bugfixes
+- Fix failure of saving plots in `QDPlotLogic` when fiting is used.
 - Basic data saving in `TimeSeriesReaderLogic` works now.
 - Fix missing meta info `generation_method_parameters` that occurred for generated sequences with granularity mismatch.
 - Ni Finite Sampling Input module now returns digital input channel values in "clicks/counts" per second and not "clicks/counts" per clock cycle

--- a/src/qudi/logic/qdplot_logic.py
+++ b/src/qudi/logic/qdplot_logic.py
@@ -650,7 +650,7 @@ class QDPlotLogic(LogicBase):
                      ) -> plt.Figure:
         fit_config, fit_results = fit_container.last_fits
         # High-resolution fit data and formatted result string
-        fit_data = [None if result is None else result.high_res_best_fit for result in fit_results]
+        fit_data = [None if result is None else result.high_res_best_fit for result in fit_results.values()]
         fit_result_str = fit_container.formatted_result(fit_results)
         if not fit_data:
             fit_data = [None] * len(data_set)


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
The plot in qdplot was not saved when fitting was used 

This was caused by improper handling of fit_results.
In qdplot_logic.py, _last_fit_results is defined under QDPlotFitContainer as a dictionary.
When _plot_figure of QDPlotLogic is called for saving, this fir_results is used to retrieve the result.high_res_best_fit. 
Since the instance of ModelResult from lmfit is stored in the values of that dictionary, values() should be used.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Firstly, data is set by set_data method. After fitting with a function on gui, save_data method was called.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
