### PR TITLE
fixed some pyside6 issues in POI manager

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ### Bugfixes
 - Fix `installtion.py` for arbitrary Python versions
+- Fix several `POIManagerGUI` `PySide6` bugs
 
 ### New Features
 

--- a/src/qudi/gui/poimanager/poimanagergui.py
+++ b/src/qudi/gui/poimanager/poimanagergui.py
@@ -474,7 +474,7 @@ class PoiManagerGui(GuiBase):
             self._poi_manager_logic().set_poi_anchor_from_position, QtCore.Qt.ConnectionType.QueuedConnection)
         self._mw.delete_poi_PushButton.clicked.connect(
             lambda: self._poi_manager_logic().delete_poi(None), QtCore.Qt.ConnectionType.QueuedConnection)
-        self._mw.active_poi_ComboBox.activated[int].connect(
+        self._mw.active_poi_ComboBox.textActivated.connect(
             self._poi_manager_logic().set_active_poi, QtCore.Qt.ConnectionType.QueuedConnection)
         self._mw.goto_poi_after_update_checkBox.stateChanged.connect(
             self._poi_manager_logic().set_move_scanner_after_optimise, QtCore.Qt.ConnectionType.QueuedConnection)
@@ -506,7 +506,7 @@ class PoiManagerGui(GuiBase):
         self._mw.manual_update_poi_PushButton.clicked.disconnect()
         self._mw.move_poi_PushButton.clicked.disconnect()
         self._mw.delete_poi_PushButton.clicked.disconnect()
-        self._mw.active_poi_ComboBox.activated[int].disconnect()
+        self._mw.active_poi_ComboBox.textActivated.disconnect()
         self._mw.goto_poi_after_update_checkBox.stateChanged.disconnect()
         self._mw.track_poi_Action.triggered.disconnect()
         self.sigTrackPeriodChanged.disconnect()

--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -687,11 +687,6 @@ class PoiManagerLogic(LogicBase):
             return
 
     @QtCore.Slot()
-    def new_poi(self):
-        """ GUI slot: add a POI at the current scanner position. """
-        self.add_poi()
-
-    @QtCore.Slot()
     def delete_poi(self, name=None):
         """
         Deletes the given poi from the ROI.

--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -667,7 +667,7 @@ class PoiManagerLogic(LogicBase):
         """
         with self._thread_lock:
             # Get current scanner position from  if no position is provided.
-            if position is None:
+            if position is None or position is False:
                 position = self.scanner_position
 
             current_poi_set = set(self.poi_names)
@@ -685,6 +685,11 @@ class PoiManagerLogic(LogicBase):
             # Set newly created POI as active poi
             self.set_active_poi(poi_name)
             return
+
+    @QtCore.Slot()
+    def new_poi(self):
+        """ GUI slot: add a POI at the current scanner position. """
+        self.add_poi()
 
     @QtCore.Slot()
     def delete_poi(self, name=None):

--- a/src/qudi/logic/poi_manager_logic.py
+++ b/src/qudi/logic/poi_manager_logic.py
@@ -804,7 +804,7 @@ class PoiManagerLogic(LogicBase):
             if position is None:
                 position = self.scanner_position
 
-            if name is None:
+            if name is None or isinstance(name, bool):
                 if self.active_poi is None:
                     self.log.error('Unable to set POI position. '
                                    'No POI name given and no active POI set.')
@@ -817,7 +817,7 @@ class PoiManagerLogic(LogicBase):
                 return
             if not isinstance(name, str):
                 self.log.error('POI name must be of type str.')
-
+                return
             shift = position - self.get_poi_position(name)
             self.add_roi_position(self.roi_origin + shift)
             return
@@ -828,7 +828,7 @@ class PoiManagerLogic(LogicBase):
             if position is None:
                 position = self.scanner_position
 
-            if name is None:
+            if name is None or isinstance(name, bool):
                 if self.active_poi is None:
                     self.log.error('Unable to set POI position. '
                                    'No POI name given and no active POI set.')
@@ -841,6 +841,7 @@ class PoiManagerLogic(LogicBase):
                 return
             if not isinstance(name, str):
                 self.log.error('POI name must be of type str.')
+                return
 
             shift = position - self.get_poi_position(name)
             self._roi.set_poi_anchor(name, self.get_poi_anchor(name) + shift)


### PR DESCRIPTION

## Description
### Fix two PySide6 migration issues in POI manager

Both bugs surfaced after the Qt5 → PySide6/Qt6 migration and made the POI
manager partially unusable.

### 1. Selecting a POI from the dropdown raises "POI name must be of type str or None"

`active_poi_ComboBox` was connected via `activated[int]`, which emits the
selected *index*, so `set_active_poi` received an integer instead of the POI
name. Qt6 removed the `activated(const QString&)` overload that the original
code(Pyside2) relied on.

Fixed by connecting to `textActivated`, the Qt6 replacement that emits the
selected text. Applied to both the connect and disconnect sites.

### 2. "New POI" no longer placed at the current scanner position

New POI can be added either by a mouse click event or defaulting to the current scanner position. Both ways , the method add_poi() is called in poi_manager_logic. In pyside2 with the default, the method was called with no parameters, but after the migration it gets called with a bool type and thus position is not fetched from the scanner. Adding a condition to check if the position is False fixes this. 

A similar issue was when clicking  Move POI anchor or Manual update Position buttons. This is also caused because a slot gets called with bool type.  Adding a condition to check if the name string is bool fixes this.

## How Has This Been Tested?
This has been tested locally and seems to work as before with pyside2


## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
