### PR TITLE
supporting customized alt plot methods in pulsed analysis

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 - Fix several `POIManagerGUI` `PySide6` bugs
 
 ### New Features
+- supporting custom alternative plots in pulsed analysis 
 - Added resizeable `PulseBlockEditor` columns in `pulsed_gui`
 - Added pulse shaping to the `pulsed` tool chain
 

--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -2398,6 +2398,15 @@ class PulsedMeasurementGui(GuiBase):
         # apply hardware constraints
         self._pa_apply_hardware_constraints()
 
+        # Dynamically populate the alternative (second) plot selection from the available methods
+        # discovered by the logic (AltPlotAnalyzer). 'None' is always offered to disable the plot.
+        self._pa.second_plot_ComboBox.blockSignals(True)
+        self._pa.second_plot_ComboBox.clear()
+        self._pa.second_plot_ComboBox.addItem('None')
+        for method_name in natural_sort(self.pulsedmasterlogic().alt_plot_methods):
+            self._pa.second_plot_ComboBox.addItem(method_name)
+        self._pa.second_plot_ComboBox.blockSignals(False)
+
         # Recall StatusVars into widgets
         self._pa.ana_param_errorbars_CheckBox.blockSignals(True)
         self._pa.ana_param_errorbars_CheckBox.setChecked(self._ana_param_errorbars)
@@ -2875,11 +2884,15 @@ class PulsedMeasurementGui(GuiBase):
         if second_plot != self.pulsedmasterlogic().alternative_data_type:
             self.pulsedmasterlogic().set_alternative_data_type(second_plot)
 
-        if self.pulsedmasterlogic().alternative_data_type == 'Delta':
-            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_x_axis_name_LineEdit.text()
-            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
-            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
-            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
+        # Axis labels for the selected method are provided by the logic (computed from the active
+        # measurement settings), 
+        current_type = self.pulsedmasterlogic().alternative_data_type
+        method_labels = self.pulsedmasterlogic().alt_plot_labels.get(current_type)
+        if method_labels:
+            self._ana_param_second_plot_x_axis_name_text = method_labels.get('x_label', '')
+            self._ana_param_second_plot_x_axis_unit_text = method_labels.get('x_unit', '')
+            self._ana_param_second_plot_y_axis_name_text = method_labels.get('y_label', '')
+            self._ana_param_second_plot_y_axis_unit_text = method_labels.get('y_unit', '')
         else:
             self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
             self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()

--- a/src/qudi/gui/pulsed/ui_pulse_analysis.ui
+++ b/src/qudi/gui/pulsed/ui_pulse_analysis.ui
@@ -426,21 +426,6 @@
           </item>
           <item row="6" column="1">
            <widget class="QComboBox" name="second_plot_ComboBox">
-            <item>
-             <property name="text">
-              <string>None</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>FFT</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Delta</string>
-             </property>
-            </item>
            </widget>
           </item>
           <item row="6" column="0">

--- a/src/qudi/logic/pulsed/alt_plot_methods/basic_alt_plot_methods.py
+++ b/src/qudi/logic/pulsed/alt_plot_methods/basic_alt_plot_methods.py
@@ -24,6 +24,8 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 from qudi.util.math import compute_ft
@@ -36,7 +38,8 @@ class FourierTransformAltPlot(AltPlotMethodBase):
 
     name = 'FFT'
 
-    def compute(self, signal_data, zeropad=0, window='none', base_corr=True, psd=False):
+    def compute(self, signal_data: np.ndarray, zeropad: int = 0, window: str = 'none',
+                base_corr: bool = True, psd: bool = False) -> np.ndarray | None:
         if signal_data.shape[1] < 2:
             return None
 
@@ -61,11 +64,11 @@ class FourierTransformAltPlot(AltPlotMethodBase):
 
     # FFT swaps the x-axis to the inverse domain and renders the y-axis in arbitrary units.
     @property
-    def x_axis_label(self):
+    def x_axis_label(self) -> str:
         return 'FT {0}'.format(self.data_labels[0])
 
     @property
-    def x_axis_unit(self):
+    def x_axis_unit(self) -> str:
         x_unit = self.data_units[0]
         if x_unit == 's':
             return 'Hz'
@@ -76,11 +79,11 @@ class FourierTransformAltPlot(AltPlotMethodBase):
         return ''
 
     @property
-    def y_axis_label(self):
+    def y_axis_label(self) -> str:
         return 'FT({0})'.format(self.data_labels[1])
 
     @property
-    def y_axis_unit(self):
+    def y_axis_unit(self) -> str:
         return 'arb. u.'
 
 
@@ -90,7 +93,7 @@ class DeltaAltPlot(AltPlotMethodBase):
 
     name = 'Delta'
 
