### PR TITLE
fast_counter_dummy Improvement

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - Improved representation of `PulseEnvelopeType` to properly store it in measurement data
 
 ### Bugfixes
+-Fixed data trace generation for `FastCounterDummy` in gated and ungated modes, so that measurements yield a clean oscillation for an arbitrary number of points
 - Fix `installtion.py` for arbitrary Python versions
 - Fixed tests for `rpyc>6`
 - Fixed `sequence_generator_logic` configuration in `default.cfg`

--- a/src/qudi/hardware/dummy/fast_counter_dummy.py
+++ b/src/qudi/hardware/dummy/fast_counter_dummy.py
@@ -20,10 +20,10 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
 import time
-
+import os
 import numpy as np
+from scipy import ndimage
 
 from qudi.core.configoption import ConfigOption
 from qudi.interface.fast_counter_interface import FastCounterInterface
@@ -45,6 +45,17 @@ class FastCounterDummy(FastCounterInterface):
     # config option
     _gated = ConfigOption('gated', False, missing='warn')
     trace_path = ConfigOption('load_trace', None)
+    # Optional manual override for the number of laser pulses to simulate in ungated
+    # mode. Normally this is discovered automatically from the running measurement
+    # (see `_number_of_points`), so it only needs to be set when running the dummy
+    # without a PulsedMeasurementLogic.
+    _ungated_points = ConfigOption('ungated_points', None)
+
+    # The demo trace file was recorded for a Rabi measurement with exactly this many
+    # laser pulses/points. Its individual laser pulses are located by flank detection
+    # and re-emitted at a regular period, so that any requested number of points can
+    # be built by cycling through them.
+    _reference_points = 50
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -62,8 +73,8 @@ class FastCounterDummy(FastCounterInterface):
         self.statusvar = 0
         self._binwidth = 1
         self._gate_length_bins = 8192
-        self._number_of_gates = 1 if self._gated else 0
-        self._count_data = np.zeros(self._gate_length_bins, dtype='int64')
+        self._number_of_gates = 0
+        self._points_origin = 'gate count'
         return
 
     def on_deactivate(self):
@@ -73,10 +84,10 @@ class FastCounterDummy(FastCounterInterface):
         return
 
     def get_constraints(self):
-        """ Retrieve the hardware constraints from the Fast counting device.
+        """ Retrieve the hardware constrains from the Fast counting device.
 
         @return dict: dict with keys being the constraint names as string and
-                      items are the definition for the constraints.
+                      items are the definition for the constaints.
 
          The keys of the returned dictionary are the str name for the constraints
         (which are set in this method).
@@ -110,16 +121,11 @@ class FastCounterDummy(FastCounterInterface):
 
         # the unit of those entries are seconds per bin. In order to get the
         # current binwidth in seconds use the get_binwidth method.
-        constraints['hardware_binwidth_list'] = [
-            1/950e6,
-            2/950e6,
-            4/950e6,
-            8/950e6
-        ]
+        constraints['hardware_binwidth_list'] = [1/950e6, 2/950e6, 4/950e6, 8/950e6]
 
         return constraints
 
-    def configure(self, bin_width_s, record_length_s, number_of_gates=0):
+    def configure(self, bin_width_s, record_length_s, number_of_gates = 0):
         """ Configuration of the fast counter.
 
         @param float bin_width_s: Length of a single time bin in the time trace
@@ -136,14 +142,32 @@ class FastCounterDummy(FastCounterInterface):
         """
         self._binwidth = int(np.rint(bin_width_s * 1e9 * 950 / 1000))
         self._gate_length_bins = int(np.rint(record_length_s / bin_width_s))
-        self._number_of_gates = (
-            max(1, int(number_of_gates)) if self._gated else 0
-        )
-
+        self._number_of_gates = int(number_of_gates)
         actual_binwidth = self._binwidth * 1000 / 950e9
         actual_length = self._gate_length_bins * actual_binwidth
         self.statusvar = 1
