### PR TITLE
fix ni io samples_in_buffer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
 - Fixed `sequence_generator_logic` configuration in `default.cfg`
 - Fix several `POIManagerGUI` `PySide6` bugs
 - Fix discovery of `AltPlotMethodBase` subclasses
+- Fix NI IO for only analog input channels.
 
 ### New Features
 - Added hardware file `hardware.ni_x_series.ni_x_series_counter` to use NI 63xx cards as fastcounters for pulsed measurements.

--- a/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_io.py
+++ b/src/qudi/hardware/ni_x_series/ni_x_series_finite_sampling_io.py
@@ -468,9 +468,9 @@ class NIXSeriesFiniteSamplingIO(FiniteSamplingIOInterface):
         if not self.is_running:
             return self._number_of_pending_samples
 
-        if self._ai_task_handle is None and self._di_task_handles is not None:
+        if self._ai_task_handle is None and len(self._di_task_handles) > 0:
             return self._di_task_handles[0].in_stream.avail_samp_per_chan
-        elif self._ai_task_handle is not None and self._di_task_handles is None:
+        elif self._ai_task_handle is not None and len(self._di_task_handles) == 0:
             return self._ai_task_handle.in_stream.avail_samp_per_chan
         else:
             return min(self._ai_task_handle.in_stream.avail_samp_per_chan,


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
Check the length of `_di_task_handles` instead of checking if it is `None`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I ran into this issue when I tried to configure only an analog input and no digital inputs. The method samples_in_buffer differentiates betwen three cases:

- no analog inputs, only digital inputs
- only analog inputs, no digital inputs
- both analog and digital inputs

to correctly compute the number of samples available in the buffer. If no digital inputs are configured, `_di_task_handles` is an empty list, and not `None`. Therefore, the checking fails and the third case is assumed incorrectly, which leads to an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Configured the NI IO with only digital, only analog and both analog and digital channels.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