-    def compute(self, signal_data):
+    def compute(self, signal_data: np.ndarray) -> np.ndarray | None:
         if len(signal_data) != 3:
             return None
         alt_data = np.empty((2, signal_data.shape[1]), dtype=float)
@@ -98,6 +101,6 @@ class DeltaAltPlot(AltPlotMethodBase):
         alt_data[1] = signal_data[1] - signal_data[2]
         return alt_data
 
-    def is_available(self):
+    def is_available(self) -> bool:
         return self.is_alternating
 

--- a/src/qudi/logic/pulsed/alt_plot_methods/basic_alt_plot_methods.py
+++ b/src/qudi/logic/pulsed/alt_plot_methods/basic_alt_plot_methods.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Basic alternative plot methods for the pulsed measurement analysis tab.
+
+These reference implementations of ``AltPlotMethodBase`` reproduce the behaviour previously
+hardcoded in ``PulsedMeasurementLogic._compute_alt_data``. To add a new alternative plot method,
+copy the structure of one of the classes below into this package or the configured
+``additional_alt_plot_path`` directory.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import numpy as np
+
+from qudi.util.math import compute_ft
+from qudi.logic.pulsed.pulse_alt_plot import AltPlotMethodBase
+
+
+class FourierTransformAltPlot(AltPlotMethodBase):
+    """ Fourier transform of the measured data trace(s). FFT parameters are exposed as configurable,
+    persisted parameters via the keyword arguments of :meth:`compute`. """
+
+    name = 'FFT'
+
+    def compute(self, signal_data, zeropad=0, window='none', base_corr=True, psd=False):
+        if signal_data.shape[1] < 2:
+            return None
+
+        fft_x, fft_y = compute_ft(x_val=signal_data[0],
+                                  y_val=signal_data[1],
+                                  zeropad_num=zeropad,
+                                  window=window,
+                                  base_corr=base_corr,
+                                  psd=psd)
+
+        alt_data = np.empty((len(signal_data), len(fft_x)), dtype=float)
+        alt_data[0] = fft_x
+        alt_data[1] = fft_y
+        for dim in range(2, len(signal_data)):
+            _, alt_data[dim] = compute_ft(x_val=signal_data[0],
+                                          y_val=signal_data[dim],
+                                          zeropad_num=zeropad,
+                                          window=window,
+                                          base_corr=base_corr,
+                                          psd=psd)
+        return alt_data
+
+    # FFT swaps the x-axis to the inverse domain and renders the y-axis in arbitrary units.
+    @property
+    def x_axis_label(self):
+        return 'FT {0}'.format(self.data_labels[0])
+
+    @property
+    def x_axis_unit(self):
+        x_unit = self.data_units[0]
+        if x_unit == 's':
+            return 'Hz'
+        elif x_unit == 'Hz':
+            return 's'
+        elif x_unit:
+            return '(1/{0})'.format(x_unit)
+        return ''
+
+    @property
+    def y_axis_label(self):
+        return 'FT({0})'.format(self.data_labels[1])
+
+    @property
+    def y_axis_unit(self):
+        return 'arb. u.'
+
+
+class DeltaAltPlot(AltPlotMethodBase):
+    """ Difference of the two traces of an alternating measurement (trace 1 - trace 2). Only
+    available for alternating measurements; uses the default (primary) axis labels. """
+
+    name = 'Delta'
+
+    def compute(self, signal_data):
+        if len(signal_data) != 3:
+            return None
+        alt_data = np.empty((2, signal_data.shape[1]), dtype=float)
+        alt_data[0] = signal_data[0]
+        alt_data[1] = signal_data[1] - signal_data[2]
+        return alt_data
+
+    def is_available(self):
+        return self.is_alternating
+

--- a/src/qudi/logic/pulsed/pulse_alt_plot.py
+++ b/src/qudi/logic/pulsed/pulse_alt_plot.py
@@ -24,10 +24,15 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import inspect
 import importlib
+from collections.abc import Callable
+from typing import Any
+import numpy as np
 
 from qudi.util.helpers import natural_sort, iter_modules_recursive
 
@@ -82,13 +87,13 @@ class AltPlotMethodBase:
         return self.__pulsedmeasurementlogic.log
 
     # --- interface to implement ---
-    def compute(self, signal_data):
+    def compute(self, signal_data: np.ndarray) -> np.ndarray | None:
         """ Transform ``signal_data`` (row 0: x-axis, rows 1..: trace(s); row 2 is the alternating
         trace) into a 2D array with the same layout. Return None if it cannot be evaluated; the
         caller then falls back to a flat default plot. """
         raise NotImplementedError('Alternative plot methods must implement "compute".')
 
-    def is_available(self):
+    def is_available(self) -> bool:
         """ Whether the method may be selected/computed for the active measurement settings. """
         return True
 