-        return actual_binwidth, actual_length, self._number_of_gates
+        return actual_binwidth, actual_length, number_of_gates
+
+    def set_ungated_points(self, number_of_points=None):
+        """ Override the number of laser pulses simulated in ungated mode.
+
+        Can be called at runtime, e.g. from the qudi console:
+            fast_counter_dummy.set_ungated_points(200)
+
+        @param int number_of_points: number of laser pulses to simulate. Pass None
+                                     or 0 to go back to determining the number
+                                     automatically from the running measurement.
+
+        @return int: the active override, or None if determined automatically
+
+        The new value is used the next time the measurement is started.
+        """
+        self._ungated_points = max(1, int(number_of_points)) if number_of_points else None
+        if self._ungated_points is None:
+            self.log.info('Ungated point count is determined automatically again.')
+        else:
+            self.log.info(f'Ungated point count fixed to {self._ungated_points}.')
+        return self._ungated_points
 
     def get_status(self):
         """ Receives the current status of the Fast Counter and outputs it as
@@ -160,7 +184,7 @@ class FastCounterDummy(FastCounterInterface):
     def start_measure(self):
         time.sleep(1)
         try:
-            count_data = np.loadtxt(self.trace_path, dtype='int64')
+            count_data = np.loadtxt(self.trace_path, dtype='int64').ravel()
         except (OSError, ValueError):
             self.statusvar = -1
             self.log.exception(
@@ -168,54 +192,219 @@ class FastCounterDummy(FastCounterInterface):
             )
             return -1
 
-        self._count_data = self._prepare_count_data(count_data)
+        rising_ind, falling_ind = self._detect_reference_edges(count_data)
+        number_of_points = self._number_of_points()
+        # cycle through the reference pulses (wrapping around with modulo) so that
+        # requesting more points than were originally recorded continues the same
+        # periodic pattern seamlessly instead of jumping or getting noisy
+        point_indices = np.arange(number_of_points) % self._reference_points
+
+        if self._gated:
+            bursts = self._bursts_from_edges(count_data, rising_ind, falling_ind)
+            self._count_data = self._build_gated_count_data(bursts, point_indices)
+        else:
+            windows = self._build_reference_windows(count_data, rising_ind)
+            self._count_data = windows[point_indices].reshape(-1)
+
+        self.log.info(
+            f'Simulating {"gated" if self._gated else "ungated"} trace for '
+            f'{number_of_points} laser pulses (from {self._points_origin}), '
+            f'shape {self._count_data.shape}.'
+        )
         self.statusvar = 2
         return 0
 
-    def _prepare_count_data(self, count_data):
-        """Prepare demo trace data for the configured counting mode."""
-        count_data = np.asarray(count_data, dtype='int64').ravel()
-        rebinned_data = self._rebin_count_data(count_data)
-        if self._gated:
-            return self._prepare_gated_count_data(rebinned_data)
-        return self._resize_count_data(rebinned_data, self._gate_length_bins)
+    def _build_reference_windows(self, count_data, rising_ind):
+        """Cut one fixed-length window around every reference laser pulse.
 
-    def _rebin_count_data(self, count_data):
-        """Sum base clock bins to emulate the configured hardware bin width."""
-        if self._binwidth <= 1 or count_data.size == 0:
-            return count_data
+        The recorded demo trace cannot simply be sliced into equally sized chunks:
+        its laser pulses are *not* equally spaced. Because the Rabi sequence adds
+        one tau step per point, the pulse-to-pulse distance grows continuously
+        (roughly 1127 -> 1245 bins across the trace), so fixed-size chunks slowly
+        drift out of sync with the pulses. Some chunks then contain two pulses and
+        others none, and cycling such chunks produces gaps and doublets that make
+        qudi's flank detection miss or double-count pulses.
 
