### PR TITLE
Running the testing framework with a local module server instead of a remote rpyc server.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,10 @@ If not, see <https://www.gnu.org/licenses/>.
 import os
 import time
 import pytest
-import multiprocessing
-import rpyc
+import sys
+import time
+import subprocess
 from PySide2 import QtWidgets
-from PySide2.QtCore import QTimer
 from qudi.core import application
 from qudi.util.yaml import yaml_load
 
@@ -99,89 +99,42 @@ def hardware_modules(config):
     modules = list(config[base].keys())
     return modules
 
-CONFIG = os.path.join(os.getcwd(),'tests/test.cfg')
 
-
-def run_qudi(timeout=150000):
+@pytest.fixture(scope="module")
+def qudi_gui():
+    """Start the Qudi GUI in a child process with the given config.
     """
-    Runs a Qudi instance with a timer.
-
-    Parameters
-    ----------
-    timeout : int, optional
-        timeout for the Qudi session in milliseconds, by default 150000.
-    """
-    app_cls = QtWidgets.QApplication
-    app = app_cls.instance()
-    if app is None:
-        app = app_cls()
-    qudi_instance = application.Qudi.instance()
-    if qudi_instance is None:
-        qudi_instance = application.Qudi(config_file=CONFIG)
-    QTimer.singleShot(timeout, qudi_instance.quit)
-    qudi_instance.run()
-
-
-@pytest.fixture(scope='module')
-def start_qudi_process():
-    """
-    Fixture that starts the Qudi process and ensures it's running before returning.
-    """
-    qudi_process = multiprocessing.Process(target=run_qudi)
-    qudi_process.start()
-    time.sleep(10)
-    yield
-    qudi_process.join(timeout=10)
-    if qudi_process.is_alive():
-        qudi_process.terminate()
-
-def connect_with_retries(host, port, config, retries=5, delay=2):
-    """
-    Attempt to connect multiple times to the RPyC server.
-
-    Parameters
-    ----------
-    host    : str 
-        The server's hostname or IP address.
-    port    : int 
-        The port number to connect to.
-    retries : int 
-        Number of retries before giving up.
-    delay   : int or float
-        Delay in seconds between attempts.
-
-    Returns
-    -------
-    conn (rpyc.Connection)
-        The RPyC connection if successful.
-
-    Raises:
-        Exception: If all attempts fail.
-    """
-    attempt = 0
-    while attempt < retries:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "qudi.core", "--config", str(CONFIG)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    time.sleep(3)
+    try:
+        yield proc
+    finally:
         try:
-            print(f"Attempt {attempt + 1} of {retries}...")
-            conn = rpyc.connect(host, port, config=config)
-            print("Connection successful!")
-            return conn  # Return the connection object if successful
-        except Exception as e:
-            print(f"Connection attempt {attempt + 1} failed: {e}")
-            attempt += 1
-            if attempt < retries:
-                print(f"Retrying in {delay} seconds...")
-                time.sleep(delay)
-            else:
-                print("All connection attempts failed.")
-                raise  # Re-raise the last exception after final attempt
+            proc.terminate()
+            proc.wait(timeout=8)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
-@pytest.fixture(scope='module')
-def remote_instance(start_qudi_process):
-    """
-    Fixture that connects to the running Qudi ipython kernel through rpyc client and returns the client instance.
-    """
-    time.sleep(5)
-    conn = connect_with_retries(host="localhost", port=18861, config={'sync_request_timeout': 20})
-    root = conn.root
-    qudi_instance = root._qudi
-    return qudi_instance
+@pytest.fixture(scope="module")
+def qudi_client(qudi_gui):
+    """Attach to the running GUI using qudikernel.QudiKernelClient."""
+    from qudi.core.qudikernel import QudiKernelClient
+    client = QudiKernelClient()
+    timeout = time.time() + 60
+    last_err = None
+    while time.time() < timeout:
+        try:
+            client.connect()   
+            ns = client.get_active_modules()
+            qudi = ns.get('qudi')
+            return qudi
+        except Exception as e:
+            last_err = e
+            time.sleep(0.5)
+    raise RuntimeError(f"Could not connect to Qudi namespace server: {last_err}")

--- a/tests/test_OdmrLogic.py
+++ b/tests/test_OdmrLogic.py
@@ -108,16 +108,16 @@ def get_tolerance(value, bound):
 
 
 @pytest.fixture(scope='module')
-def module(remote_instance):
+def module(qudi_client):
     """
     Fixture that returns ODMR logic instance.
 
     Parameters
     ----------