@@ -126,9 +131,9 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
     def __init__(self, pulsedmeasurementlogic):
         super().__init__(pulsedmeasurementlogic)
-        self._methods = dict()      # {name: instance}
-        self._parameters = dict()   # union of all compute() kwargs
-        self._current_method = None  # None => no alternative plot
+        self._methods: dict[str, AltPlotMethodBase] = dict()      # {name: instance}
+        self._parameters: dict[str, Any] = dict()   # union of all compute() kwargs
+        self._current_method: str | None = None  # None => no alternative plot
 
         # Import from the default namespace package
         import qudi.logic.pulsed.alt_plot_methods as default_ns
@@ -166,16 +171,16 @@ class AltPlotAnalyzer(AltPlotMethodBase):
                                       if k == 'method' or k in self._parameters}
 
     @property
-    def alt_plot_methods(self):
+    def alt_plot_methods(self) -> list[str]:
         """ Naturally sorted list of all available method names. """
         return natural_sort(self._methods)
 
     @property
-    def current_method(self):
+    def current_method(self) -> str | None:
         return self._current_method
 
     @current_method.setter
-    def current_method(self, name):
+    def current_method(self, name: str | None) -> None:
         if name in (None, '', 'None'):
             self._current_method = None
         elif name in self._methods:
@@ -184,7 +189,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
             self.log.error(f'Alternative plot method "{name}" not found in AltPlotAnalyzer.')
 
     @property
-    def alt_plot_settings(self):
+    def alt_plot_settings(self) -> dict[str, Any]:
         """ Current method's parameters plus the selected method name (key "method"). """
         method = self._methods.get(self._current_method)
         settings = self._get_method_kwargs(method.compute) if method is not None else dict()
@@ -192,7 +197,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
         return settings
 
     @alt_plot_settings.setter
-    def alt_plot_settings(self, settings_dict):
+    def alt_plot_settings(self, settings_dict: dict[str, Any]) -> None:
         if not isinstance(settings_dict, dict):
             return
         for parameter, value in settings_dict.items():
@@ -205,23 +210,23 @@ class AltPlotAnalyzer(AltPlotMethodBase):
                                  f'Ignoring it.')
 
     @property
-    def full_settings_dict(self):
+    def full_settings_dict(self) -> dict[str, Any]:
         """ All parameters plus the current method, for persisting in a StatusVar. """
         settings = self._parameters.copy()
         settings['method'] = self._current_method
         return settings
 
     @property
-    def alt_plot_labels(self):
+    def alt_plot_labels(self) -> dict[str, dict[str, str]]:
         """ {method_name: labels_dict} for every method (primitive strings; rpyc-safe). """
         return {name: instance.labels_dict for name, instance in self._methods.items()}
 
     @property
-    def current_labels(self):
+    def current_labels(self) -> dict[str, str]:
         method = self._methods.get(self._current_method)
         return method.labels_dict if method is not None else dict()
 
-    def is_available(self, name=None):
+    def is_available(self, name: str | None = None) -> bool:
         """ Whether the given (default: current) method can be used for the active settings. """
         method = self._methods.get(self._current_method if name is None else name)
         if method is None:
@@ -232,7 +237,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
             self.log.exception(f'Error checking availability of alternative plot method "{name}":')
             return False
 
-    def compute_alt_data(self, signal_data):
+    def compute_alt_data(self, signal_data: np.ndarray) -> np.ndarray | None:
         """ Evaluate the current method, or return None if none selected/unavailable/not evaluable. """
         if self._current_method is None or not self.is_available(self._current_method):
             return None
@@ -240,7 +245,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
         return method.compute(signal_data=signal_data, **self._get_method_kwargs(method.compute))
 
     # --- helpers ---
-    def _get_method_kwargs(self, compute_method):
+    def _get_method_kwargs(self, compute_method: Callable) -> dict[str, Any]:
         """ Build the kwargs (other than ``signal_data``) for a compute method, preferring stored
         parameter values over the signature defaults (matching by data type). """
         kwargs = dict()
@@ -251,7 +256,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
             kwargs[name] = stored if type(stored) == type(param.default) else param.default
         return kwargs
 
-    def __import_external_methods(self, path):
+    def __import_external_methods(self, path: str) -> list[type[AltPlotMethodBase]]:
         if path not in sys.path:
             sys.path.append(path)
         class_list = list()
@@ -262,6 +267,6 @@ class AltPlotAnalyzer(AltPlotMethodBase):
         return class_list
 
     @staticmethod
-    def is_alt_plot_class(obj):
+    def is_alt_plot_class(obj: Any) -> bool:
         """ True if obj inherits exclusively from AltPlotMethodBase. """
         return inspect.isclass(obj) and obj.__bases__ == (AltPlotMethodBase,)