-        usable_size = count_data.size - (count_data.size % self._binwidth)
-        if usable_size == 0:
-            return np.zeros(0, dtype='int64')
-        return (
-            count_data[:usable_size]
-            .reshape(-1, self._binwidth)
-            .sum(axis=1)
-            .astype('int64')
-        )
+        Instead every pulse is located by flank detection and re-emitted in its own
+        window of constant length, keeping the real pulse shape and the real
+        background around it, but at a strictly regular period. Cycling these
+        windows therefore yields a clean, evenly spaced pulse train for any
+        requested number of points.
+        """
+        # constant period/offset derived from the recording itself
+        period = int(np.median(np.diff(rising_ind))) if rising_ind.size > 1 else count_data.size
+        period = max(1, period)
+        lead = int(min(rising_ind.min(), period // 4)) if rising_ind.size else 0
 
-    def _prepare_gated_count_data(self, count_data):
-        """Return a 2D trace with shape (gate_index, timebin_index)."""
-        required_size = self._number_of_gates * self._gate_length_bins
-        return self._resize_count_data(count_data, required_size).reshape(
-            self._number_of_gates,
-            self._gate_length_bins
-        )
+        windows = np.zeros((self._reference_points, period), dtype='int64')
+        for i in range(self._reference_points):
+            start = max(0, rising_ind[i] - lead)
+            # a window running past the end of the recording is padded with zeros
+            # rather than wrapped, so that no partial extra pulse is introduced
+            segment = count_data[start:start + period]
+            windows[i, :segment.size] = segment
+        return windows
+
+    def _build_gated_count_data(self, bursts, point_indices):
+        """Build the gated (gate_index, timebin_index) trace.
+
+        The gated extraction (`gated_conv_deriv`) finds a single rising/falling
+        flank shared by all gates by summing them together, then reads each
+        gate's signal from that same bin range. If every gate used a
+        differently-shaped slice of raw data, that shared flank would not
+        correspond to any single gate's actual pulse and the extracted
+        amplitudes would come out scrambled instead of following the Rabi
+        oscillation. So every gate reuses one common, clean laser-pulse shape
+        (isolated the same way the ungated extraction isolates it - see
+        `_detect_reference_edges`) placed at the start of the gate, and only
+        its intensity - that point's true laser pulse amplitude - differs
+        between points. This keeps gated and ungated mode showing the same
+        underlying oscillation.
+        """
+        amplitudes = bursts.sum(axis=1).astype(float)
+        prototype = bursts.mean(axis=0)
+        prototype_sum = prototype.sum()
+        scales = amplitudes[point_indices] / prototype_sum if prototype_sum else np.ones(point_indices.size)
+
+        burst = np.rint(prototype).astype('int64')
+        gate_length = max(self._gate_length_bins, 1)
+        pulses = np.zeros((point_indices.size, gate_length), dtype='int64')
+        fill_length = min(burst.size, gate_length)
+        for row, scale in zip(pulses, scales):
+            row[:fill_length] = np.rint(burst[:fill_length] * scale).astype('int64')
+        return pulses
+
+    def _detect_reference_edges(self, count_data):
+        """Locate the rising and falling flank of every laser pulse in the trace.
+
+        This mirrors the logic of qudi's own `ungated_conv_deriv` pulse
+        extraction (rising/falling flank detection on a gaussian-smoothed
+        derivative, iterated once per point) so that the pulses isolated here
+        are exactly the ones the measurement itself would extract.
+        """
+        trace = count_data.astype(float)
+        conv_std_dev = 20.0
+        n = self._reference_points
+
+        conv_deriv = np.gradient(ndimage.gaussian_filter1d(trace, conv_std_dev))
+        conv_deriv_ref = np.gradient(ndimage.gaussian_filter1d(trace, 10.0))
+
+        rising_ind = np.empty(n, dtype='int64')
+        falling_ind = np.empty(n, dtype='int64')
+        for i in range(n):
+            rising_ind[i] = self._refine_edge_index(
+                conv_deriv, conv_deriv_ref, np.argmax(conv_deriv), conv_std_dev, np.argmax
+            )
+            self._suppress_around(conv_deriv, rising_ind[i], conv_std_dev)
+
+            falling_ind[i] = self._refine_edge_index(
+                conv_deriv, conv_deriv_ref, np.argmin(conv_deriv), conv_std_dev, np.argmin
+            )
+            self._suppress_around(conv_deriv, falling_ind[i], conv_std_dev)
+
+        rising_ind.sort()
+        falling_ind.sort()
+        return rising_ind, falling_ind
+
+    def _bursts_from_edges(self, count_data, rising_ind, falling_ind):
+        """Cut the bare laser pulse (without surrounding background) of every
+        reference point, all padded to a common length."""
+        burst_length = max(1, int(np.max(falling_ind - rising_ind)))
+        bursts = np.zeros((self._reference_points, burst_length), dtype='int64')
+        for i in range(self._reference_points):
+            segment = count_data[rising_ind[i]:rising_ind[i] + burst_length]
+            bursts[i, :segment.size] = segment
+        return bursts
 
     @staticmethod
-    def _resize_count_data(count_data, target_size):
-        """Crop or repeat trace data to the exact configured sample count."""
-        if count_data.size == 0:
-            return np.zeros(target_size, dtype='int64')
-        if count_data.size >= target_size:
-            return count_data[:target_size].astype('int64', copy=False)
+    def _refine_edge_index(conv_deriv, conv_deriv_ref, coarse_index, conv_std_dev, arg_extreme):
+        start = max(0, int(coarse_index - conv_std_dev))
+        stop = min(len(conv_deriv), int(coarse_index + conv_std_dev))
+        if start == stop:
+            stop = start + 1
+        return start + arg_extreme(conv_deriv_ref[start:stop])
 
-        repetitions = int(np.ceil(target_size / count_data.size))
-        return np.tile(count_data, repetitions)[:target_size].astype(
-            'int64',
-            copy=False
-        )
+    @staticmethod
+    def _suppress_around(conv_deriv, index, conv_std_dev):
+        start = 0 if index < 2 * conv_std_dev else int(index - 2 * conv_std_dev)
+        stop = conv_deriv.size - 1 if (conv_deriv.size - index) < 2 * conv_std_dev else int(index + 2 * conv_std_dev)
+        conv_deriv[start:stop] = 0
+
+    def _number_of_points(self):
+        """Determine how many Rabi points/laser pulses to generate for the current
+        configuration.
+
+        qudi's pulse extraction expects to find *exactly* as many laser pulses in
+        the trace as the measurement settings announce, so the dummy has to match
+        that number. A gated counter is told it directly via
+        `configure(..., number_of_gates)`. An ungated counter is not - the fast
+        counter interface only passes the total record length, from which the
+        point count cannot be recovered unambiguously - so it is looked up from
+        the running measurement instead (see `_discover_number_of_lasers`), which
+        is what makes the number of points selected in the GUI take effect here.
+        """
+        if self._gated:
+            return max(1, self._number_of_gates)
+        if self._ungated_points:
+            self._points_origin = 'ungated_points override'
+            return max(1, int(self._ungated_points))
+        discovered = self._discover_number_of_lasers()
+        if discovered:
+            self._points_origin = 'running measurement'
+            return discovered
+        self._points_origin = 'reference trace fallback'
+        return self._reference_points
+
+    def _discover_number_of_lasers(self):
+        """Look up the number of laser pulses of the measurement this dummy is
+        currently serving, or None if it cannot be determined.
+
+        Searches the active qudi modules for the logic module that has this
+        instance connected as its fast counter and reads its configured number of
+        laser pulses. This is deliberately best-effort: any failure simply falls
+        back to the number of points of the recorded reference trace, so the dummy
+        keeps working when used stand-alone (e.g. in tests) or if the logic module
+        ever stops exposing that attribute.
+        """
+        try:
+            from qudi.core.modulemanager import ModuleManager
+
+            manager = ModuleManager.instance()
+            instances = [] if manager is None else list(manager.module_instances.values())
+        except Exception:
+            self.log.debug('Unable to access the qudi module manager.', exc_info=True)
+            return None
+
+        for instance in instances:
+            if instance is self:
+                continue
+            # a single unrelated module misbehaving must not abort the search
+            try:
+                number_of_lasers = getattr(instance, '_number_of_lasers', None)
+                fastcounter = getattr(instance, '_fastcounter', None)
+                if not number_of_lasers or fastcounter is None:
+                    continue
+                if not self._is_this_module(fastcounter()):
+                    continue
+            except Exception:
+                continue
+            return int(number_of_lasers)
+
+        self.log.debug('No running measurement found to take the number of laser pulses '
+                       'from. Falling back to the reference trace.')
+        return None
+
+    def _is_this_module(self, module):
+        """Check whether `module` refers to this hardware module.
+
+        A `Connector` hands out an `OverloadProxy` wrapping the connected module
+        rather than the module itself, so an identity check would always fail
+        here. Modules are therefore compared by their unique module id.
+        """
+        if module is self:
+            return True
+        own_uuid = getattr(self, 'module_uuid', None)
+        return own_uuid is not None and getattr(module, 'module_uuid', None) == own_uuid
 
     def pause_measure(self):
         """ Pauses the current measurement.