-    remote_instance : fixture
-        Remote qudi instance
+    qudi_client : fixture
+        qudi instance
     """
-    module_manager = remote_instance.module_manager
+    module_manager = qudi_client.module_manager
     odmr_gui = 'odmr_gui'
     odmr_logic = 'odmr_logic'
     module_manager.activate_module(odmr_gui)

--- a/tests/test_modify_status_var_example.py
+++ b/tests/test_modify_status_var_example.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This test shows how a single status variable can be updated via file and tested through a remote connection
+This test shows how a single status variable can be updated via file and tested 
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-core/>
@@ -31,11 +31,11 @@ VALUE = 10
 
 
 @pytest.fixture(scope='module')
-def logic_instance(remote_instance):
+def logic_instance(qudi_client):
     """ 
     This fixture returns Odmr logic instance
     """
-    module_manager = remote_instance.module_manager
+    module_manager = qudi_client.module_manager
     module_manager.activate_module(GUI_MODULE)
     logic_instance = module_manager._modules[LOGIC_MODULE].instance
     return logic_instance

--- a/tests/test_modify_status_var_file.py
+++ b/tests/test_modify_status_var_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This test modifies all status variables via file and then runs all the modules through a remote connection
+This test modifies all status variables via file and then runs all the modules 
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-core/>
@@ -30,11 +30,11 @@ from qudi.util.paths import get_module_app_data_path
 
 
 @pytest.fixture
-def module_manager(remote_instance):
+def module_manager(qudi_client):
     """ 
-    Fixture for module manager of qudi remote instance 
+    Fixture for module manager of qudi instance 
     """
-    return remote_instance.module_manager
+    return qudi_client.module_manager
 
 def generate_random_value(var):
     """

--- a/tests/test_modify_status_var_instance.py
+++ b/tests/test_modify_status_var_instance.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This test modifies all status variables as instance variables and then runs all the modules through a remote connection
+This test modifies all status variables as instance variables and then runs all the modules
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-core/>
@@ -72,14 +72,14 @@ def generate_random_value(var):
     
 '''
 #This test also fails for some modules 
-def test_status_vars(remote_instance, logic_modules, gui_modules, hardware_modules):
+def test_status_vars(qudi_client, logic_modules, gui_modules, hardware_modules):
     """
     Test to check if qudi modules launch correctly after modifying status variable as instance variables
 
     Parameters
     ----------
-    remote_instance : fixture
-        Running remote qudi instance
+    qudi_client : fixture
+        Running  qudi instance
     logic_modules : fixture
         List of loaded logic modules
     gui_modules : fixture
@@ -87,7 +87,7 @@ def test_status_vars(remote_instance, logic_modules, gui_modules, hardware_modul
     hardware_modules : fixture
         List of loaded hardware modules
     """    
-    module_manager = remote_instance.module_manager
+    module_manager = qudi_client.module_manager
     for gui_module in gui_modules:
         module_manager.activate_module(gui_module)
         gui_managed_module = module_manager.modules[gui_module]

--- a/tests/test_reset_status_var.py
+++ b/tests/test_reset_status_var.py
@@ -22,7 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 import time
 
 
-def test_reset_module(gui_modules, hardware_modules, remote_instance):
+def test_reset_module(gui_modules, hardware_modules, qudi_client):
     """
     This tests clearing all the logic, hardware module status variables and reloads the GUI modules
 
@@ -32,10 +32,10 @@ def test_reset_module(gui_modules, hardware_modules, remote_instance):
         List of gui module names
     hardware_modules : Fixture
         List of hardware module names
-    remote_instance : Fixture
-        Remote qudi rpyc instance
+    qudi_client : Fixture
+        qudi instance
     """    
-    module_manager = remote_instance.module_manager
+    module_manager = qudi_client.module_manager
     modules = module_manager.modules
     for module in modules:
         module_manager.deactivate_module(module)

--- a/tests/test_reset_status_var_gui.py
+++ b/tests/test_reset_status_var_gui.py
@@ -23,7 +23,7 @@ import time
 
 '''
 #This test fails for some modules such as ODMR  PulsedGUI
-def test_reset_module(gui_modules, hardware_modules, remote_instance):
+def test_reset_module(gui_modules, hardware_modules, qudi_client):
     """
     This tests clearing all the logic module status variables and reloads the GUI modules
 
@@ -33,10 +33,10 @@ def test_reset_module(gui_modules, hardware_modules, remote_instance):
         List of gui module names
     hardware_modules : Fixture
         List of hardware module names
-    remote_instance : Fixture
-        Remote qudi rpyc instance
+    qudi_client : Fixture
+        qudi instance
     """    
-    module_manager = remote_instance.module_manager
+    module_manager = qudi_client.module_manager
     modules = module_manager.modules
     for module in modules:
         module_manager.deactivate_module(module)


### PR DESCRIPTION
## Description
This PR enables the testing framework to use QudiKernelClient with a subprocess for server-client connection. 

## Motivation and Context
The testing framework needs a Qudi server and client for accessing the modules. This is currently done with a custom remote server and client. An easier way to establish a client and server connection is through the QudiKernelClient, which is already present in Qudi Core. 

## How Has This Been Tested?
All the tests run normally as before.


## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