--- a/src/qudi/logic/pulsed/pulse_alt_plot.py
+++ b/src/qudi/logic/pulsed/pulse_alt_plot.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""
+Base class and management class for the "alternative plot" (second plot) of the pulsed measurement
+analysis tab.
+
+This mirrors the design of ``pulse_analyzer.PulseAnalyzer``: drop a module containing a subclass of
+``AltPlotMethodBase`` into the ``alt_plot_methods`` namespace package (or a configured additional
+import directory) and the method automatically becomes selectable in the GUI.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+import sys
+import inspect
+import importlib
+
+from qudi.util.helpers import natural_sort, iter_modules_recursive
+
+
+class AltPlotMethodBase:
+    """ Base class for alternative plot methods. Must be inherited from *exclusively*.
+
+    A subclass must set a unique ``name`` (falls back to the class name) and implement
+    :meth:`compute`. It may override :meth:`is_available` and the ``x_axis_*``/``y_axis_*`` label
+    properties. Any keyword arguments of :meth:`compute` (with correctly-typed defaults) are
+    auto-discovered as configurable, persisted parameters. The reserved kwarg name is "method".
+    """
+
+    name = None
+
+    def __init__(self, pulsedmeasurementlogic):
+        self.__pulsedmeasurementlogic = pulsedmeasurementlogic
+
+    # --- masked read-only access to the measurement logic ---
+    @property
+    def is_gated(self):
+        return self.__pulsedmeasurementlogic.fast_counter_settings.get('is_gated')
+
+    @property
+    def measurement_settings(self):
+        return self.__pulsedmeasurementlogic.measurement_settings
+
+    @property
+    def sampling_information(self):
+        return self.__pulsedmeasurementlogic.sampling_information
+
+    @property
+    def fast_counter_settings(self):
+        return self.__pulsedmeasurementlogic.fast_counter_settings
+
+    @property
+    def is_alternating(self):
+        return bool(self.measurement_settings.get('alternating'))
+
+    @property
+    def data_labels(self):
+        labels = self.measurement_settings.get('labels')
+        return tuple(labels) if labels else ('', '')
+
+    @property
+    def data_units(self):
+        units = self.measurement_settings.get('units')
+        return tuple(units) if units else ('', '')
+
+    @property
+    def log(self):
+        return self.__pulsedmeasurementlogic.log
+
+    # --- interface to implement ---
+    def compute(self, signal_data):
+        """ Transform ``signal_data`` (row 0: x-axis, rows 1..: trace(s); row 2 is the alternating
+        trace) into a 2D array with the same layout. Return None if it cannot be evaluated; the
+        caller then falls back to a flat default plot. """
+        raise NotImplementedError('Alternative plot methods must implement "compute".')
+
+    def is_available(self):
+        """ Whether the method may be selected/computed for the active measurement settings. """
+        return True
+
+    # Default axis labels mirror the primary data; the figure/GUI prepends an SI prefix to x_unit.
+    @property
+    def x_axis_label(self):
+        return self.data_labels[0]
+
+    @property
+    def x_axis_unit(self):
+        return self.data_units[0]
+
+    @property
+    def y_axis_label(self):
+        return self.data_labels[1]
+
+    @property
+    def y_axis_unit(self):
+        return self.data_units[1]
+
+    @property
+    def labels_dict(self):
+        """ Axis labels as primitive strings. """
+        return {'x_label': str(self.x_axis_label), 'x_unit': str(self.x_axis_unit),
+                'y_label': str(self.y_axis_label), 'y_unit': str(self.y_axis_unit)}
+
+
+class AltPlotAnalyzer(AltPlotMethodBase):
+    """ Discovers, instantiates and interfaces all available ``AltPlotMethodBase`` subclasses.
+
+    Methods are imported from the ``qudi.logic.pulsed.alt_plot_methods`` namespace package and from
+    the optional ``PulsedMeasurementLogic.alt_plot_import_path`` directory. The selected method and
+    all parameters are persisted by the measurement logic in a single StatusVar.
+    """
+
+    def __init__(self, pulsedmeasurementlogic):
+        super().__init__(pulsedmeasurementlogic)
+        self._methods = dict()      # {name: instance}
+        self._parameters = dict()   # union of all compute() kwargs
+        self._current_method = None  # None => no alternative plot
+
+        # Import from the default namespace package
+        import qudi.logic.pulsed.alt_plot_methods as default_ns
+        method_classes = list()
+        for mod_finder in iter_modules_recursive(default_ns.__path__, default_ns.__name__ + '.'):
+            try:
+                module = importlib.import_module(mod_finder.name)
+                method_classes.extend(c for _, c in inspect.getmembers(module, self.is_alt_plot_class))
+            except:
+                self.log.exception(f'Exception while importing alt_plot_methods sub-module '
+                                   f'"{mod_finder.name}":')
+
+        # Import from the optional additional directory
+        import_path = getattr(pulsedmeasurementlogic, 'alt_plot_import_path', None)
+        if isinstance(import_path, str):
+            try:
+                method_classes.extend(self.__import_external_methods(import_path))
+            except:
+                self.log.exception(f'Unable to import alternative plot methods from '
+                                   f'"{import_path}":')
+
+        for cls in method_classes:
+            instance = cls(pulsedmeasurementlogic)
+            method_name = instance.name if instance.name else cls.__name__
+            if method_name in self._methods:
+                self.log.warning(f'Duplicate alternative plot method name "{method_name}". '
+                                 f'Overwriting the previously registered one.')
+            self._methods[method_name] = instance
+            self._parameters.update(self._get_method_kwargs(instance.compute))
+
+        # Restore persisted selection and parameters if handed over
+        stored = getattr(pulsedmeasurementlogic, 'alt_plot_parameters', None)
+        if isinstance(stored, dict):
+            self.alt_plot_settings = {k: v for k, v in stored.items()
+                                      if k == 'method' or k in self._parameters}
+
+    @property
+    def alt_plot_methods(self):
+        """ Naturally sorted list of all available method names. """
+        return natural_sort(self._methods)
+
+    @property
+    def current_method(self):
+        return self._current_method
+
+    @current_method.setter
+    def current_method(self, name):
+        if name in (None, '', 'None'):
+            self._current_method = None
+        elif name in self._methods:
+            self._current_method = name
+        else:
+            self.log.error(f'Alternative plot method "{name}" not found in AltPlotAnalyzer.')
+
+    @property
+    def alt_plot_settings(self):
+        """ Current method's parameters plus the selected method name (key "method"). """
+        method = self._methods.get(self._current_method)
+        settings = self._get_method_kwargs(method.compute) if method is not None else dict()
+        settings['method'] = self._current_method
+        return settings
+
+    @alt_plot_settings.setter
+    def alt_plot_settings(self, settings_dict):
+        if not isinstance(settings_dict, dict):
+            return
+        for parameter, value in settings_dict.items():
+            if parameter == 'method':
+                self.current_method = value
+            elif parameter in self._parameters:
+                self._parameters[parameter] = value
+            else:
+                self.log.warning(f'No alternative plot parameter "{parameter}" in AltPlotAnalyzer. '
+                                 f'Ignoring it.')
+
+    @property
+    def full_settings_dict(self):
+        """ All parameters plus the current method, for persisting in a StatusVar. """
+        settings = self._parameters.copy()
+        settings['method'] = self._current_method
+        return settings
+
+    @property
+    def alt_plot_labels(self):
+        """ {method_name: labels_dict} for every method (primitive strings; rpyc-safe). """
+        return {name: instance.labels_dict for name, instance in self._methods.items()}
+
+    @property
+    def current_labels(self):
+        method = self._methods.get(self._current_method)
+        return method.labels_dict if method is not None else dict()
+
+    def is_available(self, name=None):
+        """ Whether the given (default: current) method can be used for the active settings. """
+        method = self._methods.get(self._current_method if name is None else name)
+        if method is None:
+            return False
+        try:
+            return bool(method.is_available())
+        except:
+            self.log.exception(f'Error checking availability of alternative plot method "{name}":')
+            return False
+
+    def compute_alt_data(self, signal_data):
+        """ Evaluate the current method, or return None if none selected/unavailable/not evaluable. """
+        if self._current_method is None or not self.is_available(self._current_method):
+            return None
+        method = self._methods[self._current_method]
+        return method.compute(signal_data=signal_data, **self._get_method_kwargs(method.compute))
+
+    # --- helpers ---
+    def _get_method_kwargs(self, compute_method):
+        """ Build the kwargs (other than ``signal_data``) for a compute method, preferring stored
+        parameter values over the signature defaults (matching by data type). """
+        kwargs = dict()
+        for name, param in inspect.signature(compute_method).parameters.items():
+            if name == 'signal_data':
+                continue
+            stored = self._parameters.get(name)
+            kwargs[name] = stored if type(stored) == type(param.default) else param.default
+        return kwargs
+
+    def __import_external_methods(self, path):
+        if path not in sys.path:
+            sys.path.append(path)
+        class_list = list()
+        for name in os.listdir(path):
+            if name.endswith('.py') and os.path.isfile(os.path.join(path, name)):
+                module = importlib.reload(importlib.import_module(name[:-3]))
+                class_list.extend(c for _, c in inspect.getmembers(module, self.is_alt_plot_class))
+        return class_list
+
+    @staticmethod
+    def is_alt_plot_class(obj):
+        """ True if obj inherits exclusively from AltPlotMethodBase. """
+        return inspect.isclass(obj) and obj.__bases__ == (AltPlotMethodBase,)

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -356,6 +356,14 @@ class PulsedMasterLogic(LogicBase):
         return self.pulsedmeasurementlogic().analysis_methods
 
     @property