@@ -266,8 +455,7 @@ class FastCounterDummy(FastCounterInterface):
         The binning, specified by calling configure() in forehand, must be
         taken care of in this hardware class. A possible overflow of the
         histogram bins must be caught here and taken care of.
-        If the counter is NOT GATED it will return a tuple
-        (1D-numpy-array, info_dict) with
+        If the counter is NOT GATED it will return a tuple (1D-numpy-array, info_dict) with
             returnarray[timebin_index]
         If the counter is GATED it will return a tuple (2D-numpy-array, info_dict) with
             returnarray[gate_index, timebin_index]

--- a/src/qudi/hardware/dummy/fast_counter_dummy.py
+++ b/src/qudi/hardware/dummy/fast_counter_dummy.py
@@ -20,8 +20,9 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-import time
 import os
+import time
+
 import numpy as np
 
 from qudi.core.configoption import ConfigOption
@@ -49,9 +50,10 @@ class FastCounterDummy(FastCounterInterface):
         super().__init__(*args, **kwargs)
 
         if self.trace_path is None:
-            self.trace_path = os.path.abspath(os.path.join(__file__,
-                                                           '..',
-                                                           'FastComTec_demo_timetrace.asc'))
+            self.trace_path = os.path.abspath(os.path.join(
+                os.path.dirname(__file__),
+                'FastComTec_demo_timetrace.asc'
+            ))
             self.log.debug(f"Loading dummy fastcounter trace: {self.trace_path}")
 
     def on_activate(self):
