### PR TITLE
Hotfix for issue in #170

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 - Fixed `t1_sequencing` predefined method's `counting_length` for gated mode
 - `QDPlotterGui` will continue to show fit results if new plot was added
 - Added `PulseSequence.generation_method_parameters` variable to correctly save `generation_method_parameters` of a `PulseSequence` and save these parameters in the output file
+- Fixed `ScanningOptimizeLogic` crashing on first start when using scanner with less than the default 3 axes configured
 
 ### New Features
 - New `qudi.interface.scanning_probe_interface.ScanSettings` dataclass added.

--- a/src/qudi/gui/scanning/scannergui.py
+++ b/src/qudi/gui/scanning/scannergui.py
@@ -541,7 +541,11 @@ class ScannerGui(GuiBase):
         tilt_settings = self._scanning_logic().tilt_correction_settings
 
         self.tilt_corr_support_vector_updated(tilt_settings)
-        self.apply_tilt_corr_support_vectors()
+        try:
+            self.apply_tilt_corr_support_vectors()
+        except ValueError:
+            self.log.warning("Couldn't restore tilt correction settings.")
+            pass
 
     @QtCore.Slot(tuple)
     def save_scan_data(self, scan_axes: Union[None, Tuple[str], Tuple[str, str]]):

--- a/src/qudi/logic/scanning_optimize_logic.py
+++ b/src/qudi/logic/scanning_optimize_logic.py
@@ -448,27 +448,22 @@ class ScanningOptimizeLogic(LogicBase):
         self._back_scan_frequency = {}
 
     def _set_default_scan_sequence(self):
-        if (
-            self._optimizer_sequence_dimensions
-            not in self.allowed_optimizer_sequence_dimensions
-        ):
+
+        if self._optimizer_sequence_dimensions not in self.allowed_optimizer_sequence_dimensions:
             fallback_dimension = self.allowed_optimizer_sequence_dimensions[0]
-            self.log.info(
-                f"Selected optimization dimensions ({self._optimizer_sequence_dimensions}) are not in the allowed optimizer dimensions ({self.allowed_optimizer_sequence_dimensions}), choosing fallback dimension {fallback_dimension}. "
-            )
+            self.log.info(f"Selected optimization dimensions ({self._optimizer_sequence_dimensions}) "
+                          f"are not in the allowed optimizer dimensions ({self.allowed_optimizer_sequence_dimensions}),"
+                          f" choosing fallback dimension {fallback_dimension}. ")
             self._optimizer_sequence_dimensions = fallback_dimension
 
-        possible_scan_sequences = self._allowed_sequences(
-            self._optimizer_sequence_dimensions
-        )
-        if (
-            self._scan_sequence is None
-            or self._scan_sequence not in possible_scan_sequences
-        ):
+        possible_scan_sequences = self._allowed_sequences(self._optimizer_sequence_dimensions)
+
+        if self._scan_sequence is None or self._scan_sequence not in possible_scan_sequences:
+
             fallback_scan_sequence = possible_scan_sequences[0]
-            self.log.info(
-                f"No valid scan sequence existing ({self._scan_sequence=}), setting scan sequence to {fallback_scan_sequence}."
-            )
+            self.log.info(f"No valid scan sequence existing ({self._scan_sequence=}),"
+                          f" setting scan sequence to {fallback_scan_sequence}.")
+
             self._scan_sequence = fallback_scan_sequence
 
     @_optimizer_sequence_dimensions.constructor

--- a/src/qudi/logic/scanning_optimize_logic.py
+++ b/src/qudi/logic/scanning_optimize_logic.py
@@ -448,12 +448,28 @@ class ScanningOptimizeLogic(LogicBase):
         self._back_scan_frequency = {}
 
     def _set_default_scan_sequence(self):