+    def alt_plot_methods(self):
+        return self.pulsedmeasurementlogic().alt_plot_methods
+
+    @property
+    def alt_plot_labels(self):
+        return self.pulsedmeasurementlogic().alt_plot_labels
+
+    @property
     def extraction_methods(self):
         return self.pulsedmeasurementlogic().extraction_methods
 

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -33,12 +33,12 @@ from qudi.core.module import LogicBase
 from qudi.util.mutex import Mutex
 from qudi.util.network import netobtain
 from qudi.util.datafitting import FitConfigurationsModel, FitContainer
-from qudi.util.math import compute_ft
 from qudi.util.datastorage import TextDataStorage, CsvDataStorage, NpyDataStorage
 from qudi.util.units import ScaledFloat
 from qudi.util.colordefs import QudiMatplotlibStyle
 from qudi.logic.pulsed.pulse_extractor import PulseExtractor
 from qudi.logic.pulsed.pulse_analyzer import PulseAnalyzer
+from qudi.logic.pulsed.pulse_alt_plot import AltPlotAnalyzer
 
 from qudi.interface.pulser_interface import PulserInterface
 from qudi.interface.fast_counter_interface import FastCounterInterface
@@ -82,6 +82,8 @@ class PulsedMeasurementLogic(LogicBase):
     # Optional additional paths to import from
     extraction_import_path = ConfigOption(name='additional_extraction_path', default=None)
     analysis_import_path = ConfigOption(name='additional_analysis_path', default=None)