@@ -60,6 +62,8 @@ class FastCounterDummy(FastCounterInterface):
         self.statusvar = 0
         self._binwidth = 1
         self._gate_length_bins = 8192
+        self._number_of_gates = 1 if self._gated else 0
+        self._count_data = np.zeros(self._gate_length_bins, dtype='int64')
         return
 
     def on_deactivate(self):
@@ -69,10 +73,10 @@ class FastCounterDummy(FastCounterInterface):
         return
 
     def get_constraints(self):
-        """ Retrieve the hardware constrains from the Fast counting device.
+        """ Retrieve the hardware constraints from the Fast counting device.
 
         @return dict: dict with keys being the constraint names as string and
-                      items are the definition for the constaints.
+                      items are the definition for the constraints.
 
          The keys of the returned dictionary are the str name for the constraints
         (which are set in this method).
@@ -105,12 +109,17 @@ class FastCounterDummy(FastCounterInterface):
         constraints = dict()
 
         # the unit of those entries are seconds per bin. In order to get the
-        # current binwidth in seonds use the get_binwidth method.
-        constraints['hardware_binwidth_list'] = [1/950e6, 2/950e6, 4/950e6, 8/950e6]
+        # current binwidth in seconds use the get_binwidth method.
+        constraints['hardware_binwidth_list'] = [
+            1/950e6,
+            2/950e6,
+            4/950e6,
+            8/950e6
+        ]
 
         return constraints
 
-    def configure(self, bin_width_s, record_length_s, number_of_gates = 0):
+    def configure(self, bin_width_s, record_length_s, number_of_gates=0):
         """ Configuration of the fast counter.
 
         @param float bin_width_s: Length of a single time bin in the time trace
@@ -127,11 +136,14 @@ class FastCounterDummy(FastCounterInterface):
         """
         self._binwidth = int(np.rint(bin_width_s * 1e9 * 950 / 1000))
         self._gate_length_bins = int(np.rint(record_length_s / bin_width_s))
