### PR TITLE
Adding missing waiting element to `t1_sequencing` predefined method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@
 - Fixed `ScanningOptimizeLogic` crashing on first start when using scanner with less than the default 3 axes configured
 - Fixed Keysight M8195A AWG sequence mode
 - Fixed setting of digital channel amplitude of Keysight M819X AWG
+- added `waiting_element` to `generate_t1_sequencing` method
 
 ### New Features
 - New `qudi.interface.scanning_probe_interface.ScanSettings` dataclass added.

--- a/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -1020,10 +1020,12 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         # Get necessary PulseBlockElements
         laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
         delay_element = self._get_delay_gate_element()
+        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
         # Create PulseBlock and append PulseBlockElements
         readout_block = PulseBlock(name='{0}_readout'.format(name))
         readout_block.append(laser_element)
         readout_block.append(delay_element)
+        readout_block.append(waiting_element)
         created_blocks.append(readout_block)
         # Create PulseBlockEnsemble and append block to it
         readout_ensemble = PulseBlockEnsemble(name='{0}_readout'.format(name), rotating_frame=False)
@@ -1038,6 +1040,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             sync_readout_block = PulseBlock(name='{0}_readout_sync'.format(name))
             sync_readout_block.append(laser_element)
             sync_readout_block.append(delay_element)
+            sync_readout_block.append(waiting_element)
             sync_readout_block.append(sync_element)
             created_blocks.append(sync_readout_block)
             # Create PulseBlockEnsemble and append block to it


### PR DESCRIPTION
## Description
When testing for #180, I discovered that `generate_t1_sequencing` is missing the `waiting_element` most of our pulse sequences have after the `laser_element` and `delay_element`.
In my particular case this caused the laser pulse to reach over into the next sweep, if only one datapoint is acquired.

<img width="1123" alt="t1_sequencing_missing_waiting_time" src="https://github.com/user-attachments/assets/7f5066a4-8c7d-4ce7-8d13-0591fbc4e1a6" />

With the fix it works as expected.

<img width="1119" alt="t1_sequencing_fixed_waiting_time" src="https://github.com/user-attachments/assets/769181ca-059c-495b-8dbd-806f85b083a3" />

Probably, this stems from a badly calibrated laser delay or laser safety, so could be fixed by changing these values as well. However, I thought with this fix one could bring this pulse sequence in line with the others, adding the `waiting_element`.


## How Has This Been Tested?
Same confocal setup #180 was tested with.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
