### PR TITLE
Qdplot GUI fit fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 - Fixed psu-dependent bugs for laser_quantum_laser
 - Laser logic does not automatically start query loop, gui will still start it on startup
 - Fixed `t1_sequencing` predefined method's `counting_length` for gated mode
+- `QDPlotterGui` will continue to show fit results if new plot was added
 
 ### New Features
 - New `qudi.interface.scanning_probe_interface.ScanSettings` dataclass added.

--- a/src/qudi/gui/qdplot/plot_widget.py
+++ b/src/qudi/gui/qdplot/plot_widget.py
@@ -91,7 +91,7 @@ class QDPlotWidget(QtWidgets.QWidget):
 
     SelectionMode = InteractiveCurvesWidget.SelectionMode
 
-    def __init__(self, *args, fit_container=None, **kwargs) -> None:
+    def __init__(self, *args, fit_container=None, show_fit: bool = True, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         layout = QtWidgets.QGridLayout()
@@ -111,6 +111,8 @@ class QDPlotWidget(QtWidgets.QWidget):
         layout.addWidget(self.fit_widget, row, 1)
         row += 1
         layout.setColumnStretch(0, 1)
+
+        self._show_fit = show_fit
 
         self.fit_widget.hide()
 
@@ -156,7 +158,7 @@ class QDPlotWidget(QtWidgets.QWidget):
         self.plot_fit = self.curve_widget.plot_fit
 
         self.toggle_selector(True)
-        self.toggle_fit(True)
+        self.toggle_fit(self._show_fit)
         self.toggle_editor(True)
         self.toggle_cursor_tracking(True)
 
@@ -248,8 +250,13 @@ class QDPlotWidget(QtWidgets.QWidget):
     def sigPlotParametersChanged(self) -> QtCore.Signal:
         return self.curve_widget.sigPlotParametersChanged
 
+    @property
+    def show_fit(self) -> bool:
+        return self._show_fit
+
     def toggle_fit(self, show: bool) -> None:
         self.control_widget.show_fit_checkbox.setChecked(show)
+        self._show_fit = show
 
     def toggle_editor(self, show: bool) -> None:
         self.control_widget.show_editor_checkbox.setChecked(show)
@@ -278,10 +285,10 @@ class QDPlotDockWidget(AdvancedDockWidget):
     """
     """
 
-    def __init__(self, *args, plot_number=0, fit_container=None, **kwargs):
+    def __init__(self, *args, plot_number=0, fit_container=None, show_fit: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self.setWindowTitle(f'Plot {plot_number:d}')
         self.setFeatures(self.DockWidgetFloatable | self.DockWidgetMovable)
-        widget = QDPlotWidget(fit_container=fit_container)
+        widget = QDPlotWidget(fit_container=fit_container, show_fit=show_fit)
         self.setWidget(widget)
 

--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -249,7 +249,7 @@ class QDPlotterGui(GuiBase):
         self._mw.setDockNestingEnabled(True)
         for ii, dockwidget in enumerate(self._plot_dockwidgets):
             widget = dockwidget.widget()
-            widget.toggle_fit(False)
+            widget.toggle_fit(widget.show_fit)
             widget.toggle_editor(False)
             dockwidget.show()
             dockwidget.setFloating(False)
@@ -264,7 +264,7 @@ class QDPlotterGui(GuiBase):
         self._mw.setDockNestingEnabled(True)
         for ii, dockwidget in enumerate(self._plot_dockwidgets):
             widget = dockwidget.widget()
-            widget.toggle_fit(False)
+            widget.toggle_fit(widget.show_fit)
             widget.toggle_editor(False)
             dockwidget.show()
             dockwidget.setFloating(False)
@@ -294,7 +294,7 @@ class QDPlotterGui(GuiBase):
         self._mw.setDockNestingEnabled(True)
         for ii, dockwidget in enumerate(self._plot_dockwidgets):
             widget = dockwidget.widget()
-            widget.toggle_fit(False)
+            widget.toggle_fit(widget.show_fit)
             widget.toggle_editor(False)
             dockwidget.show()
             dockwidget.setFloating(False)
@@ -382,7 +382,8 @@ class QDPlotterGui(GuiBase):
     def _plot_added(self) -> None:
         index = len(self._plot_dockwidgets)
         dockwidget = QDPlotDockWidget(fit_container=self._qdplot_logic().get_fit_container(index),
-                                      plot_number=index + 1)
+                                      plot_number=index + 1,
+                                      show_fit=False)
         self._plot_dockwidgets.append(dockwidget)
         self._color_cyclers.append(cycle(self._pen_color_list))
 

--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -302,7 +302,7 @@ class QDPlotterGui(GuiBase):
             if ii > 0:
                 self._mw.tabifyDockWidget(self._plot_dockwidgets[0], dockwidget)
         try:
-            self._plot_dockwidgets[0].raise_()
+            self._plot_dockwidgets[-1].raise_()
         except IndexError:
             pass
 

--- a/src/qudi/gui/qdplot/qdplot_gui.py
+++ b/src/qudi/gui/qdplot/qdplot_gui.py
@@ -302,7 +302,7 @@ class QDPlotterGui(GuiBase):
             if ii > 0:
                 self._mw.tabifyDockWidget(self._plot_dockwidgets[0], dockwidget)
         try:
-            self._plot_dockwidgets[-1].raise_()
+            self._plot_dockwidgets[0].raise_()
         except IndexError:
             pass
 


### PR DESCRIPTION
## Description
When adding a new plot, existing plots will no longer close their Fit widget, displaying the fit results, when in tabbed mode. The feature is respecting the display state of each plot before the new plot was added, if a user hid the result manually it will not be shown after the addition of the new plot.

## Motivation and Context
Whenever a new plot is added, the `restore_view` function is called. This function will reset the state of showing fits on all plots to an initial `False` state. This can be annoying when adding new plots and comparing them with each other, if suddenly the fit results disappear.

## How Has This Been Tested?
Confocal setup and dummy modules.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
