### PR TITLE
fix typos and add documentation on testing of `test.pypi.org`  release

### DIFF
--- a/docs/repo_management/release_workflow.md
+++ b/docs/repo_management/release_workflow.md
@@ -42,7 +42,7 @@ unspecified in qudi-iqo-modules `setup.py`. This is most likely the case for the
    To this end, create a new Python environment and activate it.
    Install qudi-core via
          
-         python -m install qudi-core 
+         python -m pip install qudi-core 
    
    and install qudi-iqo-modules via
 
@@ -64,14 +64,23 @@ unspecified in qudi-iqo-modules `setup.py`. This is most likely the case for the
 
 8. Increment version number in `qudi-iqo-modules/VERSIONS`.
    This will already trigger a release from the main branch to test.pypi.
+
+9. Test whether the `test.pypi.org` release worked by installing it. For this:
+   - Create new python environment and activate it
+   - pip install the `test.pypi.org` release into it (replace all `X` with the correct version number)
+     
+           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ qudi-iqo-modules==<X.X.X.devX>
+
+   - Note: Using the `pip install` command provided on `test.pypi.org`'s release page does not work
+   - Quickly test running qudi with dummy modules
    
-9. Execute the release by navigating in github to qudi-iqo-modules. On the right bar you can 'create a new release' in 
+11. Execute the release by navigating in github to qudi-iqo-modules. On the right bar you can 'create a new release' in 
    the Releases section.
    By convention we tag releases by a string like 'Release v0.1.0'.
    As the description text, you can copy the respective release section from `qudi-iqo-modules/docs/changelog.md`.
-   Don't add a heading like "Relaase v0.1.0", this is automatically created by github.   
+   Don't add a heading like "Release v0.1.0", this is automatically created by github.   
 
-10. Change the requirement equalities (`==`) (branch `main`) in`qudi-iqo-modules/setup.py` back to `>=`.
-11. Iterate the version number in `qudi-iqo-modules/VERSIONS` from release to development. Eg. 1.0.0 to 1.0.1.dev0
+12. Change the requirement equalities (`==`) (branch `main`) in`qudi-iqo-modules/setup.py` back to `>=`.
+13. Iterate the version number in `qudi-iqo-modules/VERSIONS` from release to development. Eg. 1.0.0 to 1.0.1.dev0
 
-12. Lean back and get some cold drink. You just released a new qudi-iqo-modules version! 
+14. Lean back and get some cold drink. You just released a new qudi-iqo-modules version! 


### PR DESCRIPTION
## Description
fix typos and add documentation on testing of `test.pypi.org` release

## Motivation and Context
When testing the current `test.pypi.org` release, using the command provided on the release page does not work.
We added this info in the docs.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [ ] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
