### PR TITLE
set pytest-qt to a supported version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ Changelog = "https://github.com/Ulm-IQO/qudi-iqo-modules/blob/main/docs/changelo
 version = {file = "VERSION"}
 
 [project.optional-dependencies]
-dev-test = ["pytest", "pytest-qt", "coverage"]
+dev-test = ["pytest", "pytest-qt==4.4.0", "coverage"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Fixing version for pytest-qt

## Description
A dependency for the testing framework is pytest-qt. The latest version of this package doesn't support PySide2 anymore. This PR fixes the version to 4.4.0, which still supports PySide2

## Motivation and Context
Pytest-qt offers some fixtures that allow testing qt components more effectively




## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