-        possible_scan_sequences = self._allowed_sequences(self._optimizer_sequence_dimensions)
-        if self._scan_sequence is None or self._scan_sequence not in possible_scan_sequences:
+        if (
+            self._optimizer_sequence_dimensions
+            not in self.allowed_optimizer_sequence_dimensions
+        ):
+            fallback_dimension = self.allowed_optimizer_sequence_dimensions[0]
             self.log.info(
-                f"No valid scan sequence existing ({self._scan_sequence=}), setting scan sequence to {possible_scan_sequences[0]}."
+                f"Selected optimization dimensions ({self._optimizer_sequence_dimensions}) are not in the allowed optimizer dimensions ({self.allowed_optimizer_sequence_dimensions}), choosing fallback dimension {fallback_dimension}. "
             )
-            self._scan_sequence = possible_scan_sequences[0]
+            self._optimizer_sequence_dimensions = fallback_dimension
+
+        possible_scan_sequences = self._allowed_sequences(
+            self._optimizer_sequence_dimensions
+        )
+        if (
+            self._scan_sequence is None
+            or self._scan_sequence not in possible_scan_sequences
+        ):
+            fallback_scan_sequence = possible_scan_sequences[0]
+            self.log.info(
+                f"No valid scan sequence existing ({self._scan_sequence=}), setting scan sequence to {fallback_scan_sequence}."
+            )
+            self._scan_sequence = fallback_scan_sequence
 
     @_optimizer_sequence_dimensions.constructor
     def sequence_dimension_constructor(self, dimensions: Union[list, tuple]) -> tuple:

--- a/src/qudi/logic/scanning_optimize_logic.py
+++ b/src/qudi/logic/scanning_optimize_logic.py
@@ -26,6 +26,7 @@ import numpy as np
 from PySide2 import QtCore
 import copy as cp
 from typing import Dict, Tuple, List, Optional, Union
+import itertools
 
 from qudi.core.module import LogicBase
 from qudi.interface.scanning_probe_interface import ScanData, BackScanCapability
@@ -35,7 +36,6 @@ from qudi.core.connector import Connector
 from qudi.core.statusvariable import StatusVar
 from qudi.util.fit_models.gaussian import Gaussian2D, Gaussian
 from qudi.core.configoption import ConfigOption
-import itertools
 
 
 class ScanningOptimizeLogic(LogicBase):
@@ -425,6 +425,14 @@ class ScanningOptimizeLogic(LogicBase):
     def _check_scan_settings(self):
         """Basic check of scan settings for all axes."""
         scan_logic: ScanningProbeLogic = self._scan_logic()
+
+        for stg in [self.scan_range, self.scan_resolution, self.scan_frequency]:
+            axs = stg.keys()
+            for ax in axs:
+                if ax not in scan_logic.scanner_axes.keys():
+                    self.log.debug(f"Axis {ax} from optimizer scan settings not available on scanner" )
+                    raise ValueError
+
         capability = scan_logic.back_scan_capability
         if self._back_scan_resolution and (BackScanCapability.RESOLUTION_CONFIGURABLE not in capability):
             raise AssertionError('Back scan resolution cannot be configured for this scanner hardware.')

--- a/src/qudi/logic/scanning_probe_logic.py
+++ b/src/qudi/logic/scanning_probe_logic.py
@@ -243,6 +243,13 @@ class ScanningProbeLogic(LogicBase):
 
     def check_scan_settings(self):
         """Validate current scan settings for all possible 1D and 2D scans."""
+        for stg in [self.scan_ranges, self.scan_resolution, self.scan_frequency]:
+            axs = stg.keys()
+            for ax in axs:
+                if ax not in self.scanner_axes.keys():
+                    self.log.debug(f"Axis {ax} from scan settings not available on scanner" )
+                    raise ValueError
+
         for dim in [1, 2]:
             for axes in combinations(self.scanner_axes, dim):
                 settings = self.create_scan_settings(axes)


### PR DESCRIPTION
## Description
Fixes the initialization error occuring when configuring scanner with less than 3 axes as described in #170 .

## Motivation and Context
A bug caused in `_set_default_scan_sequence` to always raise the `NotImplementedError` in `_allowed_sequences` if the default `_optimizer_sequence_dimensions` were used with scanners that have less than 3 axes configured.

## How Has This Been Tested?
Dummy session having only x and y axis configured.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
