### PR TITLE
added artifact fetch to Windows test job

### DIFF
--- a/.github/workflows/test_req.yml
+++ b/.github/workflows/test_req.yml
@@ -72,7 +72,6 @@ jobs:
             head -n 1
           )
           echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_ENV"
-          echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
 
     - name: Download reqs artifact
       if: env.artifact_run_id != ''
@@ -138,14 +137,47 @@ jobs:
       run: |
         pip freeze | Out-File -Encoding UTF8 reqs_${{ matrix.python-version }}.txt
 
+    - name: Get latest artifact run id (Windows / PowerShell)
+      id: find-id-test
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $headers = @{
+          Authorization = "Bearer $env:GH_TOKEN"
+          Accept = "application/vnd.github+json"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+
+        $artifactName = "reqs_${{ matrix.python-version }}"
+        $uri = "https://api.github.com/repos/${{ github.repository }}/actions/artifacts?per_page=100"
+
+        $resp = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+
+        $artifact = $resp.artifacts |
+          Where-Object { $_.name -eq $artifactName -and -not $_.expired } |
+          Sort-Object created_at -Descending |
+          Select-Object -First 1
+
+        if ($null -ne $artifact) {
+          $runId = [string]$artifact.workflow_run.id
+          "artifact_run_id=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Found artifact '$artifactName' in run $runId"
+        }
+        else {
+          "artifact_run_id=" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "No previous artifact found for '$artifactName'"
+        }
+
     - name: Download reqs artifact
-      if: needs.check-package-updates.outputs.artifact_run_id != ''
+      if: env.artifact_run_id != ''
       uses: actions/download-artifact@v4
       with:
         name: reqs_${{ matrix.python-version }}
         path: .github/workflow_utils/prev
-        run-id:  ${{ needs.check-package-updates.outputs.artifact_run_id }}
+        run-id: ${{ env.artifact_run_id }}
         github-token:  ${{ secrets.GITHUB_TOKEN }}
+
 
     - name: Compare pip freeze outputs
       if: failure()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@
 - Tests now use `QudiKernel` instead of a custom remote server
 - Added install script
 - Updated install documentation
+- Improved Github Actions dependency testing
 
 ## Version 0.6.0
 


### PR DESCRIPTION


## Description
The routine requirement workflow randomly fails sometimes. The changes in this PR (fetching artifacts in the Windows job, similar to the Ubuntu job)  aim to fix that. 

## Motivation and Context
The current workflow fetches the artifact run id in the first job, saves it as a Github output, and reuses it for another job. This isn't reliable and sometimes causes the routine workflow runs to fail. This PR introduces a fix by adding the artifact fetch step to the other job. 

## How Has This Been Tested?
This has been tested on a fork.


## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
