### PR TITLE
fix checker for optimizer plot dimensions

### DIFF
--- a/src/qudi/gui/scanning/scannergui.py
+++ b/src/qudi/gui/scanning/scannergui.py
@@ -123,7 +123,7 @@ class ScannerGui(GuiBase):
     _optimizer_plot_dims: List[int] = ConfigOption(
         name='optimizer_plot_dimensions',
         default=[2, 1],
-        checker=lambda x: set(x) == {1, 2},  # only 1D and 2D optimizations are supported
+        checker=lambda x: set(x).issubset({1, 2}),  # only 1D and 2D optimizations are supported
     )
     # minimum crosshair size as fraction of the displayed scan range
     _min_crosshair_size_fraction = ConfigOption(name='min_crosshair_size_fraction', default=1/50, missing='nothing')


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
fix a bug in the checker of the `optimizer_plot_dims` config option of the scanner gui: allow for only 2D optimization (no 1D optimization)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed this bug while setting up confocal for a system with only X and Y control, and only manual/external Z control. Setting the config option to `[2, 2]` did not work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested on an NI card system, but should be possible to test with scanner dummy as well

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