+    # Optional additional path to import alternative (second) plot methods from
+    alt_plot_import_path = ConfigOption(name='additional_alt_plot_path', default=None)
     # Optional file type descriptor for saving raw data to file.
     # todo: doesn't warn if checker not satisfied
     _default_data_storage_cls = ConfigOption(name='default_data_storage_type',
@@ -127,12 +129,11 @@ class PulsedMeasurementLogic(LogicBase):
     # Data fitting
     _fit_configs = StatusVar(name='fit_configs', default=None)
 
-    # alternative signal computation settings:
-    _alternative_data_type = StatusVar(default=None)
-    zeropad = StatusVar(default=0)
-    psd = StatusVar(default=False)
-    window = StatusVar(default='none')
-    base_corr = StatusVar(default=True)
+    # alternative (second) plot settings:
+    # Holds the full parameter set of all alternative plot methods plus the currently selected
+    # method (key "method"), persisted analogously to analysis_parameters. Managed by
+    # AltPlotAnalyzer.
+    alt_plot_parameters = StatusVar(default=None)
 
     # notification signals for master module (i.e. GUI)
     sigMeasurementDataUpdated = QtCore.Signal()
@@ -244,6 +245,11 @@ class PulsedMeasurementLogic(LogicBase):
         self._time_of_pause = None
         self._elapsed_pause = 0
 
+        # method manager instances (created in on_activate)
+        self._pulseextractor = None
+        self._pulseanalyzer = None
+        self._altplotanalyzer = None
+
         # for fit:
         self.fit_config_model = None  # Model for custom fit configurations
         self.fc = None  # Fit container
@@ -257,6 +263,8 @@ class PulsedMeasurementLogic(LogicBase):
         # Create an instance of PulseExtractor
         self._pulseextractor = PulseExtractor(pulsedmeasurementlogic=self)
         self._pulseanalyzer = PulseAnalyzer(pulsedmeasurementlogic=self)
+        # Create an instance of the alternative (second) plot manager
+        self._altplotanalyzer = AltPlotAnalyzer(pulsedmeasurementlogic=self)
 
         # QTimer must be created here instead of __init__ because otherwise the timer will not run
         # in this logic's thread but in the manager instead.
@@ -322,6 +330,10 @@ class PulsedMeasurementLogic(LogicBase):
     @analysis_parameters.representer
     def __repr_analysis_parameters(self, value):
         return self._pulseanalyzer.full_settings_dict
+
+    @alt_plot_parameters.representer
+    def __repr_alt_plot_parameters(self, value):
+        return self._altplotanalyzer.full_settings_dict
 
     @_fit_configs.representer
     def __repr_fit_configs(self, value):
@@ -719,13 +731,24 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def alternative_data_type(self):
-        return str(self._alternative_data_type)
+        method = self._altplotanalyzer.current_method
+        return str(method) if method is not None else 'None'
 
     @alternative_data_type.setter
     def alternative_data_type(self, alt_data_type):
         if isinstance(alt_data_type, str) or alt_data_type is None:
             self.set_alternative_data_type(alt_data_type)
         return
+
+    @property
+    def alt_plot_methods(self):
+        """ Naturally sorted list of available alternative (second) plot method names. """
+        return self._altplotanalyzer.alt_plot_methods
+
+    @property
+    def alt_plot_labels(self):
+        """ Axis labels for every alternative plot method (dict of primitive strings). """
+        return self._altplotanalyzer.alt_plot_labels
 
     @property
     def analysis_methods(self):
@@ -1070,24 +1093,23 @@ class PulsedMeasurementLogic(LogicBase):
 
     @QtCore.Slot(str)
     def set_alternative_data_type(self, alt_data_type):
-        """
-
-        @param alt_data_type:
-        @return:
-        """
+        """ Set the selected alternative (second) plot method by name ('None'/None disables it). """
         with self._threadlock:
             if alt_data_type != self.alternative_data_type:
                 self.do_fit('No Fit', True)
-            if alt_data_type == 'Delta' and not self._alternating:
-                if self._alternative_data_type == 'Delta':
-                    self._alternative_data_type = None
-                self.log.error('Can not set "Delta" as alternative data calculation if measurement is '
-                               'not alternating.\n'
-                               'Setting to previous type "{0}".'.format(self.alternative_data_type))
-            elif alt_data_type == 'None':
-                self._alternative_data_type = None
+
+            if alt_data_type in (None, 'None', ''):
+                self._altplotanalyzer.current_method = None
+            elif alt_data_type not in self._altplotanalyzer.alt_plot_methods:
+                self.log.error('Unknown alternative plot method "{0}". Keeping previous type "{1}".'
+                               ''.format(alt_data_type, self.alternative_data_type))
+            elif not self._altplotanalyzer.is_available(alt_data_type):
+                self.log.error('Alternative plot method "{0}" is not available for the current '
+                               'measurement settings. Disabling alternative plot.'
+                               ''.format(alt_data_type))
+                self._altplotanalyzer.current_method = None
             else:
-                self._alternative_data_type = alt_data_type
+                self._altplotanalyzer.current_method = alt_data_type
 
             self._compute_alt_data()
             self.sigMeasurementDataUpdated.emit()
@@ -1639,7 +1661,9 @@ class PulsedMeasurementLogic(LogicBase):
         x_axis_scaled = self.signal_data[0] / scaled_float.scale_val
 
         # Create the figure object
-        if self._alternative_data_type and self._alternative_data_type != 'None':
+        alt_type = self.alternative_data_type
+        alt_active = bool(alt_type) and alt_type != 'None'
+        if alt_active:
             fig, (ax1, ax2) = plt.subplots(2, 1)
         else:
             fig, ax1 = plt.subplots()
@@ -1670,7 +1694,7 @@ class PulsedMeasurementLogic(LogicBase):
             _plot_fit(axis=ax1)
 
         # handle the save of the alternative data plot
-        if self._alternative_data_type and self._alternative_data_type != 'None':
+        if alt_active:
 
             # scale the x_axis for plotting
             max_val = np.max(self.signal_alt_data[0])
@@ -1678,30 +1702,24 @@ class PulsedMeasurementLogic(LogicBase):
             x_axis_prefix = scaled_float.scale
             x_axis_ft_scaled = self.signal_alt_data[0] / scaled_float.scale_val
 
-            # since no ft units are provided, make a small work around:
-            if self._alternative_data_type == 'FFT':
-                if self._data_units[0] == 's':
-                    inverse_cont_var = 'Hz'
-                elif self._data_units[0] == 'Hz':
-                    inverse_cont_var = 's'
-                else:
-                    inverse_cont_var = '(1/{0})'.format(self._data_units[0])
-                x_axis_ft_label = 'FT {0} ({1}{2})'.format(
-                    self._data_labels[0], x_axis_prefix, inverse_cont_var)
-                y_axis_ft_label = 'FT({0}) (arb. u.)'.format(self._data_labels[1])
-                ft_label = 'FT of data trace 1'
-            else:
-                if self._data_units[0]:
-                    x_axis_ft_label = '{0} ({1}{2})'.format(self._data_labels[0], x_axis_prefix,
-                                                            self._data_units[0])
-                else:
-                    x_axis_ft_label = '{0}'.format(self._data_labels[0])
-                if self._data_units[1]:
-                    y_axis_ft_label = '{0} ({1})'.format(self._data_labels[1], self._data_units[1])
-                else:
-                    y_axis_ft_label = '{0}'.format(self._data_labels[1])
+            # Axis labels are provided by the selected alternative plot method. The x-axis unit is
+            # prefixed with the SI scale of the (scaled) x-axis; the y-axis is not scaled.
+            alt_labels = self._altplotanalyzer.current_labels
+            x_alt_label = alt_labels.get('x_label', '')
+            x_alt_unit = alt_labels.get('x_unit', '')
+            y_alt_label = alt_labels.get('y_label', '')
+            y_alt_unit = alt_labels.get('y_unit', '')
 
-                ft_label = '{0} of data traces'.format(self._alternative_data_type)
+            if x_alt_unit:
+                x_axis_ft_label = '{0} ({1}{2})'.format(x_alt_label, x_axis_prefix, x_alt_unit)
+            else:
+                x_axis_ft_label = '{0}'.format(x_alt_label)
+            if y_alt_unit:
+                y_axis_ft_label = '{0} ({1})'.format(y_alt_label, y_alt_unit)
+            else:
+                y_axis_ft_label = '{0}'.format(y_alt_label)
+
+            ft_label = '{0} of data trace 1'.format(alt_type)
 
             ax2.plot(x_axis_ft_scaled, self.signal_alt_data[1],
                      linestyle=':', linewidth=0.5, color=colors[0],
@@ -1742,30 +1760,20 @@ class PulsedMeasurementLogic(LogicBase):
 
     def _compute_alt_data(self):
         """
-        Performing transformations on the measurement data (e.g. fourier transform).
+        Compute the alternative (second) plot data via the selected alternative plot method. Falls
+        back to a flat default plot if no method is selected, it is unavailable, or it fails.
         """
-        if self._alternative_data_type == 'Delta' and len(self.signal_data) == 3:
-            self.signal_alt_data = np.empty((2, self.signal_data.shape[1]), dtype=float)
-            self.signal_alt_data[0] = self.signal_data[0]
-            self.signal_alt_data[1] = self.signal_data[1] - self.signal_data[2]
-        elif self._alternative_data_type == 'FFT' and self.signal_data.shape[1] >= 2:
-            fft_x, fft_y = compute_ft(x_val=self.signal_data[0],
-                                      y_val=self.signal_data[1],
-                                      zeropad_num=self.zeropad,
-                                      window=self.window,
-                                      base_corr=self.base_corr,
-                                      psd=self.psd)
-            self.signal_alt_data = np.empty((len(self.signal_data), len(fft_x)), dtype=float)
-            self.signal_alt_data[0] = fft_x
-            self.signal_alt_data[1] = fft_y
-            for dim in range(2, len(self.signal_data)):
-                dummy, self.signal_alt_data[dim] = compute_ft(x_val=self.signal_data[0],
-                                                              y_val=self.signal_data[dim],
-                                                              zeropad_num=self.zeropad,
-                                                              window=self.window,
-                                                              base_corr=self.base_corr,
-                                                              psd=self.psd)
-        else:
+        alt_data = None
+        try:
+            alt_data = self._altplotanalyzer.compute_alt_data(self.signal_data)
+        except:
+            self.log.exception('Error while computing alternative plot data:')
+            alt_data = None
+
+        if alt_data is None:
             self.signal_alt_data = np.zeros(self.signal_data.shape, dtype=float)
-            self.signal_alt_data[0] = self.signal_data[0]
+            if self.signal_data.shape[1] > 0:
+                self.signal_alt_data[0] = self.signal_data[0]
+        else:
+            self.signal_alt_data = alt_data
         return


### PR DESCRIPTION
Make the analysis-tab alternative plot extensible via a base class

## Description
The "alternative plot" (second plot) in the pulsed analysis tab previously supported only
FFT and Delta, with the computation and axis labels hardcoded in `PulsedMeasurementLogic`
and the GUI dropdown items hardcoded in the `.ui`. This PR replaces that with a discovery-
based plugin architecture mirroring `PulseAnalyzer`/`PulseExtractor`: users add a method by
dropping a subclass of `AltPlotMethodBase` into a folder, and it automatically becomes
selectable in the GUI. FFT and Delta are reimplemented as the first two such methods.

Adding a new alternative plot method :
Subclass `AltPlotMethodBase`, set a unique `name`, and implement
`compute(self, signal_data, **kwargs)` returning a 2D array (row 0 = x-axis, rows 1.. = data)
or `None` to fall back to a flat plot. Any keyword arguments of `compute` (with correctly-
typed defaults) are auto-discovered as configurable, persisted parameters. Optionally override
`is_available()` (e.g. require an alternating measurement) and the `x_axis_*`/`y_axis_*` label
properties. The method then appears in the analysis-tab dropdown automatically.

Look at the existing FFT and Delta plots that have have been reimplemented in 'basic_alt_plot_methods.py'. Any new plots can be added similarly.


## How Has This Been Tested?
This has been tested locally with dummy hardware modules.

## Screenshots (only if appropriate, delete if not):

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
