### PR TITLE
fixed netref issue for a test

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ### Bugfixes
 - Fix `installtion.py` for arbitrary Python versions
+- Fixed tests for `rpyc>6`
 
 ### New Features
 

--- a/tests/test_modify_status_var_example.py
+++ b/tests/test_modify_status_var_example.py
@@ -58,7 +58,7 @@ def get_status_var_file(instance):
         File path
     """    
     file_path = get_module_app_data_path(
-            instance.__class__.__name__, instance.module_base, instance.module_name
+            type(instance).__name__.rsplit('.', 1)[-1], instance.module_base, instance.module_name
         )
     return file_path
 


### PR DESCRIPTION

## Description
After upgrading Rpyc to v6, one of the tests (test_modify_status_var_example.py) fails due to NetRef issue that is similar to the recent mro() issue. This PR is a fix for that.


## How Has This Been Tested?
This has been tested locally


## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
