### PR TITLE
Fixed counting_length when in gated mode for T1 sequencing predefined method

### DIFF
--- a/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -1081,6 +1081,9 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         # Trigger the calculation of parameters in the PulseSequence instance
         t1_sequence.refresh_parameters()
 
+        if self.gate_channel:
+            count_length = self._get_ensemble_count_length(ensemble=readout_ensemble,
+                                                           created_blocks=created_blocks)
         # add metadata to invoke settings later on
         t1_sequence.measurement_information['alternating'] = False
         t1_sequence.measurement_information['laser_ignore_list'] = list()


### PR DESCRIPTION
## Description
Fixes the `counting_length` of the `measurement_information` dict when using a gated fastcounter and the `t1_sequencing `predefined method to be the length of one readout.

## Motivation and Context
The `count_length` is previously calculated inside the sequence step generation loop. This just sums up all `PulseBlockEnsemble` lengths yielding a `count_length` equal to the length of the entire pulse sequence. For gated mode a `count_length` of only one readout is required to configure the fastcounter.

## How Has This Been Tested?
On a confocal setup with a FastComtec MCS6A fastcounter.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
