### PR TITLE
updated github actions versions to fix Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/publish_supported_python.yml
+++ b/.github/workflows/publish_supported_python.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build Python matrix from pyproject.toml
         id: build
         run: |
@@ -30,10 +30,10 @@ jobs:
     needs: make-matrix
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
       - name: Write Python Version badge
         id: badge

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -13,11 +13,11 @@ jobs:
       id-token: write
     steps:
     - name: checkout tag
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.release.tag_name }}
     - name: setup Python environment
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: 'x64'

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -15,9 +15,9 @@ jobs:
       id-token: write
     steps:
     - name: checkout main
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: setup Python environment
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: 'x64'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build Python matrix from pyproject.toml
         id: build
         run: |
@@ -36,9 +36,9 @@ jobs:
         python-version: ${{ fromJson(needs.make-matrix.outputs.matrix) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/.github/workflows/test_req.yml
+++ b/.github/workflows/test_req.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build Python matrix from pyproject.toml
         id: build
         run: |
@@ -41,13 +41,13 @@ jobs:
       matrix:
         python-version: ${{ fromJson(needs.make-matrix.outputs.matrix) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
           python-version: ${{ matrix.python-version }}
 
@@ -75,7 +75,7 @@ jobs:
 
     - name: Download reqs artifact
       if: env.artifact_run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: reqs_${{ matrix.python-version }}
         path: .github/workflow_utils
@@ -101,13 +101,13 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version:  ${{ matrix.python-version }}
         cache: "pip"
@@ -171,7 +171,7 @@ jobs:
 
     - name: Download reqs artifact
       if: env.artifact_run_id != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: reqs_${{ matrix.python-version }}
         path: .github/workflow_utils/prev
@@ -187,7 +187,7 @@ jobs:
 
     - name: Upload pip freeze diff
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: pip-freeze-diff-${{ matrix.python-version }}
         path: .github/workflow_utils/pip_freeze_diff_${{ matrix.python-version }}.txt
@@ -196,7 +196,7 @@ jobs:
     - name: Upload reqs artifact
       if: success()
 
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: reqs_${{ matrix.python-version }}
         path: .github/workflow_utils/reqs_${{ matrix.python-version }}.txt

--- a/.github/workflows/test_sv.yml
+++ b/.github/workflows/test_sv.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       artifact_run_id: ${{ steps.find-id.outputs.artifact_run_id }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
@@ -53,13 +53,13 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Set up Python 
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: 'pyproject.toml'
         cache: "pip"
@@ -86,7 +86,7 @@ jobs:
 
     - name: Download svs artifact
       if:  needs.find_artifact_id.outputs.artifact_run_id  != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: svs
         path: .github/workflow_utils
@@ -107,7 +107,7 @@ jobs:
 
     - name: Upload status vars diff
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: status_vars_diff
         path: .github/workflow_utils/status_var_changes.txt
@@ -121,7 +121,7 @@ jobs:
 
     - name: Upload svs artifact
       if: success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: svs
         path: .github/workflow_utils/svs.zip

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,7 @@
 - Added the `PredefinedGeneratorBase._get_sequence_count_length` method to easily and correctly determine the count length of `PulseSequence` objects similar to `PredefinedGeneratorBase._get_ensemble_count_length`
 
 ### Other
+- Updated versions for Github actions to fix Node.js 20 deprecation warnings
 - Fixed testing workflow by removing deprecated `python 3.8`
 - Configured Github Action bot as author for the testing branch commits
 - Workflows automatically fetch all possible python versions from the `pyproject.toml` for testing, tests that only use a singular Python version now use the latest possible Python version


### PR DESCRIPTION
Updated versions for some Github actions such as checkout, setup-python, download-artifact, upload-artifact.

## Motivation and Context
The current workflow runs give the warning - 'Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4..' The versions of these actions have been updated to ones that run with Node.js 24. Some other actions are also updated to their latest versions.

## How Has This Been Tested?
The changes have been tested on a fork.


## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