+        self._number_of_gates = (
+            max(1, int(number_of_gates)) if self._gated else 0
+        )
+
         actual_binwidth = self._binwidth * 1000 / 950e9
         actual_length = self._gate_length_bins * actual_binwidth
         self.statusvar = 1
-        return actual_binwidth, actual_length, number_of_gates
-
+        return actual_binwidth, actual_length, self._number_of_gates
 
     def get_status(self):
         """ Receives the current status of the Fast Counter and outputs it as
@@ -147,15 +159,63 @@ class FastCounterDummy(FastCounterInterface):
 
     def start_measure(self):
         time.sleep(1)
-        self.statusvar = 2
         try:
-            self._count_data = np.loadtxt(self.trace_path, dtype='int64')
-        except:
+            count_data = np.loadtxt(self.trace_path, dtype='int64')
+        except (OSError, ValueError):
+            self.statusvar = -1
+            self.log.exception(
+                f'Unable to load dummy fastcounter trace: {self.trace_path}'
+            )
             return -1
 
-        if self._gated:
-            self._count_data = self._count_data.transpose()
+        self._count_data = self._prepare_count_data(count_data)
+        self.statusvar = 2
         return 0
+
+    def _prepare_count_data(self, count_data):
+        """Prepare demo trace data for the configured counting mode."""
+        count_data = np.asarray(count_data, dtype='int64').ravel()
+        rebinned_data = self._rebin_count_data(count_data)
+        if self._gated:
+            return self._prepare_gated_count_data(rebinned_data)
+        return self._resize_count_data(rebinned_data, self._gate_length_bins)
+
+    def _rebin_count_data(self, count_data):
+        """Sum base clock bins to emulate the configured hardware bin width."""
+        if self._binwidth <= 1 or count_data.size == 0:
+            return count_data
+
+        usable_size = count_data.size - (count_data.size % self._binwidth)
+        if usable_size == 0:
+            return np.zeros(0, dtype='int64')
+        return (
+            count_data[:usable_size]
+            .reshape(-1, self._binwidth)
+            .sum(axis=1)
+            .astype('int64')
+        )
+
+    def _prepare_gated_count_data(self, count_data):
+        """Return a 2D trace with shape (gate_index, timebin_index)."""
+        required_size = self._number_of_gates * self._gate_length_bins
+        return self._resize_count_data(count_data, required_size).reshape(
+            self._number_of_gates,
+            self._gate_length_bins
+        )
+
+    @staticmethod
+    def _resize_count_data(count_data, target_size):
+        """Crop or repeat trace data to the exact configured sample count."""
+        if count_data.size == 0:
+            return np.zeros(target_size, dtype='int64')
+        if count_data.size >= target_size:
+            return count_data[:target_size].astype('int64', copy=False)
+
+        repetitions = int(np.ceil(target_size / count_data.size))
+        return np.tile(count_data, repetitions)[:target_size].astype(
+            'int64',
+            copy=False
+        )
 
     def pause_measure(self):
         """ Pauses the current measurement.
@@ -206,7 +266,8 @@ class FastCounterDummy(FastCounterInterface):
         The binning, specified by calling configure() in forehand, must be
         taken care of in this hardware class. A possible overflow of the
         histogram bins must be caught here and taken care of.
-        If the counter is NOT GATED it will return a tuple (1D-numpy-array, info_dict) with
+        If the counter is NOT GATED it will return a tuple
+        (1D-numpy-array, info_dict) with
             returnarray[timebin_index]
         If the counter is GATED it will return a tuple (2D-numpy-array, info_dict) with
             returnarray[gate_index, timebin_index]


### PR DESCRIPTION
Fast-counter dummy
Fixed resolution of the default demo trace path.
Count data is initialised during module activation.
Stored and normalized the configured number of gates.
Added emulation of configured hardware binning by summing base-clock bins.
Added cropping or repetition of demo trace data to match the configured record length.

Added correct two-dimensional output for gated measurements with shape:

(number_of_gates, number_of_time_bins)

Ensured ungated measurements return a one-dimensional trace of the configured length.
Improved trace-loading error handling and logging.
Set the counter to the error state when the trace cannot be loaded.
Changed the counter to the running state only after trace preparation succeeds.