### PR TITLE
Fixed Inheritance of Sampling Function Params

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,9 +11,10 @@
 - Fixed code suggestions for `Connector` objects
 - Fixed Keysight AWG's from breaking when setting the external reference clock through the configuration file
 - Fixed ``laser_logic`` to work with remote laser hardware
-- Fixed typo in ``MicrowaveAnritsu.on_activate`` preventing the module from activating  
+- Fixed typo in ``MicrowaveAnritsu.on_activate`` preventing the module from activating
 - Fixed `KeysightM8195A` not loading `PulseBlock`s in the pulsed main GUI
 - Fixed counting length for the `t1_sequencing` predefined generate method for a gated counter
+- Fixed sampling functions inheritance of parameters
 
 ### New Features
 - changed to a better valid `PredefinedGenerator` class discovery method for the pulsed tool chain

--- a/src/qudi/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
@@ -28,8 +28,8 @@ class Idle(SamplingBase):
     """
     Object representing an idle element (zero voltage)
     """
-    def __init__(self):
-        pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_samples(time_array):
@@ -44,7 +44,9 @@ class DC(SamplingBase):
     params = dict()
     params['voltage'] = {'unit': 'V', 'init': 0.0, 'min': -np.inf, 'max': +np.inf, 'type': float}
 
-    def __init__(self, voltage=None):
+    def __init__(self, voltage=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(DC.params)
         if voltage is None:
             self.voltage = self.params['voltage']['init']
         else:
@@ -70,7 +72,9 @@ class Sin(SamplingBase):
     params['frequency'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
     params['phase'] = {'unit': '°', 'init': 0.0, 'min': -np.inf, 'max': np.inf, 'type': float}
 
-    def __init__(self, amplitude=None, frequency=None, phase=None):
+    def __init__(self, amplitude=None, frequency=None, phase=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(Sin.params)
         if amplitude is None:
             self.amplitude = self.params['amplitude']['init']
         else:
@@ -110,7 +114,9 @@ class DoubleSinSum(SamplingBase):
 
     def __init__(self,
                  amplitude_1=None, frequency_1=None, phase_1=None,
-                 amplitude_2=None, frequency_2=None, phase_2=None):
+                 amplitude_2=None, frequency_2=None, phase_2=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(DoubleSinSum.params)
         if amplitude_1 is None:
             self.amplitude_1 = self.params['amplitude_1']['init']
         else:
@@ -168,7 +174,9 @@ class DoubleSinProduct(SamplingBase):
 
     def __init__(self,
                  amplitude_1=None, frequency_1=None, phase_1=None,
-                 amplitude_2=None, frequency_2=None, phase_2=None):
+                 amplitude_2=None, frequency_2=None, phase_2=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(DoubleSinProduct.params)
         if amplitude_1 is None:
             self.amplitude_1 = self.params['amplitude_1']['init']
         else:
@@ -231,7 +239,9 @@ class TripleSinSum(SamplingBase):
     def __init__(self,
                  amplitude_1=None, frequency_1=None, phase_1=None,
                  amplitude_2=None, frequency_2=None, phase_2=None,
-                 amplitude_3=None, frequency_3=None, phase_3=None):
+                 amplitude_3=None, frequency_3=None, phase_3=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(TripleSinSum.params)
         if amplitude_1 is None:
             self.amplitude_1 = self.params['amplitude_1']['init']
         else:
@@ -311,7 +321,9 @@ class TripleSinProduct(SamplingBase):
     def __init__(self,
                  amplitude_1=None, frequency_1=None, phase_1=None,
                  amplitude_2=None, frequency_2=None, phase_2=None,
-                 amplitude_3=None, frequency_3=None, phase_3=None):
+                 amplitude_3=None, frequency_3=None, phase_3=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(TripleSinProduct.params)
         if amplitude_1 is None:
             self.amplitude_1 = self.params['amplitude_1']['init']
         else:
@@ -371,6 +383,272 @@ class TripleSinProduct(SamplingBase):
         samples_arr *= self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
         return samples_arr
 
+class QuintupleSinSum(SamplingBase):
+    """
+    Object representing a linear combination of five sines
+    (Superposition of five sine waves; NOT normalized)
+    """
+    params = dict()
+    params['amplitude_1'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_1'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_1'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_2'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_2'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_2'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_3'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_3'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_3'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_4'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_4'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_4'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_5'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_5'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_5'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+
+    def __init__(self,
+                 amplitude_1=None, frequency_1=None, phase_1=None,
+                 amplitude_2=None, frequency_2=None, phase_2=None,
+                 amplitude_3=None, frequency_3=None, phase_3=None,
+                 amplitude_4=None, frequency_4=None, phase_4=None,
+                 amplitude_5=None, frequency_5=None, phase_5=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(QuintupleSinSum.params)
+        if amplitude_1 is None:
+            self.amplitude_1 = self.params['amplitude_1']['init']
+        else:
+            self.amplitude_1 = amplitude_1
+        if frequency_1 is None:
+            self.frequency_1 = self.params['frequency_1']['init']
+        else:
+            self.frequency_1 = frequency_1
+        if phase_1 is None:
+            self.phase_1 = self.params['phase_1']['init']
+        else:
+            self.phase_1 = phase_1
+
+        if amplitude_2 is None:
+            self.amplitude_2 = self.params['amplitude_2']['init']
+        else:
+            self.amplitude_2 = amplitude_2
+        if frequency_2 is None:
+            self.frequency_2 = self.params['frequency_2']['init']
+        else:
+            self.frequency_2 = frequency_2
+        if phase_2 is None:
+            self.phase_2 = self.params['phase_2']['init']
+        else:
+            self.phase_2 = phase_2
+
+        if amplitude_3 is None:
+            self.amplitude_3 = self.params['amplitude_3']['init']
+        else:
+            self.amplitude_3 = amplitude_3
+        if frequency_3 is None:
+            self.frequency_3 = self.params['frequency_3']['init']
+        else:
+            self.frequency_3 = frequency_3
+        if phase_3 is None:
+            self.phase_3 = self.params['phase_3']['init']
+        else:
+            self.phase_3 = phase_3
+
+        if amplitude_4 is None:
+            self.amplitude_4 = self.params['amplitude_4']['init']
+        else:
+            self.amplitude_4 = amplitude_4
+        if frequency_4 is None:
+            self.frequency_4 = self.params['frequency_4']['init']
+        else:
+            self.frequency_4 = frequency_4
+        if phase_4 is None:
+            self.phase_4 = self.params['phase_4']['init']
+        else:
+            self.phase_4 = phase_4
+
+        if amplitude_5 is None:
+            self.amplitude_5 = self.params['amplitude_5']['init']
+        else:
+            self.amplitude_5 = amplitude_5
+        if frequency_5 is None:
+            self.frequency_5 = self.params['frequency_5']['init']
+        else:
+            self.frequency_5 = frequency_5
+        if phase_5 is None:
+            self.phase_5 = self.params['phase_5']['init']
+        else:
+            self.phase_5 = phase_5
+        return
+
+    @staticmethod
+    def _get_sine(time_array, amplitude, frequency, phase):
+        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
+        return samples_arr
+
+    def get_samples(self, time_array):
+        # First sine wave
+        phase_rad = np.pi * self.phase_1 / 180
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
+
+        # Second sine wave (add on first sine)
+        phase_rad = np.pi * self.phase_2 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
+
+        # Third sine wave (add on sum of first and second)
+        phase_rad = np.pi * self.phase_3 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
+
+        # Fourth sine wave (add on sum of first three)
+        phase_rad = np.pi * self.phase_4 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_4, self.frequency_4, phase_rad)
+
+        # Fifth sine wave (add on sum of first four)
+        phase_rad = np.pi * self.phase_5 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_5, self.frequency_5, phase_rad)
+        return samples_arr
+
+class SextupleSinSum(SamplingBase):
+    """
+    Object representing a linear combination of six sines
+    (Superposition of six sine waves; NOT normalized)
+    """
+    params = dict()
+    params['amplitude_1'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_1'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_1'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_2'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_2'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_2'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_3'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_3'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_3'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_4'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_4'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_4'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_5'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_5'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_5'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+    params['amplitude_6'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['frequency_6'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf, 'type': float}
+    params['phase_6'] = {'unit': '°', 'init': 0.0, 'min': -360, 'max': 360, 'type': float}
+
+    def __init__(self,
+                 amplitude_1=None, frequency_1=None, phase_1=None,
+                 amplitude_2=None, frequency_2=None, phase_2=None,
+                 amplitude_3=None, frequency_3=None, phase_3=None,
+                 amplitude_4=None, frequency_4=None, phase_4=None,
+                 amplitude_5=None, frequency_5=None, phase_5=None,
+                 amplitude_6=None, frequency_6=None, phase_6=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(SextupleSinSum.params)
+        if amplitude_1 is None:
+            self.amplitude_1 = self.params['amplitude_1']['init']
+        else:
+            self.amplitude_1 = amplitude_1
+        if frequency_1 is None:
+            self.frequency_1 = self.params['frequency_1']['init']
+        else:
+            self.frequency_1 = frequency_1
+        if phase_1 is None:
+            self.phase_1 = self.params['phase_1']['init']
+        else:
+            self.phase_1 = phase_1
+
+        if amplitude_2 is None:
+            self.amplitude_2 = self.params['amplitude_2']['init']
+        else:
+            self.amplitude_2 = amplitude_2
+        if frequency_2 is None:
+            self.frequency_2 = self.params['frequency_2']['init']
+        else:
+            self.frequency_2 = frequency_2
+        if phase_2 is None:
+            self.phase_2 = self.params['phase_2']['init']
+        else:
+            self.phase_2 = phase_2
+
+        if amplitude_3 is None:
+            self.amplitude_3 = self.params['amplitude_3']['init']
+        else:
+            self.amplitude_3 = amplitude_3
+        if frequency_3 is None:
+            self.frequency_3 = self.params['frequency_3']['init']
+        else:
+            self.frequency_3 = frequency_3
+        if phase_3 is None:
+            self.phase_3 = self.params['phase_3']['init']
+        else:
+            self.phase_3 = phase_3
+
+        if amplitude_4 is None:
+            self.amplitude_4 = self.params['amplitude_4']['init']
+        else:
+            self.amplitude_4 = amplitude_4
+        if frequency_4 is None:
+            self.frequency_4 = self.params['frequency_4']['init']
+        else:
+            self.frequency_4 = frequency_4
+        if phase_4 is None:
+            self.phase_4 = self.params['phase_4']['init']
+        else:
+            self.phase_4 = phase_4
+
+        if amplitude_5 is None:
+            self.amplitude_5 = self.params['amplitude_5']['init']
+        else:
+            self.amplitude_5 = amplitude_5
+        if frequency_5 is None:
+            self.frequency_5 = self.params['frequency_5']['init']
+        else:
+            self.frequency_5 = frequency_5
+        if phase_5 is None:
+            self.phase_5 = self.params['phase_5']['init']
+        else:
+            self.phase_5 = phase_5
+
+        if amplitude_6 is None:
+            self.amplitude_6 = self.params['amplitude_6']['init']
+        else:
+            self.amplitude_6 = amplitude_6
+        if frequency_6 is None:
+            self.frequency_6 = self.params['frequency_6']['init']
+        else:
+            self.frequency_6 = frequency_6
+        if phase_6 is None:
+            self.phase_6 = self.params['phase_6']['init']
+        else:
+            self.phase_6 = phase_6
+        return
+
+    @staticmethod
+    def _get_sine(time_array, amplitude, frequency, phase):
+        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
+        return samples_arr
+
+    def get_samples(self, time_array):
+        # First sine wave
+        phase_rad = np.pi * self.phase_1 / 180
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
+
+        # Second sine wave (add on first sine)
+        phase_rad = np.pi * self.phase_2 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
+
+        # Third sine wave (add on sum of first and second)
+        phase_rad = np.pi * self.phase_3 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
+
+        # Fourth sine wave (add on sum of first three)
+        phase_rad = np.pi * self.phase_4 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_4, self.frequency_4, phase_rad)
+
+        # Fifth sine wave (add on sum of first four)
+        phase_rad = np.pi * self.phase_5 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_5, self.frequency_5, phase_rad)
+
+        # Sixth sine wave (add on sum of first five)
+        phase_rad = np.pi * self.phase_6 / 180
+        samples_arr += self._get_sine(time_array, self.amplitude_6, self.frequency_6, phase_rad)
+        return samples_arr
 
 class Chirp(SamplingBase):
     """
@@ -385,7 +663,9 @@ class Chirp(SamplingBase):
     params['stop_freq'] = {'unit': 'Hz', 'init': 2.87e9, 'min': 0.0, 'max': np.inf,
                                 'type': float}
 
-    def __init__(self, amplitude=None, phase=None, start_freq=None, stop_freq=None):
+    def __init__(self, amplitude=None, phase=None, start_freq=None, stop_freq=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(Chirp.params)
         if amplitude is None:
             self.amplitude = self.params['amplitude']['init']
         else:
@@ -433,7 +713,9 @@ class AllenEberlyChirp(SamplingBase):
     params['tau_pulse'] = {'unit': '', 'init': 0.1e-6, 'min': 0.0, 'max': np.inf,
                            'type': float}
 
-    def __init__(self, amplitude=None, phase=None, start_freq=None, stop_freq=None, tau_pulse=None):
+    def __init__(self, amplitude=None, phase=None, start_freq=None, stop_freq=None, tau_pulse=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params.update(AllenEberlyChirp.params)
         if amplitude is None:
             self.amplitude = self.params['amplitude']['init']
         else:

--- a/src/qudi/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
@@ -63,7 +63,25 @@ class DC(SamplingBase):
         return samples_arr
 
 
-class Sin(SamplingBase):
+class SinBase(SamplingBase):
+    """
+    Class defining some base sine sampling functions
+    """
+    @staticmethod
+    def _get_sine(time_array, amplitude, frequency, phase):
+        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
+        return samples_arr
+
+    def _init_parameter(self, name: str, value: float):
+        return value if value is not None else self.params[name]["init"]
+
+    def _init_parameters(self, number_of_sines: int, variables_to_set: dict):
+        for i in range(1, number_of_sines + 1):
+            for name in ("amplitude", "frequency", "phase"):
+                key = f"{name}_{i}" if number_of_sines > 1 else name
+                setattr(self, key, self._init_parameter(key, variables_to_set[key]))
+
+class Sin(SinBase):
     """
     Object representing a sine wave element
     """
@@ -75,24 +93,7 @@ class Sin(SamplingBase):
     def __init__(self, amplitude=None, frequency=None, phase=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(Sin.params)
-        if amplitude is None:
-            self.amplitude = self.params['amplitude']['init']
-        else:
-            self.amplitude = amplitude
-        if frequency is None:
-            self.frequency = self.params['frequency']['init']
-        else:
-            self.frequency = frequency
-        if phase is None:
-            self.phase = self.params['phase']['init']
-        else:
-            self.phase = phase
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(1, locals())
 
     def get_samples(self, time_array):
         phase_rad = np.pi * self.phase / 180
@@ -100,7 +101,7 @@ class Sin(SamplingBase):
         return samples_arr
 
 
-class DoubleSinSum(SamplingBase):
+class DoubleSinSum(SinBase):
     """
     Object representing a double sine wave element (Superposition of two sine waves; NOT normalized)
     """
@@ -117,37 +118,7 @@ class DoubleSinSum(SamplingBase):
                  amplitude_2=None, frequency_2=None, phase_2=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(DoubleSinSum.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(2, locals())
 
     def get_samples(self, time_array):
         # First sine wave
@@ -160,7 +131,7 @@ class DoubleSinSum(SamplingBase):
         return samples_arr
 
 
-class DoubleSinProduct(SamplingBase):
+class DoubleSinProduct(SinBase):
     """
     Object representing a double sine wave element (Product of two sine waves; NOT normalized)
     """
@@ -177,37 +148,7 @@ class DoubleSinProduct(SamplingBase):
                  amplitude_2=None, frequency_2=None, phase_2=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(DoubleSinProduct.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(2, locals())
 
     def get_samples(self, time_array):
         # First sine wave
@@ -220,7 +161,7 @@ class DoubleSinProduct(SamplingBase):
         return samples_arr
 
 
-class TripleSinSum(SamplingBase):
+class TripleSinSum(SinBase):
     """
     Object representing a linear combination of three sines
     (Superposition of three sine waves; NOT normalized)
@@ -242,50 +183,7 @@ class TripleSinSum(SamplingBase):
                  amplitude_3=None, frequency_3=None, phase_3=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(TripleSinSum.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-
-        if amplitude_3 is None:
-            self.amplitude_3 = self.params['amplitude_3']['init']
-        else:
-            self.amplitude_3 = amplitude_3
-        if frequency_3 is None:
-            self.frequency_3 = self.params['frequency_3']['init']
-        else:
-            self.frequency_3 = frequency_3
-        if phase_3 is None:
-            self.phase_3 = self.params['phase_3']['init']
-        else:
-            self.phase_3 = phase_3
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(3, locals())
 
     def get_samples(self, time_array):
         # First sine wave
@@ -302,7 +200,7 @@ class TripleSinSum(SamplingBase):
         return samples_arr
 
 
-class TripleSinProduct(SamplingBase):
+class TripleSinProduct(SinBase):
     """
     Object representing a wave element composed of the product of three sines
     (Product of three sine waves; NOT normalized)
@@ -324,50 +222,7 @@ class TripleSinProduct(SamplingBase):
                  amplitude_3=None, frequency_3=None, phase_3=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(TripleSinProduct.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-
-        if amplitude_3 is None:
-            self.amplitude_3 = self.params['amplitude_3']['init']
-        else:
-            self.amplitude_3 = amplitude_3
-        if frequency_3 is None:
-            self.frequency_3 = self.params['frequency_3']['init']
-        else:
-            self.frequency_3 = frequency_3
-        if phase_3 is None:
-            self.phase_3 = self.params['phase_3']['init']
-        else:
-            self.phase_3 = phase_3
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(3, locals())
 
     def get_samples(self, time_array):
         # First sine wave
@@ -383,7 +238,7 @@ class TripleSinProduct(SamplingBase):
         samples_arr *= self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
         return samples_arr
 
-class QuintupleSinSum(SamplingBase):
+class QuintupleSinSum(SinBase):
     """
     Object representing a linear combination of five sines
     (Superposition of five sine waves; NOT normalized)
@@ -413,76 +268,7 @@ class QuintupleSinSum(SamplingBase):
                  amplitude_5=None, frequency_5=None, phase_5=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(QuintupleSinSum.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-
-        if amplitude_3 is None:
-            self.amplitude_3 = self.params['amplitude_3']['init']
-        else:
-            self.amplitude_3 = amplitude_3
-        if frequency_3 is None:
-            self.frequency_3 = self.params['frequency_3']['init']
-        else:
-            self.frequency_3 = frequency_3
-        if phase_3 is None:
-            self.phase_3 = self.params['phase_3']['init']
-        else:
-            self.phase_3 = phase_3
-
-        if amplitude_4 is None:
-            self.amplitude_4 = self.params['amplitude_4']['init']
-        else:
-            self.amplitude_4 = amplitude_4
-        if frequency_4 is None:
-            self.frequency_4 = self.params['frequency_4']['init']
-        else:
-            self.frequency_4 = frequency_4
-        if phase_4 is None:
-            self.phase_4 = self.params['phase_4']['init']
-        else:
-            self.phase_4 = phase_4
-
-        if amplitude_5 is None:
-            self.amplitude_5 = self.params['amplitude_5']['init']
-        else:
-            self.amplitude_5 = amplitude_5
-        if frequency_5 is None:
-            self.frequency_5 = self.params['frequency_5']['init']
-        else:
-            self.frequency_5 = frequency_5
-        if phase_5 is None:
-            self.phase_5 = self.params['phase_5']['init']
-        else:
-            self.phase_5 = phase_5
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(5, locals())
 
     def get_samples(self, time_array):
         # First sine wave
@@ -506,7 +292,7 @@ class QuintupleSinSum(SamplingBase):
         samples_arr += self._get_sine(time_array, self.amplitude_5, self.frequency_5, phase_rad)
         return samples_arr
 
-class SextupleSinSum(SamplingBase):
+class SextupleSinSum(SinBase):
     """
     Object representing a linear combination of six sines
     (Superposition of six sine waves; NOT normalized)
@@ -540,89 +326,7 @@ class SextupleSinSum(SamplingBase):
                  amplitude_6=None, frequency_6=None, phase_6=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.params.update(SextupleSinSum.params)
-        if amplitude_1 is None:
-            self.amplitude_1 = self.params['amplitude_1']['init']
-        else:
-            self.amplitude_1 = amplitude_1
-        if frequency_1 is None:
-            self.frequency_1 = self.params['frequency_1']['init']
-        else:
-            self.frequency_1 = frequency_1
-        if phase_1 is None:
-            self.phase_1 = self.params['phase_1']['init']
-        else:
-            self.phase_1 = phase_1
-
-        if amplitude_2 is None:
-            self.amplitude_2 = self.params['amplitude_2']['init']
-        else:
-            self.amplitude_2 = amplitude_2
-        if frequency_2 is None:
-            self.frequency_2 = self.params['frequency_2']['init']
-        else:
-            self.frequency_2 = frequency_2
-        if phase_2 is None:
-            self.phase_2 = self.params['phase_2']['init']
-        else:
-            self.phase_2 = phase_2
-
-        if amplitude_3 is None:
-            self.amplitude_3 = self.params['amplitude_3']['init']
-        else:
-            self.amplitude_3 = amplitude_3
-        if frequency_3 is None:
-            self.frequency_3 = self.params['frequency_3']['init']
-        else:
-            self.frequency_3 = frequency_3
-        if phase_3 is None:
-            self.phase_3 = self.params['phase_3']['init']
-        else:
-            self.phase_3 = phase_3
-
-        if amplitude_4 is None:
-            self.amplitude_4 = self.params['amplitude_4']['init']
-        else:
-            self.amplitude_4 = amplitude_4
-        if frequency_4 is None:
-            self.frequency_4 = self.params['frequency_4']['init']
-        else:
-            self.frequency_4 = frequency_4
-        if phase_4 is None:
-            self.phase_4 = self.params['phase_4']['init']
-        else:
-            self.phase_4 = phase_4
-
-        if amplitude_5 is None:
-            self.amplitude_5 = self.params['amplitude_5']['init']
-        else:
-            self.amplitude_5 = amplitude_5
-        if frequency_5 is None:
-            self.frequency_5 = self.params['frequency_5']['init']
-        else:
-            self.frequency_5 = frequency_5
-        if phase_5 is None:
-            self.phase_5 = self.params['phase_5']['init']
-        else:
-            self.phase_5 = phase_5
-
-        if amplitude_6 is None:
-            self.amplitude_6 = self.params['amplitude_6']['init']
-        else:
-            self.amplitude_6 = amplitude_6
-        if frequency_6 is None:
-            self.frequency_6 = self.params['frequency_6']['init']
-        else:
-            self.frequency_6 = frequency_6
-        if phase_6 is None:
-            self.phase_6 = self.params['phase_6']['init']
-        else:
-            self.phase_6 = phase_6
-        return
-
-    @staticmethod
-    def _get_sine(time_array, amplitude, frequency, phase):
-        samples_arr = amplitude * np.sin(2 * np.pi * frequency * time_array + phase)
-        return samples_arr
+        self._init_parameters(6, locals())
 
     def get_samples(self, time_array):
         # First sine wave

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -106,6 +106,11 @@ class SamplingBase:
     params = dict()
     log = logging.getLogger(__name__)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params = dict()
+
+
     def __repr__(self):
         kwargs = []
         for param, def_dict in self.params.items():

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -110,7 +110,6 @@ class SamplingBase:
         super().__init__(*args, **kwargs)
         self.params = dict()
 
-
     def __repr__(self):
         kwargs = []
         for param, def_dict in self.params.items():


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
When one generates functions that inherit from one of the basic sampling functions, e.g. when creating shaped pulses, they should have both parameters from their own class as well as from the sampling function. Therefore they should inherit the `params` dict content of the basic sampling function as well as have their `params` dict content from their own class. To fix this, a instance `params` dict is introduced and updated with the class `params` in the `__init__()` method. This way any pulse object that inherits from one of the basic sampling functions has all parameters stored in its  `self.params` instance variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some sampling functions inherit from the basic sampling functions. The problem was, that the inheritance of the `params` variable didn't work when both classes have params variables and any change to `self.params` was changing the class variable `params` and therefore for all objects of the sampling function class. This has lead to errors in the pulsed measurement gui pulse generator when displaying the parameters of different pulse elements with different parameters that both inherit from the same basic sampling function.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on confocal setup with normal and shaped pulses for e.g. Sine and TripleSinSum sampling function
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? -->
- `super.__init__()` call for all sampling function classes in the init method
- assignment of the `params` class variable to `self.params` in the init method of all sampling classes
- default assignment of an empty dict in `SamplingBase` `__init__()` method to ensure the instance variable `params` exists for all objects that inherit from `SamplingBase`
- When generating normal sampling functions, the only change is that there is now both the params instance variable as well as the params class variable. If you want to change the default params for a sampling function class, you have to change the class variable, not the instance variable of an object of this class. For an object you can just change `self.params` without having to worry that it changes the `params` for future objects.
- 
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.