### PR TITLE
Pulsed dataclasses system 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Improved pulse envelope handling by introducing the `PulseEnvelope` `dataclass`
 - Improved representation of `DDMethods` to properly store it in measurement data
 - Improved representation of `PulseEnvelopeType` to properly store it in measurement data
+- `generation_parameters` is now a typed schema (`GenerationParameters`) rather than a free-form `dict`. Setting a name that is not part of it is rejected with a warning instead of silently added and persisted. Declare lab-specific parameters via `PredefinedGeneratorBase.generation_parameter_contributors` on the generator that needs them, or in `logic/pulsed/pulsed_data/generation_parameter_extensions.py` for the whole setup
 
 ### Bugfixes
 - Fix `installtion.py` for arbitrary Python versions
@@ -13,8 +14,10 @@
 - Fixed `sequence_generator_logic` configuration in `default.cfg`
 - Fix several `POIManagerGUI` `PySide6` bugs
 - Fix discovery of `AltPlotMethodBase` subclasses
+- Fixed generation parameters silently coming up empty on `Python 3.14`, which left the Predefined Methods tab without any parameter widgets and wrote an empty `generation_parameters` block to the status file
 
 ### New Features
+- Predefined generator classes can declare the global generation parameters they need via `generation_parameter_contributors`, including generators loaded through `additional_predefined_methods_path`
 - Added hardware file `hardware.ni_x_series.ni_x_series_counter` to use NI 63xx cards as fastcounters for pulsed measurements.
 - Added resizeable `PulseBlockEditor` columns in `pulsed_gui`
 - Added pulse shaping to the `pulsed` tool chain

--- a/docs/pulsed_dataclasses.md
+++ b/docs/pulsed_dataclasses.md
@@ -806,6 +806,13 @@ own `name`. Those flat keys are the long-standing readable convention, their nes
 removed without breaking reconstruction, and both copies are read off one object in one call, so
 they cannot diverge.
 
+One scalar was removed under that policy rather than kept: `'loaded asset type'`. It is the
+exception because it did not merely *duplicate* a value, it duplicated a **derivation** — the kind
+is already implied by which of `pulse objects`' fixed keys is populated, so keeping the string was
+a second, independently-writable answer to a question the structure already settles. `loaded asset
+name` fails that test and stays: nothing else in the file identifies which asset was loaded when a
+sequence references several ensembles.
+
 #### `PulsedData` *(mutable)*
 
 `measurement_data: PulsedMeasurementData` plus `fit_result` / `fit_result_alt`.
@@ -829,13 +836,45 @@ so there is no "at most one is set" invariant for `replace()` or a stray assignm
 follow the tri-state `getattr(x, 'is_sequence', None)` pattern, so an object that is not a pulse
 asset at all reads `None` from both rather than raising.
 
-`to_dict()` writes the asset under `loaded_sequence` or `loaded_ensemble` — the key names the kind,
-so a saved file never reads `sequence` while describing a `PulseBlockEnsemble` — and shows
-`ensembles` **only** for a sequence. A bare ensemble resolves nothing one level up, so the key is
-left out rather than written as an empty dict; an empty `ensembles` beside an ensemble was exactly
-the reading that used to confuse people. `from_dict()` branches on which key is present, and still
-reads the pre-split single `sequence` key by its `type` tag; `__setstate__` does the same for a
-`.pulsedmeasurement` pickled before the rename.
+`to_dict()` always writes exactly three keys — `sequence`, `ensembles`, `blocks` — whichever kind of
+asset is loaded. The kind is **not** encoded; it is reconstructed from the structure:
+
+```python
+if not data['sequence']:      # -> a PulseBlockEnsemble was loaded (or nothing was)
+```
+
+A loaded `PulseSequence` goes in `sequence`. A loaded bare `PulseBlockEnsemble` goes into
+`ensembles` instead — it resolves nothing one level up, so that slot is free — and `sequence` stays
+empty. Evaluation code therefore reads one fixed shape and never tests which keys are present,
+which is the whole reason for the layout: branching on key names is the cost that gets paid by
+every downstream consumer, forever.
+
+**Test the whole `sequence` value, never its `ensemble_list`.** `PulseSequence(name='x')` has an
+empty `ensemble_list` and is still a sequence; a real sequence's representation always carries at
+least its `name`, so the value itself is never falsy. Keying off `ensemble_list` would silently
+reclassify an empty-but-real sequence as an ensemble.
+
+`from_dict()` reads three layouts, told apart without ambiguity:
+
+| Layout | Shape | Discriminator |
+|---|---|---|
+| current | `sequence` (no `type` tag); a bare ensemble in `ensembles` | no `type` tag |
+| split | `loaded_sequence` / `loaded_ensemble`, named after the kind | key name |
+| pre-split | one `sequence` key holding either kind | inner `type` tag |
+
+The current and pre-split layouts share the key name, so the `type` tag separates them: the current
+format never writes one. `__setstate__` separately handles a `.pulsedmeasurement` pickled before the
+`sequence` → `loaded_asset` **attribute** rename, which is unrelated to any of this.
+
+Reconstructing a bare ensemble from the sole `ensembles` entry is the one lossy spot: an empty
+`sequence` beside *several* ensembles cannot come from `to_dict()` and leaves the loaded asset
+genuinely ambiguous, so `from_dict()` warns and leaves `loaded_asset` unset rather than guessing.
+
+> **History.** This reverses an earlier decision. The `loaded_sequence`/`loaded_ensemble` split was
+> introduced deliberately so the key name would state the kind, on the reasoning that "an empty
+> `ensembles` beside an ensemble is exactly the reading that used to confuse people". That optimises
+> for a person *reading* the file and charges the person *parsing* it. The trade was reversed in
+> favour of parsers; the split layout stays readable by `from_dict()`.
 
 The point is that a saved measurement's dict shows every block/ensemble definition in full rather than
 just a name, and stays frozen in time — editing a same-named asset later never changes an
@@ -849,7 +888,9 @@ already-taken snapshot.
   header shows sequence *structure* rather than thousands of numbers. Its
   `omit_generation_method_parameters` flag additionally drops the loaded asset's own
   `generation_method_parameters` for the signal file, which writes that container flat at its top
-  level — see **One copy of a container per file** below. There is no `from_metadata_dict()`.
+  level — see **One copy of a container per file** below. Because a loaded bare ensemble now lives
+  under `ensembles`, that flag follows it there, while every *other* ensemble under `ensembles`
+  keeps its own copy (those are not duplicated anywhere). There is no `from_metadata_dict()`.
 
 #### `PulsedMeasurement` *(mutable)* — the root
 
@@ -1050,12 +1091,21 @@ object's actual type. Had it been a persisted field instead, convention 3's miss
 would have defaulted it to `False` on every pre-existing file, silently reclassifying every saved
 `PulseSequence` as an ensemble.
 
-It is therefore **not** in `to_dict()`, `to_metadata_dict()` or any pickle. The saved form carries the
-distinction as strings instead, in three places: the key name `PulseObjects.to_dict()` files the asset
-under (`loaded_sequence` / `loaded_ensemble`), which is what `from_dict()` branches on; a `'type'` tag
-holding the class name inside that value; and `'loaded asset type'` in each `.dat` header. Keep all
-three as strings: they must survive without the classes present, and the `'type'` tag in particular
-is what a third asset type would extend — the key name alone would not generalise as cleanly.
+It is therefore **not** in `to_dict()`, `to_metadata_dict()` or any pickle. The saved form does not
+record the distinction at all any more — it **reconstructs** it from the structure: an empty
+`sequence` key means a bare `PulseBlockEnsemble` was loaded, and it is then the sole entry under
+`ensembles`. That works without the classes importable, which is the property that matters, and it
+cannot drift out of sync with the content the way a redundant string tag can.
+
+This replaced three string markers that all said the same thing: the key name (`loaded_sequence` /
+`loaded_ensemble`), a `'type'` tag inside the value, and `'loaded asset type'` in each `.dat`
+header. The standing argument for keeping the `'type'` tag was that a third asset type would extend
+it. A third type is better served by its own top-level key alongside `sequence` — that keeps the
+"read fixed keys, test which is populated" rule intact, where another tag value would force every
+consumer back into branching on strings.
+
+`'loaded asset name'` **stays** in the header. It is not reconstructable: a sequence referencing
+several ensembles gives no other way to say which asset was the loaded one.
 
 Three places it deliberately does **not** replace `isinstance`:
 

--- a/src/qudi/gui/pulsed/pulse_editors.py
+++ b/src/qudi/gui/pulsed/pulse_editors.py
@@ -80,7 +80,6 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def _create_header_data(self):
         """
 
-        @return:
         """
         # The horizontal header data
         self._h_header_data = ['length\nin s', 'increment\nin s', 'laser\nchannel']
@@ -94,8 +93,9 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def _notify_column_width(self, column=None):
         """
 
-        @param column:
-        @return:
+        Parameters
+        ----------
+        column
         """
         if column is None:
             for column, width in enumerate(self._col_widths):
@@ -110,7 +110,6 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def _get_column_widths(self):
         """
 
-        @return:
         """
         widths = list()
         for column in range(self.columnCount()):
@@ -123,7 +122,6 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def _get_column_width(self, column):
         """
 
-        @return:
         """
         if not isinstance(column, int):
             return -1
@@ -171,8 +169,9 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def set_activation_config(self, activation_config):
         """
 
-        @param activation_config:
-        @return:
+        Parameters
+        ----------
+        activation_config
         """
         if isinstance(activation_config, list):
             activation_config = set(activation_config)
@@ -371,10 +370,11 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def insertRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Sanity/range checking
         if row < 0 or row > self.rowCount():
@@ -394,10 +394,11 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def removeRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Sanity/range checking
         if row < 0 or row >= self.rowCount() or (row + count) > self.rowCount():
@@ -419,8 +420,9 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
     def set_pulse_block(self, pulse_block):
         """
 
-        @param pulse_block:
-        @return:
+        Parameters
+        ----------
+        pulse_block
         """
         if not isinstance(pulse_block, PulseBlock):
             return False
@@ -470,7 +472,6 @@ class BlockEditor(QtWidgets.QTableView):
     def _set_item_delegates(self):
         """
 
-        @return:
         """
         # Set item delegates (scientific SpinBoxes) for length and increment column
         length_item_dict = {'unit': 's',
@@ -520,8 +521,9 @@ class BlockEditor(QtWidgets.QTableView):
     def set_activation_config(self, activation_config):
         """
 
-        @param activation_config:
-        @return:
+        Parameters
+        ----------
+        activation_config
         """
         # Remove item delegates
         for column in range(self.model().columnCount()):
@@ -535,8 +537,9 @@ class BlockEditor(QtWidgets.QTableView):
     def setModel(self, model):
         """
 
-        @param model:
-        @return:
+        Parameters
+        ----------
+        model
         """
         super().setModel(model)
         for column in range(model.columnCount()):
@@ -565,9 +568,15 @@ class BlockEditor(QtWidgets.QTableView):
     def add_elements(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -583,9 +592,15 @@ class BlockEditor(QtWidgets.QTableView):
     def remove_elements(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -602,7 +617,10 @@ class BlockEditor(QtWidgets.QTableView):
         """
         Removes all PulseBlockElements from the view/model and inserts a single afterwards.
 
-        @return: bool, operation success
+        Returns
+        -------
+        bool
+            Operation success.
         """
         success = self.remove_elements(self.model().rowCount(), 0)
         if success:
@@ -613,7 +631,10 @@ class BlockEditor(QtWidgets.QTableView):
         """
         Returns a (deep)copy of the PulseBlock instance serving as model for this editor.
 
-        @return: PulseBlock, an instance of PulseBlock
+        Returns
+        -------
+        PulseBlock
+            An instance of PulseBlock.
         """
         block_copy = copy.deepcopy(
             self.model().data(QtCore.QModelIndex(), self.model().pulseBlockRole))
@@ -625,8 +646,15 @@ class BlockEditor(QtWidgets.QTableView):
         """
         Load an instance of PulseBlock into the model in order to view/edit it.
 
-        @param pulse_block: PulseBlock, the PulseBlock instance to load into the model/view
-        @return: bool, operation success
+        Parameters
+        ----------
+        pulse_block : PulseBlock
+            The PulseBlock instance to load into the model/view.
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         return self.model().set_pulse_block(pulse_block)
 
@@ -656,8 +684,15 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
     def set_available_pulse_blocks(self, blocks):
         """
 
-        @param blocks: list|dict|set, list/dict/set containing all available PulseBlock names
-        @return: int, error code (>=0: OK, <0: ERR)
+        Parameters
+        ----------
+        blocks : list or dict or set
+            List/dict/set containing all available PulseBlock names.
+
+        Returns
+        -------
+        int
+            Error code (>=0: OK, <0: ERR).
         """
         # Convert to set
         if isinstance(blocks, (list, dict)):
@@ -691,8 +726,9 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
     def set_rotating_frame(self, rotating_frame=True):
         """
 
-        @param rotating_frame:
-        @return:
+        Parameters
+        ----------
+        rotating_frame
         """
         if isinstance(rotating_frame, bool):
             self._block_ensemble.rotating_frame = rotating_frame
@@ -759,10 +795,11 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
     def insertRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Do nothing if no blocks are available
         if len(self.available_pulse_blocks) == 0:
@@ -786,10 +823,11 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
     def removeRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Sanity/range checking
         if row < 0 or row >= self.rowCount() or (row + count) > self.rowCount():
@@ -808,8 +846,9 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
     def set_block_ensemble(self, block_ensemble):
         """
 
-        @param block_ensemble:
-        @return:
+        Parameters
+        ----------
+        block_ensemble
         """
         if not isinstance(block_ensemble, PulseBlockEnsemble):
             return False
@@ -862,8 +901,14 @@ class EnsembleEditor(QtWidgets.QTableView):
     def set_available_pulse_blocks(self, blocks):
         """
 
-        @param list|set blocks:
-        @return: int, error code (>=0: OK, <0: ERR)
+        Parameters
+        ----------
+        blocks : list or set
+
+        Returns
+        -------
+        int
+            Error code (>=0: OK, <0: ERR).
         """
         if isinstance(blocks, (list, dict, set)):
             blocks = natural_sort(blocks)
@@ -879,8 +924,9 @@ class EnsembleEditor(QtWidgets.QTableView):
     def set_rotating_frame(self, rotating_frame=True):
         """
 
-        @param rotating_frame:
-        @return:
+        Parameters
+        ----------
+        rotating_frame
         """
         self.model().set_rotating_frame(rotating_frame)
         return
@@ -902,9 +948,15 @@ class EnsembleEditor(QtWidgets.QTableView):
     def add_blocks(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -919,9 +971,15 @@ class EnsembleEditor(QtWidgets.QTableView):
     def remove_blocks(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -937,7 +995,10 @@ class EnsembleEditor(QtWidgets.QTableView):
         """
         Removes all PulseBlocks from the view/model and inserts a single one afterwards.
 
-        @return: bool, operation success
+        Returns
+        -------
+        bool
+            Operation success.
         """
         success = self.remove_blocks(self.model().rowCount(), 0)
         if not success:
@@ -949,7 +1010,10 @@ class EnsembleEditor(QtWidgets.QTableView):
         """
         Returns a (deep)copy of the PulseBlockEnsemble instance serving as model for this editor.
 
-        @return: PulseBlockEnsemble, an instance of PulseBlockEnsemble
+        Returns
+        -------
+        PulseBlockEnsemble
+            An instance of PulseBlockEnsemble.
         """
         data_container = self.model().data(QtCore.QModelIndex(), self.model().blockEnsembleRole)
         ensemble_copy = copy.deepcopy(data_container)
@@ -960,9 +1024,15 @@ class EnsembleEditor(QtWidgets.QTableView):
         """
         Load an instance of PulseBlockEnsemble into the model in order to view/edit it.
 
-        @param block_ensemble: PulseBlockEnsemble, the PulseBlockEnsemble instance to load into the
-                               model/view
-        @return: bool, operation success
+        Parameters
+        ----------
+        block_ensemble : PulseBlockEnsemble
+            The PulseBlockEnsemble instance to load into the model/view.
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         return self.model().set_block_ensemble(block_ensemble)
 
@@ -1008,8 +1078,15 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def set_available_block_ensembles(self, ensembles):
         """
 
-        @param ensembles: list|set, list/set containing all available PulseBlockEnsemble names
-        @return: int, error code (>=0: OK, <0: ERR)
+        Parameters
+        ----------
+        ensembles : list or set
+            List/set containing all available PulseBlockEnsemble names.
+
+        Returns
+        -------
+        int
+            Error code (>=0: OK, <0: ERR).
         """
         # Convert to set
         if isinstance(ensembles, (list, dict)):
@@ -1046,8 +1123,15 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def set_available_flags(self, flags):
         """
 
-        @param flags: list|set, list/set containing all available flag names
-        @return: int, error code (>=0: OK, <0: ERR)
+        Parameters
+        ----------
+        flags : list or set
+            List/set containing all available flag names.
+
+        Returns
+        -------
+        int
+            Error code (>=0: OK, <0: ERR).
         """
         # Convert to set
         if isinstance(flags, (list, dict)):
@@ -1076,8 +1160,9 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def set_rotating_frame(self, rotating_frame=True):
         """
 
-        @param rotating_frame:
-        @return:
+        Parameters
+        ----------
+        rotating_frame
         """
         if isinstance(rotating_frame, bool):
             self._pulse_sequence.rotating_frame = rotating_frame
@@ -1163,10 +1248,11 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def insertRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Do nothing if no ensembles are available
         if len(self.available_block_ensembles) == 0:
@@ -1190,10 +1276,11 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def removeRows(self, row, count, parent=None):
         """
 
-        @param row:
-        @param count:
-        @param parent:
-        @return:
+        Parameters
+        ----------
+        row
+        count
+        parent
         """
         # Sanity/range checking
         if row < 0 or row >= self.rowCount() or (row + count) > self.rowCount():
@@ -1212,8 +1299,9 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
     def set_pulse_sequence(self, pulse_sequence):
         """
 
-        @param pulse_sequence:
-        @return:
+        Parameters
+        ----------
+        pulse_sequence
         """
         if not isinstance(pulse_sequence, PulseSequence):
             return False
@@ -1286,8 +1374,14 @@ class SequenceEditor(QtWidgets.QTableView):
     def set_available_block_ensembles(self, ensembles):
         """
 
-        @param ensembles:
-        @return: int, error code (>=0: OK, <0: ERR)
+        Parameters
+        ----------
+        ensembles
+
+        Returns
+        -------
+        int
+            Error code (>=0: OK, <0: ERR).
         """
         err_code = self.model().set_available_block_ensembles(ensembles)
         if err_code >= 0:
@@ -1299,8 +1393,9 @@ class SequenceEditor(QtWidgets.QTableView):
     def set_rotating_frame(self, rotating_frame=True):
         """
 
-        @param rotating_frame:
-        @return:
+        Parameters
+        ----------
+        rotating_frame
         """
         self.model().set_rotating_frame(rotating_frame)
         return
@@ -1308,8 +1403,10 @@ class SequenceEditor(QtWidgets.QTableView):
     def set_available_triggers(self, trigger_list):
         """
 
-        @param list trigger_list: List of strings describing the available pulse generator trigger
-                                  input channels.
+        Parameters
+        ----------
+        trigger_list : list
+            List of strings describing the available pulse generator trigger input channels.
         """
         if not isinstance(trigger_list, list):
             return
@@ -1325,7 +1422,10 @@ class SequenceEditor(QtWidgets.QTableView):
     def set_available_flags(self, flag_set):
         """
 
-        @param list flag_set: Set of strings describing the available pulse generator flag output channels.
+        Parameters
+        ----------
+        flag_set : list
+            Set of strings describing the available pulse generator flag output channels.
         """
         if not isinstance(flag_set, set):
             return
@@ -1370,9 +1470,15 @@ class SequenceEditor(QtWidgets.QTableView):
     def add_steps(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -1387,9 +1493,15 @@ class SequenceEditor(QtWidgets.QTableView):
     def remove_steps(self, count=1, at_position=None):
         """
 
-        @param count:
-        @param at_position:
-        @return: bool, operation success
+        Parameters
+        ----------
+        count
+        at_position
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         # Sanity checking
         if count < 1:
@@ -1405,7 +1517,10 @@ class SequenceEditor(QtWidgets.QTableView):
         """
         Removes all sequence steps from the view/model and inserts a single one afterwards.
 
-        @return: bool, operation success
+        Returns
+        -------
+        bool
+            Operation success.
         """
         success = self.remove_steps(self.model().rowCount(), 0)
         if success:
@@ -1416,7 +1531,10 @@ class SequenceEditor(QtWidgets.QTableView):
         """
         Returns a (deep)copy of the PulseSequence instance serving as model for this editor.
 
-        @return: object, an instance of PulseSequence
+        Returns
+        -------
+        object
+            An instance of PulseSequence.
         """
         data_container = self.model().data(QtCore.QModelIndex(), self.model().sequenceRole)
         sequence_copy = PulseSequence('', ensemble_list=data_container.ensemble_list)
@@ -1426,7 +1544,14 @@ class SequenceEditor(QtWidgets.QTableView):
         """
         Load an instance of PulseSequence into the model in order to view/edit it.
 
-        @param pulse_sequence: object, the PulseSequence instance to load into the model/view
-        @return: bool, operation success
+        Parameters
+        ----------
+        pulse_sequence : object
+            The PulseSequence instance to load into the model/view.
+
+        Returns
+        -------
+        bool
+            Operation success.
         """
         return self.model().set_pulse_sequence(pulse_sequence)

--- a/src/qudi/gui/pulsed/pulsed_item_delegates.py
+++ b/src/qudi/gui/pulsed/pulsed_item_delegates.py
@@ -33,7 +33,10 @@ class CheckBoxItemDelegate(QtWidgets.QStyledItemDelegate):
 
     def __init__(self, parent, data_access_role=QtCore.Qt.ItemDataRole.DisplayRole):
         """
-        @param QWidget parent: the parent QWidget which hosts this child widget
+        Parameters
+        ----------
+        parent : QWidget
+            The parent QWidget which hosts this child widget.
         """
         super().__init__(parent)
         self._access_role = data_access_role
@@ -43,12 +46,15 @@ class CheckBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object (probably QTableView)
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use for
-                                                    style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableView to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object (probably QTableView).
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableView to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is like a container, which handles the passed entries
@@ -79,12 +85,15 @@ class CheckBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                     here a ScienDSpinBox.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
-        This function converts the passed data to an value, which can be
-        understood by the editor.
+        This function converts the passed data to an value, which can be understood by the
+        editor.
         """
         data = index.data(self._access_role)
         if not isinstance(data, bool):
@@ -98,10 +107,14 @@ class CheckBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                                here a ScienDSpinBox.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the underlying data
         model. The setModelData() function reads the content of the editor, and writes it to the
@@ -131,10 +144,13 @@ class SpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
 
     def __init__(self, parent, item_dict=None, data_access_role=QtCore.Qt.ItemDataRole.DisplayRole):
         """
-        @param QWidget parent: the parent QWidget which hosts this child widget
-        @param dict item_dict:  dict with the following keys which give informations about the
-                                current viewbox: 'unit', 'init_val', 'min', 'max', 'view_stepsize',
-                                                 'dec', 'unit_prefix'
+        Parameters
+        ----------
+        parent : QWidget
+            The parent QWidget which hosts this child widget.
+        item_dict : dict
+            Dict with the following keys which give informations about the current viewbox:
+            'unit', 'init_val', 'min', 'max', 'view_stepsize', 'dec', 'unit_prefix'.
         """
         super().__init__(parent)
         if item_dict is None:
@@ -147,12 +163,15 @@ class SpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object (probably QTableView)
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use for
-                                                    style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableView to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object (probably QTableView).
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableView to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is like a container, which handles the passed entries
@@ -189,12 +208,15 @@ class SpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                     here a ScienDSpinBox.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
-        This function converts the passed data to an value, which can be
-        understood by the editor.
+        This function converts the passed data to an value, which can be understood by the
+        editor.
         """
         data = index.data(self._access_role)
         if not isinstance(data, (np.integer, int)):
@@ -208,10 +230,14 @@ class SpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                     here a ScienDSpinBox.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the underlying data
         model. The setModelData() function reads the content of the editor, and writes it to the
@@ -247,9 +273,13 @@ class ScienDSpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
 
     def __init__(self, parent, item_dict, data_access_role=QtCore.Qt.ItemDataRole.DisplayRole):
         """
-        @param QWidget parent: the parent QWidget which hosts this child widget
-        @param dict item_dict:  dict with the following keys which give informations about the
-                                current viewbox: 'unit', 'init_val', 'min', 'max'
+        Parameters
+        ----------
+        parent : QWidget
+            The parent QWidget which hosts this child widget.
+        item_dict : dict
+            Dict with the following keys which give informations about the current viewbox:
+            'unit', 'init_val', 'min', 'max'.
         """
         super().__init__(parent)
         self.item_dict = item_dict
@@ -262,12 +292,15 @@ class ScienDSpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object (probably QTableView)
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use for
-                                                    style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableView to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object (probably QTableView).
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableView to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is like a container, which handles the passed entries
@@ -306,12 +339,15 @@ class ScienDSpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                     here a ScienDSpinBox.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
-        This function converts the passed data to an value, which can be
-        understood by the editor.
+        This function converts the passed data to an value, which can be understood by the
+        editor.
         """
         data = index.data(self._access_role)
         if not isinstance(data, float):
@@ -325,10 +361,14 @@ class ScienDSpinBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param ScienDSpinBox editor: QObject which was created in createEditor function,
-                                                here a ScienDSpinBox.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : ScienDSpinBox
+            QObject which was created in createEditor function, here a ScienDSpinBox.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the underlying data
         model. The setModelData() function reads the content of the editor, and writes it to the
@@ -372,12 +412,15 @@ class ComboBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object (probably QTableView)
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use for
-                                                    style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableView to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object (probably QTableView).
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableView to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is also a container, which handles the passed entries
@@ -408,9 +451,12 @@ class ComboBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param QComboBox editor: QObject which was created in createEditor function,
-                                 here a QCombobox.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : QComboBox
+            QObject which was created in createEditor function, here a QCombobox.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
         """
         data = index.data(self._access_role)
         combo_index = editor.findText(data)
@@ -423,10 +469,14 @@ class ComboBoxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param QComboBox editor: QObject which was created in createEditor function,
-                                 here a QCombobox.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : QComboBox
+            QObject which was created in createEditor function, here a QCombobox.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the data model.
         The setModelData() function reads the content of the editor, and writes it to the model.
@@ -464,12 +514,15 @@ class MultipleCheckboxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object, here QTableWidget
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use
-                                                    for style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableWidget to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object, here QTableWidget.
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableWidget to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is also a container, which handles the passed entries
@@ -500,9 +553,12 @@ class MultipleCheckboxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param MultipleCheckboxWidget editor: QObject which was created in createEditor function,
-                                              here a MultipleCheckboxWidget.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : MultipleCheckboxWidget
+            QObject which was created in createEditor function, here a MultipleCheckboxWidget.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         This function converts the passed data to an value, which can be understood by the editor.
         """
@@ -516,10 +572,14 @@ class MultipleCheckboxItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param MultipleCheckboxWidget editor: QObject which was created in createEditor function,
-                                              here a MultipleCheckboxWidget.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : MultipleCheckboxWidget
+            QObject which was created in createEditor function, here a MultipleCheckboxWidget.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the underlying data
         model. The setModelData() function reads the content of the editor, and writes it to the
@@ -556,12 +616,15 @@ class AnalogParametersItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Create for the display and interaction with the user an editor.
 
-        @param QtGui.QWidget parent: The parent object, here QTableWidget
-        @param QtGui.QStyleOptionViewItemV4 option: This is a setting option which you can use
-                                                    for style configuration.
-        @param QtCore.QModelIndex index: That index will be passed by the model object of the
-                                         QTableWidget to the delegated object. This index contains
-                                         information about the selected current cell.
+        Parameters
+        ----------
+        parent : QtGui.QWidget
+            The parent object, here QTableWidget.
+        option : QtGui.QStyleOptionViewItemV4
+            This is a setting option which you can use for style configuration.
+        index : QtCore.QModelIndex
+            That index will be passed by the model object of the QTableWidget to the delegated
+            object. This index contains information about the selected current cell.
 
         An editor can be in principle any QWidget, which you want to use to display the current
         (model-)data. Therefore the editor is also a container, which handles the passed entries
@@ -594,9 +657,12 @@ class AnalogParametersItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Set the display of the current value of the used editor.
 
-        @param AnalogParametersWidget editor: QObject which was created in createEditor function,
-                                              here a AnalogParametersWidget.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : AnalogParametersWidget
+            QObject which was created in createEditor function, here a AnalogParametersWidget.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         This function converts the passed data to an value, which can be understood by the editor.
         """
@@ -610,10 +676,14 @@ class AnalogParametersItemDelegate(QtWidgets.QStyledItemDelegate):
         """
         Save the data of the editor to the model.
 
-        @param AnalogParametersWidget editor: QObject which was created in createEditor function,
-                                              here a AnalogParametersWidget.
-        @param QtCore.QAbstractTableModel model: That is the object which contains the data model.
-        @param QtCore.QModelIndex index: explained in createEditor function.
+        Parameters
+        ----------
+        editor : AnalogParametersWidget
+            QObject which was created in createEditor function, here a AnalogParametersWidget.
+        model : QtCore.QAbstractTableModel
+            That is the object which contains the data model.
+        index : QtCore.QModelIndex
+            Explained in createEditor function.
 
         Before the editor is destroyed the current selection should be saved in the underlying data
         model. The setModelData() function reads the content of the editor, and writes it to the

--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -2369,8 +2369,8 @@ class PulsedMeasurementGui(GuiBase):
 
         # Fit settings dialog
         fit_containers = self.pulsedmasterlogic().fit_containers
-        self._pa.first_plot_fitwidget.link_fit_container(fit_containers[0])
-        self._pa.second_plot_fitwidget.link_fit_container(fit_containers[1])
+        self._pa.first_plot_fitwidget.link_fit_container(fit_containers.primary)
+        self._pa.second_plot_fitwidget.link_fit_container(fit_containers.alternative)
         self._pa.first_plot_fitwidget.sigDoFit.connect(
             lambda x: self.pulsedmasterlogic().do_fit(x, False)
         )

--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -679,9 +679,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(bool)
     def pulser_running_updated(self, is_running):
         """
-
-        @param is_running:
-        @return:
+        Parameters
+        ----------
+        is_running
         """
         # block signals
         self._mw.pulser_on_off_PushButton.blockSignals(True)
@@ -737,7 +737,10 @@ class PulsedMeasurementGui(GuiBase):
     def measurement_run_stop_clicked(self, isChecked):
         """ Manages what happens if pulsed measurement is started or stopped.
 
-        @param bool isChecked: start scan if that is possible
+        Parameters
+        ----------
+        isChecked : bool
+            Start scan if that is possible.
         """
         self.pulsedmasterlogic().toggle_pulsed_measurement(isChecked)
         return
@@ -751,10 +754,10 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(bool, bool)
     def measurement_status_updated(self, is_running, is_paused):
         """
-
-        @param is_running:
-        @param is_paused:
-        @return:
+        Parameters
+        ----------
+        is_running
+        is_paused
         """
         # block signals
         self._mw.action_run_stop.blockSignals(True)
@@ -902,10 +905,11 @@ class PulsedMeasurementGui(GuiBase):
         """
         Refreshes the elapsed time and sweeps of the measurement.
 
-        @param float elapsed_time:
-        @param int elapsed_sweeps:
-        @param float timer_interval:
-        @return:
+        Parameters
+        ----------
+        elapsed_time : float
+        elapsed_sweeps : int
+        timer_interval : float
         """
         time_str = str(datetime.timedelta(seconds=elapsed_time)).rsplit('.', 1)[0]
         # block signals
@@ -1300,6 +1304,17 @@ class PulsedMeasurementGui(GuiBase):
                     widget.addItem(option.name, PulseEnvelope(option))
                 widget.setCurrentText(value.type.name)
                 widget.currentTextChanged.connect(self.generation_parameters_changed)
+            else:
+                # Without this branch `widget` would still be bound to the previous iteration's
+                # widget, which then gets silently re-registered under this parameter's name.
+                # Reachable for any generation parameter whose type is outside the set above -
+                # note the checks are `type(x) is`, not isinstance, so an int/float subclass
+                # (numpy scalar, IntEnum) lands here too.
+                self.log.error('The generation parameter "{0}" has an invalid type ({1}).\n'
+                               'Only str, int, float, bool, Enum and PulseEnvelope can be shown '
+                               'in the global parameters editor - skipping it.'
+                               ''.format(param, type(value).__name__))
+                continue
 
             widget.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
 
@@ -1445,9 +1460,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def pulse_generator_settings_updated(self, settings_dict):
         """
-
-        @param settings_dict
-        @return:
+        Parameters
+        ----------
+        settings_dict
         """
         # block signals
         self._pgs.gen_sample_freq_DSpinBox.blockSignals(True)
@@ -1602,8 +1617,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def generation_parameters_changed(self):
         """
-
-        @return:
         """
         settings_dict = dict()
         settings_dict['laser_channel'] = self._pg.gen_laserchannel_ComboBox.currentText()
@@ -1637,9 +1650,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def generation_parameters_updated(self, settings_dict):
         """
-
-        @param settings_dict:
-        @return:
+        Parameters
+        ----------
+        settings_dict
         """
         # block signals
         self._pg.gen_laserchannel_ComboBox.blockSignals(True)
@@ -1694,8 +1707,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def block_add_last_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_editor.add_elements(1, self._pg.block_editor.rowCount())
         return
@@ -1703,8 +1714,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def block_del_last_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_editor.remove_elements(1, self._pg.block_editor.rowCount() - 1)
         return
@@ -1712,8 +1721,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def block_add_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._pg.block_editor.currentRow()
         self._pg.block_editor.add_elements(1, index + 1)
@@ -1722,8 +1729,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def block_del_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._pg.block_editor.currentRow()
         self._pg.block_editor.remove_elements(1, index)
@@ -1732,8 +1737,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def block_clear_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_editor.clear()
         return
@@ -1741,8 +1744,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def organizer_add_last_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_organizer.add_blocks(1, self._pg.block_organizer.rowCount())
         return
@@ -1750,8 +1751,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def organizer_del_last_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_organizer.remove_blocks(1, self._pg.block_organizer.rowCount() - 1)
         return
@@ -1759,8 +1758,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def organizer_add_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._pg.block_organizer.currentRow()
         self._pg.block_organizer.add_blocks(1, index + 1)
@@ -1769,8 +1766,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def organizer_del_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._pg.block_organizer.currentRow()
         self._pg.block_organizer.remove_blocks(1, index)
@@ -1779,8 +1774,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def organizer_clear_clicked(self):
         """
-
-        @return:
         """
         self._pg.block_organizer.clear()
         return
@@ -1887,9 +1880,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def update_block_dict(self, block_dict):
         """
-
-        @param block_dict:
-        @return:
+        Parameters
+        ----------
+        block_dict
         """
         block_names = natural_sort(block_dict)
         # Check if a block has been added. In that case set the current index to the new one.
@@ -1916,9 +1909,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def update_ensemble_dict(self, ensemble_dict):
         """
-
-        @param ensemble_dict:
-        @return:
+        Parameters
+        ----------
+        ensemble_dict
         """
         ensemble_names = natural_sort(ensemble_dict)
         # Check if an ensemble has been added. In that case set the current index to the new one.
@@ -2032,9 +2025,10 @@ class PulsedMeasurementGui(GuiBase):
 
     def generate_predefined_clicked(self, method_name, sample_and_load=False):
         """
-
-        @param str method_name:
-        @param bool sample_and_load:
+        Parameters
+        ----------
+        method_name : str
+        sample_and_load : bool
         """
         # get parameters from input widgets
         # Store parameters together with the parameter names in a dictionary
@@ -2090,8 +2084,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(list)
     def waveform_list_updated(self, waveform_list):
         """
-
-        @param list waveform_list:
+        Parameters
+        ----------
+        waveform_list : list
         """
         # TODO: This method will be needed later on to implement an upload center
         pass
@@ -2113,8 +2108,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def sequence_add_last_clicked(self):
         """
-
-        @return:
         """
         self._sg.sequence_editor.add_steps(1, self._sg.sequence_editor.rowCount())
         return
@@ -2122,8 +2115,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def sequence_del_last_clicked(self):
         """
-
-        @return:
         """
         self._sg.sequence_editor.remove_steps(1, self._sg.sequence_editor.rowCount() - 1)
         return
@@ -2131,8 +2122,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def sequence_add_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._sg.sequence_editor.currentRow()
         self._sg.sequence_editor.add_steps(1, index + 1)
@@ -2141,8 +2130,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def sequence_del_sel_clicked(self):
         """
-
-        @return:
         """
         index = self._sg.sequence_editor.currentRow()
         self._sg.sequence_editor.remove_steps(1, index)
@@ -2151,8 +2138,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def sequence_clear_clicked(self):
         """
-
-        @return:
         """
         self._sg.sequence_editor.clear()
         return
@@ -2211,9 +2196,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def update_sequence_dict(self, sequence_dict):
         """
-
-        @param sequence_dict:
-        @return:
+        Parameters
+        ----------
+        sequence_dict
         """
         sequence_names = natural_sort(sequence_dict)
         # Check if a sequence has been added. In that case set the current index to the new one.
@@ -2302,8 +2287,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(list)
     def sequence_list_updated(self, sequence_list):
         """
-
-        @param list sequence_list:
+        Parameters
+        ----------
+        sequence_list : list
         """
         # TODO: This method will be needed later on to implement an upload center
         pass
@@ -2407,6 +2393,11 @@ class PulsedMeasurementGui(GuiBase):
             self._pa.second_plot_ComboBox.addItem(method_name)
         self._pa.second_plot_ComboBox.blockSignals(False)
 
+        self._pa.ana_param_errorbars_CheckBox.setToolTip(
+            'Controls whether the saved plot thumbnail shows error bars. The saved data file always '
+            'includes error data regardless of this setting.'
+        )
+
         # Recall StatusVars into widgets
         self._pa.ana_param_errorbars_CheckBox.blockSignals(True)
         self._pa.ana_param_errorbars_CheckBox.setChecked(self._ana_param_errorbars)
@@ -2463,8 +2454,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def measurement_data_updated(self):
         """
-
-        @return:
         """
         signal_data = self.pulsedmasterlogic().signal_data
         signal_alt_data = self.pulsedmasterlogic().signal_alt_data
@@ -2518,11 +2507,11 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(str, object, bool)
     def fit_data_updated(self, fit_config, result, use_alternative_data):
         """
-
-        @param str fit_config:
-        @param object result:
-        @param bool use_alternative_data:
-        @return:
+        Parameters
+        ----------
+        fit_config : str
+        result : object
+        use_alternative_data : bool
         """
 
         # Update plot.
@@ -2580,8 +2569,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def microwave_settings_updated(self, settings_dict):
         """
-
-        @param dict settings_dict:
+        Parameters
+        ----------
+        settings_dict : dict
         """
         # block signals
         self._pa.ext_control_mw_freq_DoubleSpinBox.blockSignals(True)
@@ -2606,9 +2596,9 @@ class PulsedMeasurementGui(GuiBase):
 
     def toggle_microwave_settings_editor(self, show_editor):
         """
-
-        @param show_editor:
-        @return:
+        Parameters
+        ----------
+        show_editor
         """
         if show_editor:
             self._pa.ext_control_mw_freq_Label.setVisible(True)
@@ -2629,16 +2619,12 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(bool)
     def microwave_running_updated(self, is_running):
         """
-
-        @return:
         """
         pass
 
     @QtCore.Slot()
     def fast_counter_settings_changed(self):
         """
-
-        @return:
         """
         if self._mw.action_run_stop.isChecked():
             return
@@ -2651,8 +2637,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def fast_counter_settings_updated(self, settings_dict):
         """
-
-        @param dict settings_dict:
+        Parameters
+        ----------
+        settings_dict : dict
         """
         # block signals
         self._pa.ana_param_record_length_DoubleSpinBox.blockSignals(True)
@@ -2678,8 +2665,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def measurement_settings_changed(self):
         """
-
-        @return:
         """
         # Do nothing if measurement is already running
         if self._mw.action_run_stop.isChecked():
@@ -2709,8 +2694,9 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def measurement_settings_updated(self, settings_dict):
         """
-
-        @param dict settings_dict:
+        Parameters
+        ----------
+        settings_dict : dict
         """
         # block signals
         self._pa.ana_param_ignore_first_CheckBox.blockSignals(True)
@@ -2798,9 +2784,9 @@ class PulsedMeasurementGui(GuiBase):
 
     def set_plot_dimensions(self):
         """
-
-        @param alternating:
-        @return:
+        Parameters
+        ----------
+        alternating
         """
         number_of_signals = self.pulsedmasterlogic().signal_data.shape[0] - 1
         number_of_alt_signals = self.pulsedmasterlogic().signal_alt_data.shape[0] - 1
@@ -2853,8 +2839,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(bool)
     def toggle_error_bars(self, show_bars):
         """
-
-        @return:
         """
         is_alternating = self.signal_image2 in self._pa.pulse_analysis_PlotWidget.items()
         if show_bars:
@@ -3010,9 +2994,10 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def extraction_settings_updated(self, settings_dict):
         """
-
-        @param dict settings_dict: dictionary with parameters to update
-        @return:
+        Parameters
+        ----------
+        settings_dict : dict
+            Dictionary with parameters to update.
         """
         # If no widgets have been generated yet, generate them now.
         if self._extraction_param_widgets is None:
@@ -3047,8 +3032,6 @@ class PulsedMeasurementGui(GuiBase):
 
     def _delete_extraction_param_widgets(self):
         """
-
-        @return:
         """
         for index in reversed(range(len(self._extraction_param_widgets))):
             label = self._extraction_param_widgets[index][0]
@@ -3070,9 +3053,9 @@ class PulsedMeasurementGui(GuiBase):
 
     def _create_extraction_param_widgets(self, extraction_settings):
         """
-
-        @param extraction_settings:
-        @return:
+        Parameters
+        ----------
+        extraction_settings
         """
         self._extraction_param_widgets = list()
         layout_row = 1
@@ -3119,8 +3102,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def analysis_settings_changed(self):
         """
-
-        @return:
         """
         settings_dict = dict()
 
@@ -3155,9 +3136,10 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot(dict)
     def analysis_settings_updated(self, settings_dict):
         """
-
-        @param dict settings_dict: dictionary with parameters to update
-        @return:
+        Parameters
+        ----------
+        settings_dict : dict
+            Dictionary with parameters to update.
         """
 
         # block signals
@@ -3207,8 +3189,6 @@ class PulsedMeasurementGui(GuiBase):
     @QtCore.Slot()
     def update_laser_data(self):
         """
-
-        @return:
         """
         laser_index = self._pe.laserpulses_ComboBox.currentIndex()
         show_raw = self._pe.laserpulses_display_raw_CheckBox.isChecked()

--- a/src/qudi/gui/pulsed/pulsed_maingui.py
+++ b/src/qudi/gui/pulsed/pulsed_maingui.py
@@ -2059,7 +2059,9 @@ class PulsedMeasurementGui(GuiBase):
         )
 
     @QtCore.Slot(object, bool)
-    def predefined_generated(self, asset_name, is_sequence):
+    def predefined_generated(self, asset_name, produced_sequence):
+        """`produced_sequence` reports whether the generate method returned any PulseSequence - a
+        different question from PulseSequence.is_sequence, which asks whether an object is one."""
         # Enable all "Generate" buttons in predefined methods tab
         for button in self._pm.gen_buttons.values():
             button.setEnabled(True)
@@ -2075,7 +2077,7 @@ class PulsedMeasurementGui(GuiBase):
             self._pg.sample_ensemble_PushButton.setEnabled(False)
             self._pg.samplo_ensemble_PushButton.setEnabled(False)
             self._pg.load_ensemble_PushButton.setEnabled(False)
-            if is_sequence:
+            if produced_sequence:
                 self._sg.load_sequence_PushButton.setEnabled(False)
                 self._sg.samplo_sequence_PushButton.setEnabled(False)
                 self._sg.sample_sequence_PushButton.setEnabled(False)

--- a/src/qudi/hardware/dummy/fast_counter_dummy.py
+++ b/src/qudi/hardware/dummy/fast_counter_dummy.py
@@ -60,6 +60,7 @@ class FastCounterDummy(FastCounterInterface):
         self.statusvar = 0
         self._binwidth = 1
         self._gate_length_bins = 8192
+        self._number_of_gates = 1
         return
 
     def on_deactivate(self):
@@ -127,6 +128,7 @@ class FastCounterDummy(FastCounterInterface):
         """
         self._binwidth = int(np.rint(bin_width_s * 1e9 * 950 / 1000))
         self._gate_length_bins = int(np.rint(record_length_s / bin_width_s))
+        self._number_of_gates = number_of_gates
         actual_binwidth = self._binwidth * 1000 / 950e9
         actual_length = self._gate_length_bins * actual_binwidth
         self.statusvar = 1
@@ -154,7 +156,16 @@ class FastCounterDummy(FastCounterInterface):
             return -1
 
         if self._gated:
-            self._count_data = self._count_data.transpose()
+            # np.loadtxt returns a 1D array for this single-column demo trace, and .transpose()
+            # is a no-op on a 1D array - it will NOT turn this into the 2D (gates, bins) shape
+            # the rest of the pulsed logic expects when gated. Synthesize a proper 2D array
+            # instead, by tiling/truncating the loaded trace to the configured gate length and
+            # stacking it across the configured number of gates.
+            flat = self._count_data.ravel()
+            gate_len = self._gate_length_bins
+            reps = int(np.ceil(gate_len / flat.size)) if flat.size else 1
+            tiled = np.tile(flat, max(reps, 1))[:gate_len]
+            self._count_data = np.tile(tiled, (self._number_of_gates, 1))
         return 0
 
     def pause_measure(self):

--- a/src/qudi/hardware/dummy/pulser_dummy.py
+++ b/src/qudi/hardware/dummy/pulser_dummy.py
@@ -562,10 +562,15 @@ class PulserDummy(PulserInterface):
                              respective asset loaded into the channel,
                              string describing the asset type ('waveform' or 'sequence')
         """
-        # Determine if it's a waveform or a sequence
+        # Determine if it's a waveform or a sequence. Waveform names always carry a '_ch<N>'
+        # suffix (see load_waveform(), which parses them the same way); a loaded sequence's name
+        # is stored bare, with no suffix at all - including, potentially, no underscore whatsoever
+        # (e.g. a sequence simply named "Rabi"), so this must not assume rsplit('_', 1) always
+        # yields two pieces.
         asset_type = None
         for asset_name in self.current_loaded_assets.values():
-            if 'ch' in asset_name.rsplit('_', 1)[1]:
+            name_parts = asset_name.rsplit('_ch', 1)
+            if len(name_parts) == 2 and name_parts[1].isdigit():
                 current_type = 'waveform'
             else:
                 current_type = 'sequence'

--- a/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -305,13 +305,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = False
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau<sub>pulse spacing</sub>', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating= False
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau<sub>pulse spacing</sub>', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # Append ensemble to created_ensembles list
@@ -377,13 +377,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = False
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = freq_array
-        block_ensemble.measurement_information['units'] = ('Hz', '')
-        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = False
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = freq_array
+        block_ensemble.measurement_information.units = ('Hz', '')
+        block_ensemble.measurement_information.labels = ('Frequency', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -476,13 +476,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = 2 * num_of_points if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -687,13 +687,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = 2 * num_of_points if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -802,13 +802,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = 2 * num_of_points if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
         # append ensemble to created ensembles
         created_ensembles.append(block_ensemble)
@@ -883,13 +883,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = 2 * num_of_points if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau<sub>pulse spacing</sub>', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau<sub>pulse spacing</sub>', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
         # append ensemble to created ensembles
         created_ensembles.append(block_ensemble)
@@ -969,13 +969,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = 2 * num_of_points if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau<sub>pulse spacing</sub>', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau<sub>pulse spacing</sub>', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
         # append ensemble to created ensembles
         created_ensembles.append(block_ensemble)
@@ -1047,13 +1047,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = True
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = amp_array
-        block_ensemble.measurement_information['units'] = ('V', '')
-        block_ensemble.measurement_information['labels'] = ('MW amplitude', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = 2 * num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = True
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = amp_array
+        block_ensemble.measurement_information.units = ('V', '')
+        block_ensemble.measurement_information.labels = ('MW amplitude', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = 2 * num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -1125,13 +1125,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = True
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Spinlock time', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = 2 * num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = True
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Spinlock time', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = 2 * num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -1207,13 +1207,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = False
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = steps_array
-        block_ensemble.measurement_information['units'] = ('#', '')
-        block_ensemble.measurement_information['labels'] = ('Polarization Steps', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = 2 * polarization_steps
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = False
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = steps_array
+        block_ensemble.measurement_information.units = ('#', '')
+        block_ensemble.measurement_information.labels = ('Polarization Steps', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = 2 * polarization_steps
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -1330,13 +1330,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                 approx_transfer_eff_perfect_adiab))
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = False
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = freq_array
-        block_ensemble.measurement_information['labels'] = ('Frequency', '')
-        block_ensemble.measurement_information['units'] = ('Hz', '')
-        block_ensemble.measurement_information['number_of_lasers'] = num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = False
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = freq_array
+        block_ensemble.measurement_information.labels = ('Frequency', '')
+        block_ensemble.measurement_information.units = ('Hz', '')
+        block_ensemble.measurement_information.number_of_lasers = num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -1471,13 +1471,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
                 approx_transfer_eff_perfect_adiab_ae))
 
         # add metadata to invoke settings later on
-        block_ensemble.measurement_information['alternating'] = False
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = freq_array
-        block_ensemble.measurement_information['labels'] = ('Frequency', '')
-        block_ensemble.measurement_information['units'] = ('Hz', '')
-        block_ensemble.measurement_information['number_of_lasers'] = num_of_points
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = False
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = freq_array
+        block_ensemble.measurement_information.labels = ('Frequency', '')
+        block_ensemble.measurement_information.units = ('Hz', '')
+        block_ensemble.measurement_information.number_of_lasers = num_of_points
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -1586,13 +1586,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         t1_sequence.refresh_parameters()
 
         # add metadata to invoke settings later on
-        t1_sequence.measurement_information['alternating'] = False
-        t1_sequence.measurement_information['laser_ignore_list'] = list()
-        t1_sequence.measurement_information['controlled_variable'] = tau_array
-        t1_sequence.measurement_information['units'] = ('s', '')
-        t1_sequence.measurement_information['labels'] = ('Tau<sub>pulse spacing</sub>', 'Signal')
-        t1_sequence.measurement_information['number_of_lasers'] = len(tau_array)
-        t1_sequence.measurement_information['counting_length'] = self._get_sequence_count_length(t1_sequence, created_ensembles, created_blocks)
+        t1_sequence.measurement_information.alternating = False
+        t1_sequence.measurement_information.laser_ignore_list = list()
+        t1_sequence.measurement_information.controlled_variable = tau_array
+        t1_sequence.measurement_information.units = ('s', '')
+        t1_sequence.measurement_information.labels = ('Tau<sub>pulse spacing</sub>', 'Signal')
+        t1_sequence.measurement_information.number_of_lasers = len(tau_array)
+        t1_sequence.measurement_information.counting_length = self._get_sequence_count_length(t1_sequence, created_ensembles, created_blocks)
 
         # Append PulseSequence to created_sequences list
         created_sequences.append(t1_sequence)

--- a/src/qudi/logic/pulsed/predefined_generate_methods/contdd_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/contdd_predefined_methods.py
@@ -121,13 +121,13 @@ class ContDDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Frequency', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -222,13 +222,13 @@ class ContDDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = order_array
-        block_ensemble.measurement_information['units'] = ('', '')
-        block_ensemble.measurement_information['labels'] = ('HHXY8 order', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = order_array
+        block_ensemble.measurement_information.units = ('', '')
+        block_ensemble.measurement_information.labels = ('HHXY8 order', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -310,13 +310,13 @@ class ContDDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Frequency', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -398,13 +398,13 @@ class ContDDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = order_array
-        block_ensemble.measurement_information['units'] = ('', '')
-        block_ensemble.measurement_information['labels'] = ('order', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = order_array
+        block_ensemble.measurement_information.units = ('', '')
+        block_ensemble.measurement_information.labels = ('order', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles

--- a/src/qudi/logic/pulsed/predefined_generate_methods/dd_predefined_methods.py
+++ b/src/qudi/logic/pulsed/predefined_generate_methods/dd_predefined_methods.py
@@ -146,13 +146,13 @@ class DDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = tau_array
-        block_ensemble.measurement_information['units'] = ('s', '')
-        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.units = ('s', '')
+        block_ensemble.measurement_information.labels = ('Tau', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles
@@ -277,13 +277,13 @@ class DDPredefinedGenerator(PredefinedGeneratorBase):
 
         # add metadata to invoke settings later on
         number_of_lasers = num_of_points * 2 if alternating else num_of_points
-        block_ensemble.measurement_information['alternating'] = alternating
-        block_ensemble.measurement_information['laser_ignore_list'] = list()
-        block_ensemble.measurement_information['controlled_variable'] = freq_array
-        block_ensemble.measurement_information['units'] = ('Hz', '')
-        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
-        block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
-        block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+        block_ensemble.measurement_information.alternating = alternating
+        block_ensemble.measurement_information.laser_ignore_list = list()
+        block_ensemble.measurement_information.controlled_variable = freq_array
+        block_ensemble.measurement_information.units = ('Hz', '')
+        block_ensemble.measurement_information.labels = ('Frequency', 'Signal')
+        block_ensemble.measurement_information.number_of_lasers = number_of_lasers
+        block_ensemble.measurement_information.counting_length = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
 
         # append ensemble to created ensembles

--- a/src/qudi/logic/pulsed/pulse_alt_plot.py
+++ b/src/qudi/logic/pulsed/pulse_alt_plot.py
@@ -126,14 +126,19 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
     Methods are imported from the ``qudi.logic.pulsed.alt_plot_methods`` namespace package and from
     the optional ``PulsedMeasurementLogic.alt_plot_import_path`` directory. The selected method and
-    all parameters are persisted by the measurement logic in a single StatusVar.
+    all parameters are held on ``PulsedMeasurementLogic.alternate_signal_settings`` (an
+    ``AlternativeSignalSettings`` instance) - mutated in place as this class's live state, and
+    persisted automatically as part of the measurement logic's regular settings StatusVar.
     """
 
     def __init__(self, pulsedmeasurementlogic):
         super().__init__(pulsedmeasurementlogic)
         self._methods: dict[str, AltPlotMethodBase] = dict()      # {name: instance}
-        self._parameters: dict[str, Any] = dict()   # union of all compute() kwargs
-        self._current_method: str | None = None  # None => no alternative plot
+        # The real, shared AlternativeSignalSettings instance held by PulsedMeasurementLogic's
+        # settings - not a copy. Mutated in place (attribute/dict assignment) as this class's
+        # real, live, authoritative state, the same pattern PulseExtractor/PulseAnalyzer already
+        # use for their own ExtractionParameters/AnalysisParameters.
+        self.__settings = pulsedmeasurementlogic.alternate_signal_settings
 
         # Import from the default namespace package
         import qudi.logic.pulsed.alt_plot_methods as default_ns
@@ -162,13 +167,29 @@ class AltPlotAnalyzer(AltPlotMethodBase):
                 self.log.warning(f'Duplicate alternative plot method name "{method_name}". '
                                  f'Overwriting the previously registered one.')
             self._methods[method_name] = instance
-            self._parameters.update(self._get_method_kwargs(instance.compute))
+            # Values already persisted in self.__settings.parameters (e.g. from a previous
+            # session) win over compute()'s own signature defaults - see _get_method_kwargs().
+            self.__settings.parameters.update(self._get_method_kwargs(instance.compute))
 
-        # Restore persisted selection and parameters if handed over
-        stored = getattr(pulsedmeasurementlogic, 'alt_plot_parameters', None)
-        if isinstance(stored, dict):
-            self.alt_plot_settings = {k: v for k, v in stored.items()
-                                      if k == 'method' or k in self._parameters}
+        # Drop any persisted parameter that no longer corresponds to a real method (e.g. removed
+        # or renamed since last session) - mirrors PulseExtractor/PulseAnalyzer's same cleanup, so
+        # a stale value can't accumulate forever or get silently adopted by an unrelated future
+        # method that happens to reuse the same parameter name.
+        valid_parameter_names = set()
+        for instance in self._methods.values():
+            valid_parameter_names.update(inspect.signature(instance.compute).parameters.keys())
+        valid_parameter_names.discard('signal_data')
+        for param in [p for p in list(self.__settings.parameters) if p not in valid_parameter_names]:
+            del self.__settings.parameters[param]
+
+        # A persisted selection that no longer matches any loaded method (e.g. its plugin file
+        # was removed, or this is the very first activation) must not be kept as "selected".
+        if self.__settings.method not in self._methods:
+            if self.__settings.method is not None:
+                self.log.warning(f'Previously selected alternative plot method '
+                                 f'"{self.__settings.method}" is no longer available. Disabling '
+                                 f'alternative plot.')
+            self.__settings.method = None
 
     @property
     def alt_plot_methods(self) -> list[str]:
@@ -177,23 +198,23 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
     @property
     def current_method(self) -> str | None:
-        return self._current_method
+        return self.__settings.method
 
     @current_method.setter
     def current_method(self, name: str | None) -> None:
         if name in (None, '', 'None'):
-            self._current_method = None
+            self.__settings.method = None
         elif name in self._methods:
-            self._current_method = name
+            self.__settings.method = name
         else:
             self.log.error(f'Alternative plot method "{name}" not found in AltPlotAnalyzer.')
 
     @property
     def alt_plot_settings(self) -> dict[str, Any]:
         """ Current method's parameters plus the selected method name (key "method"). """
-        method = self._methods.get(self._current_method)
+        method = self._methods.get(self.__settings.method)
         settings = self._get_method_kwargs(method.compute) if method is not None else dict()
-        settings['method'] = self._current_method
+        settings['method'] = self.__settings.method
         return settings
 
     @alt_plot_settings.setter
@@ -203,18 +224,11 @@ class AltPlotAnalyzer(AltPlotMethodBase):
         for parameter, value in settings_dict.items():
             if parameter == 'method':
                 self.current_method = value
-            elif parameter in self._parameters:
-                self._parameters[parameter] = value
+            elif parameter in self.__settings.parameters:
+                self.__settings.parameters[parameter] = value
             else:
                 self.log.warning(f'No alternative plot parameter "{parameter}" in AltPlotAnalyzer. '
                                  f'Ignoring it.')
-
-    @property
-    def full_settings_dict(self) -> dict[str, Any]:
-        """ All parameters plus the current method, for persisting in a StatusVar. """
-        settings = self._parameters.copy()
-        settings['method'] = self._current_method
-        return settings
 
     @property
     def alt_plot_labels(self) -> dict[str, dict[str, str]]:
@@ -223,12 +237,12 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
     @property
     def current_labels(self) -> dict[str, str]:
-        method = self._methods.get(self._current_method)
+        method = self._methods.get(self.__settings.method)
         return method.labels_dict if method is not None else dict()
 
     def is_available(self, name: str | None = None) -> bool:
         """ Whether the given (default: current) method can be used for the active settings. """
-        method = self._methods.get(self._current_method if name is None else name)
+        method = self._methods.get(self.__settings.method if name is None else name)
         if method is None:
             return False
         try:
@@ -239,9 +253,9 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
     def compute_alt_data(self, signal_data: np.ndarray) -> np.ndarray | None:
         """ Evaluate the current method, or return None if none selected/unavailable/not evaluable. """
-        if self._current_method is None or not self.is_available(self._current_method):
+        if self.__settings.method is None or not self.is_available(self.__settings.method):
             return None
-        method = self._methods[self._current_method]
+        method = self._methods[self.__settings.method]
         return method.compute(signal_data=signal_data, **self._get_method_kwargs(method.compute))
 
     # --- helpers ---
@@ -252,7 +266,7 @@ class AltPlotAnalyzer(AltPlotMethodBase):
         for name, param in inspect.signature(compute_method).parameters.items():
             if name == 'signal_data':
                 continue
-            stored = self._parameters.get(name)
+            stored = self.__settings.parameters.get(name)
             kwargs[name] = stored if type(stored) == type(param.default) else param.default
         return kwargs
 

--- a/src/qudi/logic/pulsed/pulse_analyzer.py
+++ b/src/qudi/logic/pulsed/pulse_analyzer.py
@@ -149,6 +149,12 @@ class PulseAnalyzer(PulseAnalyzerBase):
 
         # Ensure a valid current method is selected
         if self._parameters.get('method') not in self._analysis_methods:
+            invalid_method = self._parameters.get('method')
+            if invalid_method is not None:
+                self.log.warning(
+                    'Analysis method "{0}" could not be found in PulseAnalyzer. '
+                    'Falling back to default.'.format(invalid_method)
+                )
             self._parameters['method'] = natural_sort(self._analysis_methods)[0]
         return
 

--- a/src/qudi/logic/pulsed/pulse_analyzer.py
+++ b/src/qudi/logic/pulsed/pulse_analyzer.py
@@ -164,7 +164,10 @@ class PulseAnalyzer(PulseAnalyzerBase):
         This property holds all parameters needed for the currently selected analysis_method as
         well as the currently selected method name.
 
-        @return dict: dictionary with keys being the parameter name and values being the parameter
+        Returns
+        -------
+        dict
+            Dictionary with keys being the parameter name and values being the parameter.
         """
         current_method = self._parameters.get('method')
         # Get reference to the extraction method
@@ -184,7 +187,10 @@ class PulseAnalyzer(PulseAnalyzerBase):
         Also sets the current analysis method by passing its name using key "method".
         Parameters not included in self._parameters (except "method") will be ignored.
 
-        @param dict settings_dict: dictionary containing the parameters to set (name, value)
+        Parameters
+        ----------
+        settings_dict : dict
+            Dictionary containing the parameters to set (name, value).
         """
         if not isinstance(settings_dict, dict):
             return
@@ -211,7 +217,10 @@ class PulseAnalyzer(PulseAnalyzerBase):
         """
         Return available analysis methods.
 
-        @return dict: Dictionary with keys being the method names and values being the methods.
+        Returns
+        -------
+        dict
+            Dictionary with keys being the method names and values being the methods.
         """
         return self._analysis_methods
 
@@ -220,12 +229,17 @@ class PulseAnalyzer(PulseAnalyzerBase):
         Wrapper method to call the currently selected analysis method with laser_data and the
         appropriate keyword arguments.
 
-        @param numpy.ndarray laser_data: 2D numpy array (dtype='int64') containing the timetraces
-                                         for all extracted laser pulses.
-        @return (numpy.ndarray, numpy.ndarray): tuple of two numpy arrays containing the evaluated
-                                                signal data (one data point for each laser pulse)
-                                                and the measurement error corresponding to each
-                                                data point.
+        Parameters
+        ----------
+        laser_data : numpy.ndarray
+            2D numpy array (dtype='int64') containing the timetraces for all extracted laser
+            pulses.
+
+        Returns
+        -------
+        (numpy.ndarray, numpy.ndarray)
+            Tuple of two numpy arrays containing the evaluated signal data (one data point for
+            each laser pulse) and the measurement error corresponding to each data point.
         """
         current_method = self._parameters.get('method')
         analysis_method = self._analysis_methods[current_method]
@@ -239,9 +253,16 @@ class PulseAnalyzer(PulseAnalyzerBase):
         Try to take the values from self._parameters. If the keyword is missing in the dictionary,
         take the default values from the method signature.
 
-        @param method: reference to a callable analysis method
-        @return dict: A dictionary containing the argument keywords for <method> and corresponding
-                      values from self._parameters.
+        Parameters
+        ----------
+        method
+            Reference to a callable analysis method.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the argument keywords for <method> and corresponding values
+            from self._parameters.
         """
         kwargs_dict = dict()
         method_signature = inspect.signature(method)
@@ -263,8 +284,15 @@ class PulseAnalyzer(PulseAnalyzerBase):
         Find all classes in those modules that inherit exclusively from PulseAnalyzerBase class
         and return a list of them.
 
-        @param str path: Paths to import modules from
-        @return list: A list of imported valid analyzer classes
+        Parameters
+        ----------
+        path : str
+            Paths to import modules from.
+
+        Returns
+        -------
+        list
+            A list of imported valid analyzer classes.
         """
         class_list = list()
         # Get all python modules to import from.
@@ -293,7 +321,10 @@ class PulseAnalyzer(PulseAnalyzerBase):
         Helper method to populate the dictionaries containing all references to callable analysis
         methods contained in analyzer instances passed to this method.
 
-        @param list instance_list: List containing instances of analyzer classes
+        Parameters
+        ----------
+        instance_list : list
+            List containing instances of analyzer classes.
         """
         self._analysis_methods = dict()
         for instance in instance_list:
@@ -318,8 +349,15 @@ class PulseAnalyzer(PulseAnalyzerBase):
         """
         Helper method to check if an object is a valid analyzer class.
 
-        @param object obj: object to check
-        @return bool: True if obj is a valid analyzer class, False otherwise
+        Parameters
+        ----------
+        obj : object
+            Object to check.
+
+        Returns
+        -------
+        bool
+            True if obj is a valid analyzer class, False otherwise.
         """
         if inspect.isclass(obj):
             return PulseAnalyzerBase in obj.__bases__ and len(obj.__bases__) == 1

--- a/src/qudi/logic/pulsed/pulse_analyzer.py
+++ b/src/qudi/logic/pulsed/pulse_analyzer.py
@@ -86,10 +86,10 @@ class PulseAnalyzer(PulseAnalyzerBase):
 
         # Dictionary holding references to all analysis methods
         self._analysis_methods = dict()
-        # dictionary containing all possible parameters that can be used by the analysis methods
-        self._parameters = dict()
-        # Currently selected analysis method
-        self._current_analysis_method = None
+        # The real, shared AnalysisParameters instance held by PulsedMeasurementLogic's
+        # settings - not a copy. Mutated in place (dict item assignment) as this class's real,
+        # live, authoritative state; nothing else needs to be kept in sync with it.
+        self._parameters = pulsedmeasurementlogic.analysis_parameters
 
         # import analysis modules from default namespace package
         # "qudi.logic.pulsed.pulsed_analysis_methods"
@@ -133,21 +133,23 @@ class PulseAnalyzer(PulseAnalyzerBase):
         # add references to all analysis methods in each instance to a dict
         self.__populate_method_dict(instance_list=analyzer_instances)
 
-        # populate "_parameters" dictionary from analysis method signatures
+        # Drop any persisted parameter that no longer corresponds to a real method (e.g.
+        # removed or renamed since last session)
+        valid_parameter_names = set()
+        for method in self._analysis_methods.values():
+            valid_parameter_names.update(inspect.signature(method).parameters.keys())
+        valid_parameter_names.discard('laser_data')
+        for param in [p for p in list(self._parameters) if p not in valid_parameter_names and p != 'method']:
+            del self._parameters[param]
+
+        # Fill in defaults (from method signatures) for any valid parameter name not already
+        # present in the shared, persisted self._parameters dict (e.g. a newly discovered
+        # method). Never overwrites an already-persisted value.
         self.__populate_parameter_dict()
 
-        # Set default analysis method
-        self._current_analysis_method = natural_sort(self._analysis_methods)[0]
-
-        # Update from parameter_dict if handed over
-        if isinstance(pulsedmeasurementlogic.analysis_parameters, dict):
-            # Delete unused parameters
-            params = [p for p in pulsedmeasurementlogic.analysis_parameters if
-                      p not in self._parameters and p != 'method']
-            for param in params:
-                del pulsedmeasurementlogic.analysis_parameters[param]
-            # Update parameter dict and current method
-            self.analysis_settings = pulsedmeasurementlogic.analysis_parameters
+        # Ensure a valid current method is selected
+        if self._parameters.get('method') not in self._analysis_methods:
+            self._parameters['method'] = natural_sort(self._analysis_methods)[0]
         return
 
     @property
@@ -158,14 +160,15 @@ class PulseAnalyzer(PulseAnalyzerBase):
 
         @return dict: dictionary with keys being the parameter name and values being the parameter
         """
+        current_method = self._parameters.get('method')
         # Get reference to the extraction method
-        method = self._analysis_methods.get(self._current_analysis_method)
+        method = self._analysis_methods.get(current_method)
 
         # Get keyword arguments for the currently selected method
         settings_dict = self._get_analysis_method_kwargs(method)
 
         # Attach current analysis method name
-        settings_dict['method'] = self._current_analysis_method
+        settings_dict['method'] = current_method
         return settings_dict
 
     @analysis_settings.setter
@@ -180,12 +183,13 @@ class PulseAnalyzer(PulseAnalyzerBase):
         if not isinstance(settings_dict, dict):
             return
 
-        # go through all key-value pairs in settings_dict and update self._parameters and
-        # self._current_analysis_method accordingly. Ignore unknown parameters.
+        # go through all key-value pairs in settings_dict and update self._parameters
+        # (including the current method, stored under the 'method' key) accordingly. Ignore
+        # unknown parameters.
         for parameter, value in settings_dict.items():
             if parameter == 'method':
                 if value in self._analysis_methods:
-                    self._current_analysis_method = value
+                    self._parameters['method'] = value
                 else:
                     self.log.error('Analysis method "{0}" could not be found in PulseAnalyzer.'
                                    ''.format(value))
@@ -205,18 +209,6 @@ class PulseAnalyzer(PulseAnalyzerBase):
         """
         return self._analysis_methods
 
-    @property
-    def full_settings_dict(self):
-        """
-        Returns the full set of parameters for all methods as well as the currently selected method
-        in order to store them in a StatusVar in PulsedMeasurementLogic.
-
-        @return dict: full set of parameters and currently selected analysis method.
-        """
-        settings_dict = self._parameters.copy()
-        settings_dict['method'] = self._current_analysis_method
-        return settings_dict
-
     def analyse_laser_pulses(self, laser_data):
         """
         Wrapper method to call the currently selected analysis method with laser_data and the
@@ -229,7 +221,8 @@ class PulseAnalyzer(PulseAnalyzerBase):
                                                 and the measurement error corresponding to each
                                                 data point.
         """
-        analysis_method = self._analysis_methods[self._current_analysis_method]
+        current_method = self._parameters.get('method')
+        analysis_method = self._analysis_methods[current_method]
 
         kwargs = self._get_analysis_method_kwargs(analysis_method)
         return analysis_method(laser_data=laser_data, **kwargs)
@@ -305,12 +298,13 @@ class PulseAnalyzer(PulseAnalyzerBase):
 
     def __populate_parameter_dict(self):
         """
-        Helper method to populate the dictionary containing all possible keyword arguments from all
-        analysis methods.
+        Helper method to fill in default values (from method signatures) for any analysis
+        method keyword argument not already present in the shared self._parameters dict. Never
+        overwrites an already-present (e.g. persisted) value.
         """
-        self._parameters = dict()
         for method in self._analysis_methods.values():
-            self._parameters.update(self._get_analysis_method_kwargs(method=method))
+            for name, default in self._get_analysis_method_kwargs(method=method).items():
+                self._parameters.setdefault(name, default)
         return
 
     @staticmethod

--- a/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
+++ b/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
@@ -58,11 +58,13 @@ class BasicPulseExtractor(PulseExtractorBase):
         # apply gaussian filter to remove noise and compute the gradient of the timetrace sum
         try:
             conv = ndimage.filters.gaussian_filter1d(timetrace_sum.astype(float), conv_std_dev)
-        except:
+        except Exception:
+            self.log.exception('Gaussian smoothing failed during gated_conv_deriv extraction:')
             conv = np.zeros(timetrace_sum.size)
         try:
             conv_deriv = np.gradient(conv)
-        except:
+        except Exception:
+            self.log.exception('Gradient computation failed during gated_conv_deriv extraction:')
             conv_deriv = np.zeros(conv.size)
 
         # get indices of rising and falling flank
@@ -136,11 +138,13 @@ class BasicPulseExtractor(PulseExtractorBase):
         # apply gaussian filter to remove noise and compute the gradient of the timetrace sum
         try:
             conv = ndimage.filters.gaussian_filter1d(count_data.astype(float), conv_std_dev)
-        except:
+        except Exception:
+            self.log.exception('Gaussian smoothing failed during ungated_conv_deriv extraction:')
             conv = np.zeros(count_data.size)
         try:
             conv_deriv = np.gradient(conv)
-        except:
+        except Exception:
+            self.log.exception('Gradient computation failed during ungated_conv_deriv extraction:')
             conv_deriv = np.zeros(conv.size)
 
         # if gaussian smoothing or derivative failed, the returned array only contains zeros.
@@ -154,11 +158,17 @@ class BasicPulseExtractor(PulseExtractorBase):
         # a large conv_std_dev value.
         try:
             conv = ndimage.filters.gaussian_filter1d(count_data.astype(float), 10)
-        except:
+        except Exception:
+            self.log.exception(
+                'Reference gaussian smoothing failed during ungated_conv_deriv extraction:'
+            )
             conv = np.zeros(count_data.size)
         try:
             conv_deriv_ref = np.gradient(conv)
-        except:
+        except Exception:
+            self.log.exception(
+                'Reference gradient computation failed during ungated_conv_deriv extraction:'
+            )
             conv_deriv_ref = np.zeros(conv.size)
 
         # initialize arrays to contain indices for all rising and falling

--- a/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
+++ b/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
@@ -63,17 +63,13 @@ class BasicPulseExtractor(PulseExtractorBase):
         # sum up all gated timetraces to ease flank detection
         timetrace_sum = np.sum(count_data, 0)
 
-        # apply gaussian filter to remove noise and compute the gradient of the timetrace sum
-        try:
-            conv = ndimage.filters.gaussian_filter1d(timetrace_sum.astype(float), conv_std_dev)
-        except Exception:
-            self.log.exception('Gaussian smoothing failed during gated_conv_deriv extraction:')
-            conv = np.zeros(timetrace_sum.size)
-        try:
-            conv_deriv = np.gradient(conv)
-        except Exception:
-            self.log.exception('Gradient computation failed during gated_conv_deriv extraction:')
-            conv_deriv = np.zeros(conv.size)
+        # apply gaussian filter to remove noise and compute the gradient of the timetrace sum.
+        # Deliberately unguarded: PulsedMeasurementLogic._pulsed_analysis_loop() catches a failing
+        # tick, reports it through sigAnalysisProblem and keeps the previous data. Substituting a
+        # zero array here instead would hand flank detection a flat trace, which yields
+        # plausible-looking but wrong laser pulses with nothing to show the reader they are wrong.
+        conv = ndimage.gaussian_filter1d(timetrace_sum.astype(float), conv_std_dev)
+        conv_deriv = np.gradient(conv)
 
         # get indices of rising and falling flank
         rising_ind, falling_ind = sorted([int(np.clip(conv_deriv.argmax() - flank_width, 0, len(timetrace_sum))),
@@ -150,20 +146,13 @@ class BasicPulseExtractor(PulseExtractorBase):
         if not isinstance(number_of_lasers, int):
             return return_dict
 
-        # apply gaussian filter to remove noise and compute the gradient of the timetrace sum
-        try:
-            conv = ndimage.filters.gaussian_filter1d(count_data.astype(float), conv_std_dev)
-        except Exception:
-            self.log.exception('Gaussian smoothing failed during ungated_conv_deriv extraction:')
-            conv = np.zeros(count_data.size)
-        try:
-            conv_deriv = np.gradient(conv)
-        except Exception:
-            self.log.exception('Gradient computation failed during ungated_conv_deriv extraction:')
-            conv_deriv = np.zeros(conv.size)
+        # apply gaussian filter to remove noise and compute the gradient of the timetrace sum.
+        # Unguarded on purpose - see the note in gated_conv_deriv().
+        conv = ndimage.gaussian_filter1d(count_data.astype(float), conv_std_dev)
+        conv_deriv = np.gradient(conv)
 
-        # if gaussian smoothing or derivative failed, the returned array only contains zeros.
-        # Check for that and return also only zeros to indicate a failed pulse extraction.
+        # A completely flat derivative carries no flanks to find, so there is nothing to extract.
+        # Return zeros to signal that rather than letting argmax/argmin pick arbitrary indices.
         if len(conv_deriv.nonzero()[0]) == 0:
             return_dict['laser_counts_arr'] = np.zeros((number_of_lasers, 10), dtype='int64')
             return return_dict
@@ -171,20 +160,8 @@ class BasicPulseExtractor(PulseExtractorBase):
         # use a reference for array, because the exact position of the peaks or dips
         # (i.e. maxima or minima, which are the inflection points in the pulse) are distorted by
         # a large conv_std_dev value.
-        try:
-            conv = ndimage.filters.gaussian_filter1d(count_data.astype(float), 10)
-        except Exception:
-            self.log.exception(
-                'Reference gaussian smoothing failed during ungated_conv_deriv extraction:'
-            )
-            conv = np.zeros(count_data.size)
-        try:
-            conv_deriv_ref = np.gradient(conv)
-        except Exception:
-            self.log.exception(
-                'Reference gradient computation failed during ungated_conv_deriv extraction:'
-            )
-            conv_deriv_ref = np.zeros(conv.size)
+        conv = ndimage.gaussian_filter1d(count_data.astype(float), 10)
+        conv_deriv_ref = np.gradient(conv)
 
         # initialize arrays to contain indices for all rising and falling
         # flanks, respectively

--- a/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
+++ b/src/qudi/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
@@ -39,13 +39,21 @@ class BasicPulseExtractor(PulseExtractorBase):
         There is no information about the data needed.
         Only the gaussian filter width to reduce shot noise can be given as parameter.
 
-        @param 2D numpy.ndarray count_data: the raw timetrace data from a gated fast counter
-                                            dim 0: gate number; dim 1: time bin
-        @param float conv_std_dev: The standard deviation of the gaussian filter used for smoothing
-        @param int flank_width: The width of the flank in pixel to include/exclude additionally from the found position
+        Parameters
+        ----------
+        count_data : 2D numpy.ndarray
+            The raw timetrace data from a gated fast counter
+            dim 0: gate number; dim 1: time bin.
+        conv_std_dev : float
+            The standard deviation of the gaussian filter used for smoothing.
+        flank_width : int
+            The width of the flank in pixel to include/exclude additionally from the found position.
 
-        @return dict: The extracted laser pulses of the timetrace as well as the indices for rising
-                      and falling flanks.
+        Returns
+        -------
+        dict
+            The extracted laser pulses of the timetrace as well as the indices for rising
+            and falling flanks.
         """
         # Create return dictionary
         return_dict = {'laser_counts_arr': np.zeros(0, dtype='int64'),
@@ -90,11 +98,18 @@ class BasicPulseExtractor(PulseExtractorBase):
         """ Detects the laser pulses in the ungated timetrace data and extracts
             them.
 
-        @param numpy.ndarray count_data: The raw timetrace data (1D) from an ungated fast counter
-        @param float conv_std_dev: The standard deviation of the gaussian used for smoothing
+        Parameters
+        ----------
+        count_data : numpy.ndarray
+            The raw timetrace data (1D) from an ungated fast counter.
+        conv_std_dev : float
+            The standard deviation of the gaussian used for smoothing.
 
-        @return 2D numpy.ndarray:   2D array, the extracted laser pulses of the timetrace.
-                                    dimensions: 0: laser number, 1: time bin
+        Returns
+        -------
+        2D numpy.ndarray
+            2D array, the extracted laser pulses of the timetrace.
+            dimensions: 0: laser number, 1: time bin.
 
         Procedure:
             Edge Detection:
@@ -269,14 +284,20 @@ class BasicPulseExtractor(PulseExtractorBase):
         """
         Detects the laser pulses in the ungated timetrace data and extracts them.
     
-        @param numpy.ndarray count_data: The raw timetrace data (1D) from an ungated fast counter
-        @param count_threshold: 
-        @param min_laser_length: 
-        @param threshold_tolerance: 
-        
-        @return 2D numpy.ndarray:   2D array, the extracted laser pulses of the timetrace.
-                                    dimensions: 0: laser number, 1: time bin
-    
+        Parameters
+        ----------
+        count_data : numpy.ndarray
+            The raw timetrace data (1D) from an ungated fast counter.
+        count_threshold
+        min_laser_length
+        threshold_tolerance
+
+        Returns
+        -------
+        2D numpy.ndarray
+            2D array, the extracted laser pulses of the timetrace.
+            dimensions: 0: laser number, 1: time bin.
+
         Procedure:
             Threshold detection:
             ---------------
@@ -350,14 +371,21 @@ class BasicPulseExtractor(PulseExtractorBase):
             Finds the laser pulses from the ungated timetrace using that their positions are
             known. The laser pulses are then extracted using gated_conv_deriv.
 
-        @param numpy.ndarray count_data: 1D array the raw timetrace data from an ungated fast
-                                         counter
-        @param float conv_std_dev: The standard deviation of the gaussian filter used for smoothing
-        @param float delay:
-        @param float safety:
+        Parameters
+        ----------
+        count_data : numpy.ndarray
+            1D array the raw timetrace data from an ungated fast
+            counter.
+        conv_std_dev : float
+            The standard deviation of the gaussian filter used for smoothing.
+        delay : float
+        safety : float
 
-        @return 2D numpy.ndarray: 2D array, the extracted laser pulses of the timetrace.
-                                  dimensions: 0: laser number, 1: time bin
+        Returns
+        -------
+        2D numpy.ndarray
+            2D array, the extracted laser pulses of the timetrace.
+            dimensions: 0: laser number, 1: time bin.
         """
         # get the generation sampling rate
         sample_rate = self.sampling_information['pulse_generator_settings']['sample_rate']
@@ -407,11 +435,17 @@ class BasicPulseExtractor(PulseExtractorBase):
         into a 2D array, where the length of the second dimension is 1. The data itself is handed through.
         This function is useful, if the extraction and analysis are performed in hardware.
 
-        @param numpy.ndarray count_data: 1D array the raw timetrace data from an ungated fast
-                                         counter
+        Parameters
+        ----------
+        count_data : numpy.ndarray
+            1D array the raw timetrace data from an ungated fast
+            counter.
 
-        @return dict: The extracted laser pulses of the timetrace as well as the indices for rising
-                      and falling flanks.
+        Returns
+        -------
+        dict
+            The extracted laser pulses of the timetrace as well as the indices for rising
+            and falling flanks.
         """
         # Create return dictionary
         return_dict = {'laser_counts_arr': np.reshape(count_data, (-1, 1)),
@@ -425,11 +459,17 @@ class BasicPulseExtractor(PulseExtractorBase):
         This method does not actually extract anything. It just passes through the data from the hardware.
         This function is useful, if the extraction is performed in hardware.
 
-        @param 2D numpy.ndarray count_data: the raw timetrace data from a gated fast counter
-                                            dim 0: gate number; dim 1: time bin
+        Parameters
+        ----------
+        count_data : 2D numpy.ndarray
+            The raw timetrace data from a gated fast counter
+            dim 0: gate number; dim 1: time bin.
 
-        @return dict: The extracted laser pulses of the timetrace as well as the indices for rising
-                      and falling flanks.
+        Returns
+        -------
+        dict
+            The extracted laser pulses of the timetrace as well as the indices for rising
+            and falling flanks.
         """
         # Create return dictionary
         return_dict = {'laser_counts_arr': np.array(count_data),

--- a/src/qudi/logic/pulsed/pulse_extractor.py
+++ b/src/qudi/logic/pulsed/pulse_extractor.py
@@ -87,10 +87,10 @@ class PulseExtractor(PulseExtractorBase):
         # Dictionaries holding references to the extraction methods
         self._gated_extraction_methods = dict()
         self._ungated_extraction_methods = dict()
-        # dictionary containing all possible parameters that can be used by the extraction methods
-        self._parameters = dict()
-        # Currently selected extraction method
-        self._current_extraction_method = None
+        # The real, shared ExtractionParameters instance held by PulsedMeasurementLogic's
+        # settings - not a copy. Mutated in place (dict item assignment) as this class's real,
+        # live, authoritative state; nothing else needs to be kept in sync with it.
+        self._parameters = pulsedmeasurementlogic.extraction_parameters
 
         # import extraction modules from default namespace package
         # "qudi.logic.pulse_extraction_methods"
@@ -134,24 +134,24 @@ class PulseExtractor(PulseExtractorBase):
         # add references to all extraction methods in each instance to a dict
         self.__populate_method_dicts(instance_list=extractor_instances)
 
-        # populate "_parameters" dictionary from extraction method signatures
+        # Drop any persisted parameter that no longer corresponds to a real method (e.g.
+        # removed or renamed since last session)
+        valid_parameter_names = set()
+        for method in list(self._ungated_extraction_methods.values()) + list(self._gated_extraction_methods.values()):
+            valid_parameter_names.update(inspect.signature(method).parameters.keys())
+        valid_parameter_names.discard('count_data')
+        for param in [p for p in list(self._parameters) if p not in valid_parameter_names and p != 'method']:
+            del self._parameters[param]
+
+        # Fill in defaults (from method signatures) for any valid parameter name not already
+        # present in the shared, persisted self._parameters dict (e.g. a newly discovered
+        # method). Never overwrites an already-persisted value.
         self.__populate_parameter_dict()
 
-        # Set default extraction method
-        if self.is_gated:
-            self._current_extraction_method = natural_sort(self._gated_extraction_methods)[0]
-        else:
-            self._current_extraction_method = natural_sort(self._ungated_extraction_methods)[0]
-
-        # Update from parameter_dict if handed over
-        if isinstance(pulsedmeasurementlogic.extraction_parameters, dict):
-            # Delete unused parameters
-            params = [p for p in pulsedmeasurementlogic.extraction_parameters if
-                      p not in self._parameters and p != 'method']
-            for param in params:
-                del pulsedmeasurementlogic.extraction_parameters[param]
-            # Update parameter dict and current method
-            self.extraction_settings = pulsedmeasurementlogic.extraction_parameters
+        # Ensure a valid current method is selected for the current gated/ungated mode
+        available_methods = self._gated_extraction_methods if self.is_gated else self._ungated_extraction_methods
+        if self._parameters.get('method') not in available_methods:
+            self._parameters['method'] = natural_sort(available_methods)[0]
         return
 
     @property
@@ -162,17 +162,18 @@ class PulseExtractor(PulseExtractorBase):
 
         @return dict: dictionary with keys being the parameter name and values being the parameter
         """
+        current_method = self._parameters.get('method')
         # Get reference to the extraction method
         if self.is_gated:
-            method = self._gated_extraction_methods.get(self._current_extraction_method)
+            method = self._gated_extraction_methods.get(current_method)
         else:
-            method = self._ungated_extraction_methods.get(self._current_extraction_method)
+            method = self._ungated_extraction_methods.get(current_method)
 
         # Get keyword arguments for the currently selected method
         settings_dict = self._get_extraction_method_kwargs(method)
 
         # Attach current extraction method name
-        settings_dict['method'] = self._current_extraction_method
+        settings_dict['method'] = current_method
         return settings_dict
 
     @extraction_settings.setter
@@ -187,13 +188,14 @@ class PulseExtractor(PulseExtractorBase):
         if not isinstance(settings_dict, dict):
             return
 
-        # go through all key-value pairs in settings_dict and update self._parameters and
-        # self._current_extraction_method accordingly. Ignore unknown parameters.
+        # go through all key-value pairs in settings_dict and update self._parameters
+        # (including the current method, stored under the 'method' key) accordingly. Ignore
+        # unknown parameters.
         for parameter, value in settings_dict.items():
             if parameter == 'method':
                 if (value in self._gated_extraction_methods and self.is_gated) or (
                         value in self._ungated_extraction_methods and not self.is_gated):
-                    self._current_extraction_method = value
+                    self._parameters['method'] = value
                 else:
                     self.log.error('Extraction method "{0}" could not be found in PulseExtractor.'
                                    ''.format(value))
@@ -216,18 +218,6 @@ class PulseExtractor(PulseExtractorBase):
         else:
             return self._ungated_extraction_methods
 
-    @property
-    def full_settings_dict(self):
-        """
-        Returns the full set of parameters for all methods as well as the currently selected method
-        in order to store them in a StatusVar in PulsedMeasurementLogic.
-
-        @return dict: full set of parameters and currently selected extraction method.
-        """
-        settings_dict = self._parameters.copy()
-        settings_dict['method'] = self._current_extraction_method
-        return settings_dict
-
     def extract_laser_pulses(self, count_data):
         """
         Wrapper method to call the currently selected extraction method with count_data and the
@@ -244,10 +234,11 @@ class PulseExtractor(PulseExtractorBase):
             self.log.error('"is_gated" flag is set to True but the count data to extract laser '
                            'pulses from is in the format of an ungated timetrace (1D numpy array).')
 
+        current_method = self._parameters.get('method')
         if self.is_gated:
-            extraction_method = self._gated_extraction_methods[self._current_extraction_method]
+            extraction_method = self._gated_extraction_methods[current_method]
         else:
-            extraction_method = self._ungated_extraction_methods[self._current_extraction_method]
+            extraction_method = self._ungated_extraction_methods[current_method]
         kwargs = self._get_extraction_method_kwargs(extraction_method)
         return extraction_method(count_data=count_data, **kwargs)
 
@@ -325,14 +316,16 @@ class PulseExtractor(PulseExtractorBase):
 
     def __populate_parameter_dict(self):
         """
-        Helper method to populate the dictionary containing all possible keyword arguments from all
-        extraction methods.
+        Helper method to fill in default values (from method signatures) for any extraction
+        method keyword argument not already present in the shared self._parameters dict. Never
+        overwrites an already-present (e.g. persisted) value.
         """
-        self._parameters = dict()
         for method in self._ungated_extraction_methods.values():
-            self._parameters.update(self._get_extraction_method_kwargs(method=method))
+            for name, default in self._get_extraction_method_kwargs(method=method).items():
+                self._parameters.setdefault(name, default)
         for method in self._gated_extraction_methods.values():
-            self._parameters.update(self._get_extraction_method_kwargs(method=method))
+            for name, default in self._get_extraction_method_kwargs(method=method).items():
+                self._parameters.setdefault(name, default)
         return
 
     @staticmethod

--- a/src/qudi/logic/pulsed/pulse_extractor.py
+++ b/src/qudi/logic/pulsed/pulse_extractor.py
@@ -151,6 +151,12 @@ class PulseExtractor(PulseExtractorBase):
         # Ensure a valid current method is selected for the current gated/ungated mode
         available_methods = self._gated_extraction_methods if self.is_gated else self._ungated_extraction_methods
         if self._parameters.get('method') not in available_methods:
+            invalid_method = self._parameters.get('method')
+            if invalid_method is not None:
+                self.log.warning(
+                    'Extraction method "{0}" could not be found in PulseExtractor. '
+                    'Falling back to default.'.format(invalid_method)
+                )
             self._parameters['method'] = natural_sort(available_methods)[0]
         return
 

--- a/src/qudi/logic/pulsed/pulse_extractor.py
+++ b/src/qudi/logic/pulsed/pulse_extractor.py
@@ -166,7 +166,10 @@ class PulseExtractor(PulseExtractorBase):
         This property holds all parameters needed for the currently selected extraction_method as
         well as the currently selected method name.
 
-        @return dict: dictionary with keys being the parameter name and values being the parameter
+        Returns
+        -------
+        dict
+            Dictionary with keys being the parameter name and values being the parameter.
         """
         current_method = self._parameters.get('method')
         # Get reference to the extraction method
@@ -189,7 +192,10 @@ class PulseExtractor(PulseExtractorBase):
         Also sets the current extraction method by passing its name using key "method".
         Parameters not included in self._parameters (except "method") will be ignored.
 
-        @param dict settings_dict: dictionary containing the parameters to set (name, value)
+        Parameters
+        ----------
+        settings_dict : dict
+            Dictionary containing the parameters to set (name, value).
         """
         if not isinstance(settings_dict, dict):
             return
@@ -217,7 +223,10 @@ class PulseExtractor(PulseExtractorBase):
         """
         Return available extraction methods depending on if the fast counter is gated or not.
 
-        @return dict: Dictionary with keys being the method names and values being the methods.
+        Returns
+        -------
+        dict
+            Dictionary with keys being the method names and values being the methods.
         """
         if self.is_gated:
             return self._gated_extraction_methods
@@ -229,9 +238,16 @@ class PulseExtractor(PulseExtractorBase):
         Wrapper method to call the currently selected extraction method with count_data and the
         appropriate keyword arguments.
 
-        @param numpy.ndarray count_data: 1D (ungated) or 2D (gated) numpy array (dtype='int64')
-                                         containing the timetrace to extract laser pulses from.
-        @return dict: result dictionary of the extraction method
+        Parameters
+        ----------
+        count_data : numpy.ndarray
+            1D (ungated) or 2D (gated) numpy array (dtype='int64') containing the timetrace to
+            extract laser pulses from.
+
+        Returns
+        -------
+        dict
+            Result dictionary of the extraction method.
         """
         if count_data.ndim > 1 and not self.is_gated:
             self.log.error('"is_gated" flag is set to False but the count data to extract laser '
@@ -254,9 +270,16 @@ class PulseExtractor(PulseExtractorBase):
         Try to take the values from self._parameters. If the keyword is missing in the dictionary,
         take the default values from the method signature.
 
-        @param method: reference to a callable extraction method
-        @return dict: A dictionary containing the argument keywords for <method> and corresponding
-                      values from self._parameters.
+        Parameters
+        ----------
+        method
+            Reference to a callable extraction method.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the argument keywords for <method> and corresponding values
+            from self._parameters.
         """
         kwargs_dict = dict()
         method_signature = inspect.signature(method)
@@ -278,8 +301,15 @@ class PulseExtractor(PulseExtractorBase):
         Find all classes in those modules that inherit exclusively from PulseExtractorBase and
         return a list of them.
 
-        @param str path: Path to import modules from
-        @return list: A list of imported valid extractor classes
+        Parameters
+        ----------
+        path : str
+            Path to import modules from.
+
+        Returns
+        -------
+        list
+            A list of imported valid extractor classes.
         """
         class_list = list()
         # Get all python modules to import from.
@@ -308,7 +338,10 @@ class PulseExtractor(PulseExtractorBase):
         Helper method to populate the dictionaries containing all references to callable extraction
         methods contained in extractor instances passed to this method.
 
-        @param list instance_list: List containing instances of extractor classes
+        Parameters
+        ----------
+        instance_list : list
+            List containing instances of extractor classes.
         """
         self._ungated_extraction_methods = dict()
         self._gated_extraction_methods = dict()
@@ -339,8 +372,15 @@ class PulseExtractor(PulseExtractorBase):
         """
         Helper method to check if an object is a valid extractor class.
 
-        @param object obj: object to check
-        @return bool: True if obj is a valid extractor class, False otherwise
+        Parameters
+        ----------
+        obj : object
+            Object to check.
+
+        Returns
+        -------
+        bool
+            True if obj is a valid extractor class, False otherwise.
         """
         if inspect.isclass(obj):
             return PulseExtractorBase in obj.__bases__ and len(obj.__bases__) == 1

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -120,7 +120,7 @@ class PulseBlockElement(object):
             return False
         if set(self.digital_high.items()) != set(other.digital_high.items()):
             return False
-        for chnl, func in self.pulse_function:
+        for chnl, func in self.pulse_function.items():
             if func != other.pulse_function[chnl]:
                 return False
         return True
@@ -381,6 +381,11 @@ class PulseBlock(object):
         self.element_list.reverse()
         return
 
+    def copy(self):
+        """Independent copy: mutating the copy's element_list never affects the original (each
+        element is deep-copied, matching PulseBlock.insert()'s existing behavior)."""
+        return PulseBlock(name=self.name, element_list=[copy.deepcopy(e) for e in self.element_list])
+
     def get_dict_representation(self):
         dict_repr = dict()
         dict_repr['name'] = self.name
@@ -594,7 +599,7 @@ class PulseBlockEnsemble(object):
         )
         new_ensemble.sampling_information = self.sampling_information.copy()
         new_ensemble.measurement_information = self.measurement_information.copy()
-        new_ensemble.generation_method_parameters = GenerationMethodParameters(self.generation_method_parameters)
+        new_ensemble.generation_method_parameters = copy.deepcopy(self.generation_method_parameters)
         return new_ensemble
 
     def get_dict_representation(self):
@@ -711,7 +716,7 @@ class SequenceStep(dict):
         return
 
     def copy(self):
-        return SequenceStep(super().copy())
+        return SequenceStep(copy.deepcopy(dict(self)))
 
 
 class PulseSequence(object):
@@ -1014,15 +1019,10 @@ class PulseSequence(object):
 
     def copy(self):
         """Independent copy: mutating the copy's ensemble_list or its sampling/measurement/
-        generation_method_parameters containers never affects the original.
-
-        Unlike PulseBlockEnsemble.block_list (immutable (name, repetitions) tuples),
-        ensemble_list entries are SequenceStep - a mutable dict subclass - and
-        PulseSequence.insert() stores whatever SequenceStep instance it's given by reference
-        (no internal copy, unlike PulseBlock.insert()'s copy.deepcopy). A shallow list() copy
-        here would leave the copy and the original sharing the same SequenceStep objects, so
-        each step is copied individually via its own existing .copy() method instead.
-        """
+        generation_method_parameters containers never affects the original. Unlike
+        PulseBlockEnsemble.block_list (immutable tuples), ensemble_list entries are mutable
+        SequenceStep dicts stored by reference, so a shallow list() copy would still share them -
+        each step is copied individually via its own .copy() instead."""
         new_sequence = PulseSequence(
             name=self.name,
             ensemble_list=[step.copy() for step in self.ensemble_list],
@@ -1030,7 +1030,7 @@ class PulseSequence(object):
         )
         new_sequence.sampling_information = self.sampling_information.copy()
         new_sequence.measurement_information = self.measurement_information.copy()
-        new_sequence.generation_method_parameters = GenerationMethodParameters(self.generation_method_parameters)
+        new_sequence.generation_method_parameters = copy.deepcopy(self.generation_method_parameters)
         return new_sequence
 
     def get_dict_representation(self):

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -47,22 +47,26 @@ class PulseBlockElement(object):
         """
         The constructor for a Pulse_Block_Element needs to have:
 
-        @param float init_length_s: an initial length of the element, this parameters should not be
-                                    zero but must have a finite value.
-        @param float increment_s: the number which will be incremented during each repetition of
-                                  this element.
-        @param dict pulse_function: dictionary with keys being the qudi analog channel string
-                                    descriptors ('a_ch1', 'a_ch2' etc.) and the corresponding
-                                    objects being instances of the mathematical function objects
-                                    provided by SamplingFunctions class.
-        @param dict digital_high: dictionary with keys being the qudi digital channel string
-                                  descriptors ('d_ch1', 'd_ch2' etc.) and the corresponding objects
-                                  being boolean values describing if the channel should be logical
-                                  low (False) or high (True).
-                                  For 3 digital channel it may look like:
-                                  {'d_ch1': True, 'd_ch2': False, 'd_ch5': False}
-        @param bool laser_on: boolean indicating if the laser is on during this block.
-                              This is required for laser channels, that are not digital channels.
+        Parameters
+        ----------
+        init_length_s : float
+            An initial length of the element, this parameters should not be zero but must have a
+            finite value.
+        increment_s : float
+            The number which will be incremented during each repetition of this element.
+        pulse_function : dict
+            Dictionary with keys being the qudi analog channel string descriptors ('a_ch1', 'a_ch2'
+            etc.) and the corresponding objects being instances of the mathematical function objects
+            provided by SamplingFunctions class.
+        digital_high : dict
+            Dictionary with keys being the qudi digital channel string descriptors ('d_ch1', 'd_ch2'
+            etc.) and the corresponding objects being boolean values describing if the channel should
+            be logical low (False) or high (True).
+            For 3 digital channel it may look like:
+            {'d_ch1': True, 'd_ch2': False, 'd_ch5': False}
+        laser_on : bool
+            Boolean indicating if the laser is on during this block.
+            This is required for laser channels, that are not digital channels.
         """
         # FIXME: Sanity checks need to be implemented here
         self.init_length_s = init_length_s
@@ -153,9 +157,13 @@ class PulseBlock(object):
         """
         The constructor for a Pulse_Block needs to have:
 
-        @param str name: chosen name for the Pulse_Block
-        @param list element_list: which contains the Pulse_Block_Element Objects forming a
-                                  Pulse_Block, e.g. [Pulse_Block_Element, Pulse_Block_Element, ...]
+        Parameters
+        ----------
+        name : str
+            Chosen name for the Pulse_Block.
+        element_list : list
+            Which contains the Pulse_Block_Element Objects forming a Pulse_Block, e.g.
+            [Pulse_Block_Element, Pulse_Block_Element, ...].
         """
         self.name = name
         self.element_list = list() if element_list is None else element_list
@@ -329,8 +337,12 @@ class PulseBlock(object):
         """Insert a PulseBlockElement at the given position. The old element at this position and
         all consecutive elements after that will be shifted to higher indices.
 
-        @param int position: position in the element list
-        @param PulseBlockElement element: PulseBlockElement instance
+        Parameters
+        ----------
+        position : int
+            Position in the element list.
+        element : PulseBlockElement
+            PulseBlockElement instance.
         """
         if not isinstance(element, PulseBlockElement):
             raise ValueError('PulseBlock elements must be of type PulseBlockElement, not {0}'.format(type(element)))
@@ -412,11 +424,15 @@ class PulseBlockEnsemble(object):
         """
         The constructor for a Pulse_Block_Ensemble needs to have:
 
-        @param str name: chosen name for the PulseBlockEnsemble
-        @param list block_list: contains the PulseBlock names with their number of repetitions,
-                                e.g. [(name, repetitions), (name, repetitions), ...])
-        @param bool rotating_frame: indicates whether the phase should be preserved for all the
-                                    functions.
+        Parameters
+        ----------
+        name : str
+            Chosen name for the PulseBlockEnsemble.
+        block_list : list
+            Contains the PulseBlock names with their number of repetitions, e.g. [(name,
+            repetitions), (name, repetitions), ...]).
+        rotating_frame : bool
+            Indicates whether the phase should be preserved for all the functions.
         """
         # FIXME: Sanity checking needed here
         self.name = name
@@ -544,8 +560,12 @@ class PulseBlockEnsemble(object):
         """Insert a (PulseBlock.name, repetitions) tuple at the given position. The old element
         at this position and all consecutive elements after that will be shifted to higher indices.
 
-        @param int position: position in the element list
-        @param tuple element: (PulseBlock name (str), repetitions (int))
+        Parameters
+        ----------
+        position : int
+            Position in the element list.
+        element : tuple
+            (PulseBlock name (str), repetitions (int)).
         """
         if not isinstance(element, (tuple, list)) or len(element) != 2:
             raise TypeError('PulseBlockEnsemble block list entries must be a tuple or list of length 2')
@@ -731,48 +751,43 @@ class PulseSequence(object):
         """
         The constructor for a PulseSequence objects needs to have:
 
-        @param str name: the actual name of the sequence
-        @param list ensemble_list: list containing a tuple of two entries:
-                                          [(PulseBlockEnsemble name, seq_param),
-                                           (PulseBlockEnsemble name, seq_param), ...]
-                                          The seq_param is a dictionary, where the various sequence
-                                          parameters are saved with their keywords and the
-                                          according parameter (as item).
-                                          Available parameters are:
-                                          'repetitions': The number of repetitions for that sequence
-                                                         step. (Default 0)
-                                                         0 meaning the step is played once.
-                                                         Set to -1 for infinite looping.
-                                          'go_to':   The sequence step index to jump to after
-                                                     having played all repetitions. (Default -1)
-                                                     Indices starting at 1 for first step.
-                                                     Set to 0 or -1 to follow up with the next step.
-                                          'event_jump_to': The sequence step to jump to
-                                                           (starting from 1) in case of a trigger
-                                                           event (see event_trigger).
-                                                           Setting it to 0 or -1 means jump to next
-                                                           step. Ignored if event_trigger is 'OFF'.
-                                          'event_trigger': The trigger input to listen to in order
-                                                           to perform sequence jumps. Set to 'OFF'
-                                                           (default) in order to ignore triggering.
-                                          'wait_for': The trigger input to wait for before playing
-                                                      this sequence step. Set to 'OFF' (default)
-                                                      in order to play the current step immediately.
-                                          'flag_trigger': List containing the flags (str) to
-                                                          trigger when this sequence step starts
-                                                          playing. Empty list (default) for no flag
-                                                          trigger.
-                                          'flag_high': List containing the flags (str) to set to
-                                                       high when this sequence step is playing. All
-                                                       others will be low (or triggered; see above).
-                                                       Empty list (default) for all flags low.
+        Parameters
+        ----------
+        name : str
+            The actual name of the sequence.
+        ensemble_list : list
+            List containing a tuple of two entries:
+            [(PulseBlockEnsemble name, seq_param), (PulseBlockEnsemble name, seq_param), ...]
+            The seq_param is a dictionary, where the various sequence parameters are saved with
+            their keywords and the according parameter (as item).
+            Available parameters are:
 
-                                          If only 'repetitions' are in the dictionary, then the dict
-                                          will look like:
-                                            seq_param = {'repetitions': 41}
-                                          and so the respective sequence step will play 42 times.
-        @param bool rotating_frame: indicates, whether the phase has to be preserved in all
-                                    analog signals ACROSS different waveforms
+            'repetitions': The number of repetitions for that sequence step. (Default 0)
+                0 meaning the step is played once.
+                Set to -1 for infinite looping.
+            'go_to': The sequence step index to jump to after having played all repetitions.
+                (Default -1)
+                Indices starting at 1 for first step.
+                Set to 0 or -1 to follow up with the next step.
+            'event_jump_to': The sequence step to jump to (starting from 1) in case of a trigger
+                event (see event_trigger).
+                Setting it to 0 or -1 means jump to next step. Ignored if event_trigger is 'OFF'.
+            'event_trigger': The trigger input to listen to in order to perform sequence jumps.
+                Set to 'OFF' (default) in order to ignore triggering.
+            'wait_for': The trigger input to wait for before playing this sequence step. Set to
+                'OFF' (default) in order to play the current step immediately.
+            'flag_trigger': List containing the flags (str) to trigger when this sequence step
+                starts playing. Empty list (default) for no flag trigger.
+            'flag_high': List containing the flags (str) to set to high when this sequence step
+                is playing. All others will be low (or triggered; see above). Empty list (default)
+                for all flags low.
+
+            If only 'repetitions' are in the dictionary, then the dict will look like:
+            seq_param = {'repetitions': 41}
+            and so the respective sequence step will play 42 times.
+        rotating_frame : bool
+            Indicates, whether the phase has to be preserved in all analog signals ACROSS
+            different waveforms.
         """
         self.name = name
         self.rotating_frame = rotating_frame
@@ -956,10 +971,13 @@ class PulseSequence(object):
         Insert a SequenceStep instance at the given position. The old element
         at this position and all consecutive elements after that will be shifted to higher indices.
 
-        @param int position: position in the ensemble list
-        @param tuple|list|str|dict|SequenceStep element:
+        Parameters
+        ----------
+        position : int
+            Position in the ensemble list.
+        element : tuple or list or str or dict or SequenceStep
             PulseBlockEnsemble name (str) |
-            (PulseBlockEnsemble name, sequence parameters dict) (tuple|list) |
+            (PulseBlockEnsemble name, sequence parameters dict) (tuple or list) |
             sequence parameters dict including PulseBlockEnsemble name (dict) |
             SequenceStep instance (SequenceStep)
         """
@@ -1245,10 +1263,17 @@ class PredefinedGeneratorBase:
         """
         Creates an idle pulse PulseBlockElement
 
-        @param float length: idle duration in seconds
-        @param float increment: idle duration increment in seconds
+        Parameters
+        ----------
+        length : float
+            Idle duration in seconds.
+        increment : float
+            Idle duration increment in seconds.
 
-        @return: PulseBlockElement, the generated idle element
+        Returns
+        -------
+        PulseBlockElement
+            The generated idle element.
         """
         # Create idle element
         return PulseBlockElement(
@@ -1262,11 +1287,19 @@ class PredefinedGeneratorBase:
         """
         Creates a trigger PulseBlockElement
 
-        @param float length: trigger duration in seconds
-        @param float increment: trigger duration increment in seconds
-        @param str|list channels: The pulser channel(s) to be triggered.
+        Parameters
+        ----------
+        length : float
+            Trigger duration in seconds.
+        increment : float
+            Trigger duration increment in seconds.
+        channels : str or list
+            The pulser channel(s) to be triggered.
 
-        @return: PulseBlockElement, the generated trigger element
+        Returns
+        -------
+        PulseBlockElement
+            The generated trigger element.
         """
         if isinstance(channels, str):
             channels = [channels]
@@ -1291,10 +1324,17 @@ class PredefinedGeneratorBase:
         """
         Creates laser trigger PulseBlockElement
 
-        @param float length: laser pulse duration in seconds
-        @param float increment: laser pulse duration increment in seconds
+        Parameters
+        ----------
+        length : float
+            Laser pulse duration in seconds.
+        increment : float
+            Laser pulse duration increment in seconds.
 
-        @return: PulseBlockElement, two elements for laser and gate trigger (delay element)
+        Returns
+        -------
+        PulseBlockElement
+            Two elements for laser and gate trigger (delay element).
         """
         laser_element = self._get_trigger_element(length=length, increment=increment, channels=self.laser_channel)
         laser_element.laser_on = True
@@ -1316,7 +1356,10 @@ class PredefinedGeneratorBase:
         """
         Creates an idle element of length of the laser delay
 
-        @return PulseBlockElement: The delay element
+        Returns
+        -------
+        PulseBlockElement
+            The delay element.
         """
         return self._get_idle_element(length=self.laser_delay, increment=0)
 
@@ -1325,7 +1368,10 @@ class PredefinedGeneratorBase:
         Creates a gate trigger of length of the laser delay.
         If no gate channel is specified will return a simple idle element.
 
-        @return PulseBlockElement: The delay element
+        Returns
+        -------
+        PulseBlockElement
+            The delay element.
         """
         if self.gate_channel:
             return self._get_trigger_element(length=self.laser_delay, increment=0, channels=self.gate_channel)
@@ -1363,13 +1409,23 @@ class PredefinedGeneratorBase:
         """
         Creates a MW pulse PulseBlockElement
 
-        @param float length: MW pulse duration in seconds
-        @param float increment: MW pulse duration increment in seconds
-        @param float freq: MW frequency in case of analogue MW channel in Hz
-        @param float amp: MW amplitude in case of analogue MW channel in V
-        @param float phase: MW phase in case of analogue MW channel in deg
+        Parameters
+        ----------
+        length : float
+            MW pulse duration in seconds.
+        increment : float
+            MW pulse duration increment in seconds.
+        freq : float
+            MW frequency in case of analogue MW channel in Hz.
+        amp : float
+            MW amplitude in case of analogue MW channel in V.
+        phase : float
+            MW phase in case of analogue MW channel in deg.
 
-        @return: PulseBlockElement, the generated MW element
+        Returns
+        -------
+        PulseBlockElement
+            The generated MW element.
         """
         envelope = self._get_envelope(envelope)
         self.log.debug(f"_get_mw_element called with envelope {envelope}")
@@ -1406,12 +1462,23 @@ class PredefinedGeneratorBase:
         """
         Creates single, double or triple sine mw element.
 
-        @param float length: MW pulse duration in seconds
-        @param float increment: MW pulse duration increment in seconds
-        @param amps: list containing the amplitudes
-        @param freqs: list containing the frequencies
-        @param phases: list containing the phases
-        @return: PulseBlockElement, the generated MW element
+        Parameters
+        ----------
+        length : float
+            MW pulse duration in seconds.
+        increment : float
+            MW pulse duration increment in seconds.
+        amps
+            List containing the amplitudes.
+        freqs
+            List containing the frequencies.
+        phases
+            List containing the phases.
+
+        Returns
+        -------
+        PulseBlockElement
+            The generated MW element.
         """
         if isinstance(amps, (int, float)):
             amps = [amps]
@@ -1605,13 +1672,13 @@ class PredefinedGeneratorBase:
 
     def _get_mw_laser_element(self, length, increment, amp=None, freq=None, phase=None):
         """
-
-        @param length:
-        @param increment:
-        @param amp:
-        @param freq:
-        @param phase:
-        @return:
+        Parameters
+        ----------
+        length
+        increment
+        amp
+        freq
+        phase
         """
         mw_laser_element = self._get_mw_element(length=length, increment=increment, amp=amp, freq=freq, phase=phase)
         if self.laser_channel.startswith('d'):
@@ -1630,14 +1697,25 @@ class PredefinedGeneratorBase:
         """
         Creates a MW pulse PulseBlockElement
 
-        @param float length: MW pulse duration in seconds
-        @param float increment: MW pulse duration increment in seconds
-        @param float start_freq: start MW frequency in case of analogue MW channel in Hz
-        @param float stop_freq: stop MW frequency in case of analogue MW channel in Hz
-        @param float amp: MW amplitude in case of analogue MW channel in V
-        @param float phase: MW phase in case of analogue MW channel in deg
+        Parameters
+        ----------
+        length : float
+            MW pulse duration in seconds.
+        increment : float
+            MW pulse duration increment in seconds.
+        start_freq : float
+            Start MW frequency in case of analogue MW channel in Hz.
+        stop_freq : float
+            Stop MW frequency in case of analogue MW channel in Hz.
+        amp : float
+            MW amplitude in case of analogue MW channel in V.
+        phase : float
+            MW phase in case of analogue MW channel in deg.
 
-        @return: PulseBlockElement, the generated MW element
+        Returns
+        -------
+        PulseBlockElement
+            The generated MW element.
         """
         if self.microwave_channel.startswith('d'):
             mw_element = self._get_trigger_element(length=length, increment=increment, channels=self.microwave_channel)
@@ -1659,14 +1737,25 @@ class PredefinedGeneratorBase:
         """
         Creates a MW pulse PulseBlockElement
 
-        @param float length: MW pulse duration in seconds
-        @param float increment: MW pulse duration increment in seconds
-        @param float start_freq: start MW frequency in case of analogue MW channel in Hz
-        @param float stop_freq: stop MW frequency in case of analogue MW channel in Hz
-        @param float amp: MW amplitude in case of analogue MW channel in V
-        @param float phase: MW phase in case of analogue MW channel in deg
+        Parameters
+        ----------
+        length : float
+            MW pulse duration in seconds.
+        increment : float
+            MW pulse duration increment in seconds.
+        start_freq : float
+            Start MW frequency in case of analogue MW channel in Hz.
+        stop_freq : float
+            Stop MW frequency in case of analogue MW channel in Hz.
+        amp : float
+            MW amplitude in case of analogue MW channel in V.
+        phase : float
+            MW phase in case of analogue MW channel in deg.
 
-        @return: PulseBlockElement, the generated MW element
+        Returns
+        -------
+        PulseBlockElement
+            The generated MW element.
         """
         if self.microwave_channel.startswith('d'):
             mw_element = self._get_trigger_element(length=length, increment=increment, channels=self.microwave_channel)
@@ -1748,10 +1837,17 @@ class PredefinedGeneratorBase:
         should check if the timing value is generateable with the current sampling rate and if nout round
         it to the next possible value...
 
-        @param value: the desired timing value
-        @param divisibility: Takes into account that only parts of variables might be used
-                             (for example for a pi/2 pulse...)
-        @return: value matching to the current sampling rate of pulser
+        Parameters
+        ----------
+        value
+            The desired timing value.
+        divisibility
+            Takes into account that only parts of variables might be used (for example for a
+            pi/2 pulse...).
+
+        Returns
+        -------
+        Value matching to the current sampling rate of pulser.
         """
         resolution = 1 / self.sample_rate * divisibility
         mod = value % resolution
@@ -1766,10 +1862,10 @@ class PredefinedGeneratorBase:
 
     def _get_ensemble_count_length(self, ensemble, created_blocks):
         """
-
-        @param ensemble:
-        @param created_blocks:
-        @return:
+        Parameters
+        ----------
+        ensemble
+        created_blocks
         """
         if self.gate_channel:
             length = self.laser_length + self.laser_delay
@@ -1866,8 +1962,15 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
         Find all classes in those modules that inherit exclusively from PredefinedGeneratorBase
         class and return a list of them.
 
-        @param str path: Path to import modules from
-        @return list: A list of imported valid generator classes
+        Parameters
+        ----------
+        path : str
+            Path to import modules from.
+
+        Returns
+        -------
+        list
+            A list of imported valid generator classes.
         """
         class_list = list()
         # Get all python modules to import from.
@@ -1897,7 +2000,10 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
         Helper method to populate the dictionaries containing all references to callable generate
         methods contained in generator instances passed to this method.
 
-        @param list instance_list: List containing instances of generator classes
+        Parameters
+        ----------
+        instance_list : list
+            List containing instances of generator classes.
         """
         self._generate_methods = dict()
         for instance in instance_list:
@@ -1926,8 +2032,15 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
         """
         Helper method to check if an object is a valid generator class.
 
-        @param object obj: object to check
-        @return bool: True if obj is a valid generator class, False otherwise
+        Parameters
+        ----------
+        obj : object
+            Object to check.
+
+        Returns
+        -------
+        bool
+            True if obj is a valid generator class, False otherwise.
         """
         if inspect.isclass(obj):
             return PredefinedGeneratorBase in obj.mro()

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -28,10 +28,13 @@ import importlib
 import numpy as np
 import warnings
 
+from dataclasses import field, make_dataclass
+
 from qudi.logic.pulsed.sampling_functions import SamplingFunctions, PulseEnvelope, PulseEnvelopeType
 from qudi.util.helpers import natural_sort, iter_modules_recursive
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import MeasurementInformation, GenerationMethodParameters
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
+from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import BaseGenerationParameters
 
 
 class PulseBlockElement(object):
@@ -1089,6 +1092,63 @@ class PulseSequence(object):
         return new_seq
 
 
+def _as_generation_parameter_contributor(entry, owner):
+    """Normalise one `generation_parameter_contributors` entry to a BaseGenerationParameters subclass.
+
+    A subclass passes through; a `{name: default}` dict is turned into one, taking each field's type
+    from its default so the inherited type-driven coercion applies unchanged.
+
+    Parameters
+    ----------
+    entry : type or dict
+    owner : type
+        The generator class that declared it, used to name the synthesised class and in errors.
+
+    Returns
+    -------
+    type
+        A BaseGenerationParameters subclass.
+
+    Raises
+    ------
+    TypeError
+        If `entry` is neither, or a dict value's type has no sensible field default.
+    """
+    if isinstance(entry, type):
+        if not issubclass(entry, BaseGenerationParameters):
+            raise TypeError(
+                f'{owner.__name__}.generation_parameter_contributors lists {entry.__name__}, which '
+                f'does not inherit BaseGenerationParameters.'
+            )
+        return entry
+    if not isinstance(entry, dict):
+        raise TypeError(
+            f'{owner.__name__}.generation_parameter_contributors entries must be a '
+            f'BaseGenerationParameters subclass or a dict of defaults, got {type(entry).__name__}.'
+        )
+
+    specs = []
+    for name, default in entry.items():
+        if not isinstance(name, str) or not name.isidentifier():
+            raise TypeError(
+                f'{owner.__name__}.generation_parameter_contributors: "{name}" is not a valid '
+                f'parameter name.'
+            )
+        # Mutable defaults need a factory; dataclass rejects them outright.
+        spec = (
+            field(default_factory=lambda value=default: copy.deepcopy(value))
+            if isinstance(default, (dict, list, set, bytearray))
+            else field(default=default)
+        )
+        specs.append((name, type(default), spec))
+    # make_dataclass rather than type() with a hand-built '__annotations__' namespace: it is the
+    # supported way to build a dataclass dynamically, so how annotations reach the decorator stays
+    # the interpreter's business rather than an assumption of ours.
+    return make_dataclass(
+        f'{owner.__name__}Parameters', specs, bases=(BaseGenerationParameters,), frozen=True
+    )
+
+
 class PredefinedGeneratorBase:
     """
     Base class for PulseObjectGenerator and predefined generator classes containing the actual
@@ -1099,9 +1159,26 @@ class PredefinedGeneratorBase:
     SequenceGeneratorLogic logger is also accessible via this base class and can be used as in any
     qudi module (e.g. self.log.error(...)).
     Also provides helper methods to simplify sequence/ensemble generation.
+
+    A subclass needing global generation parameters of its own declares them in
+    `generation_parameter_contributors`; they become ordinary GenerationParameters fields when the
+    SequenceGeneratorLogic activates, with a widget on the Predefined Methods tab and a slot in the
+    status file. Either form works::
+
+        generation_parameter_contributors = ({'rf_amplitude': 1e-3, 'rf_channel': 'a_ch2'},)
+
+        generation_parameter_contributors = (MyLabParameters,)  # a BaseGenerationParameters subclass
+
+    The dict form infers each type from its default and is enough for str/int/float/bool values;
+    declare a subclass when a parameter needs an Enum, a PulseEnvelope or custom coercion. Parameters
+    the whole setup shares, rather than one generator, belong in generation_parameter_extensions.py
+    instead.
     """
 
-    def __init__(self, sequencegeneratorlogic): 
+    #: Generation parameters this generator needs - see the class docstring.
+    generation_parameter_contributors = ()
+
+    def __init__(self, sequencegeneratorlogic):
         # Keep protected reference to the SequenceGeneratorLogic
         self.__sequencegeneratorlogic = sequencegeneratorlogic
 
@@ -1954,6 +2031,8 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
                 except:
                     self.log.exception(f'Unable to import predefined generator from "{path}":')
 
+        self._generator_classes = generator_classes
+
         # create an instance of each class and put them in a temporary list
         generator_instances = [cls(sequencegeneratorlogic) for cls in generator_classes]
         self._generator_instances = generator_instances
@@ -1963,6 +2042,47 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
 
         # populate parameters dictionary from generate method signatures
         self.__populate_parameter_dict()
+
+    def collect_generation_parameter_contributors(self):
+        """BaseGenerationParameters subclasses declared by the imported generator classes.
+
+        Read off the classes rather than the instances, so a declaration is picked up even if
+        instantiating that generator failed. A class inherits its bases' declaration, so the same
+        contributor is seen repeatedly - de-duplicated here, since the merge rejects duplicate
+        field names.
+
+        Returns
+        -------
+        list of type
+            Contributor classes, in a stable order.
+        """
+        contributors = []
+        seen_entries = {}
+        for cls in self._generator_classes:
+            declared = getattr(cls, 'generation_parameter_contributors', ())
+            if isinstance(declared, (dict, type)):
+                # A single contributor rather than a tuple of them - a natural enough mistake that
+                # accepting it beats a confusing failure further down.
+                declared = (declared,)
+            for entry in declared:
+                # Keyed on the declaration itself, not on the class converted from it: sibling
+                # generators sharing a base inherit the same dict object, and converting it once per
+                # subclass would produce several classes declaring identical field names, which the
+                # merge then rejects as duplicates.
+                if id(entry) in seen_entries:
+                    continue
+                try:
+                    contributor = _as_generation_parameter_contributor(entry, cls)
+                except TypeError:
+                    self.log.exception(
+                        f'Ignoring an entry in {cls.__name__}.generation_parameter_contributors:'
+                    )
+                    seen_entries[id(entry)] = None
+                    continue
+                seen_entries[id(entry)] = contributor
+                if contributor not in contributors:
+                    contributors.append(contributor)
+        return contributors
 
     @property
     def predefined_generate_methods(self):

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -586,6 +586,17 @@ class PulseBlockEnsemble(object):
         self.generation_method_parameters = GenerationMethodParameters()
         return
 
+    def copy(self):
+        """Independent copy: mutating the copy's block_list or its sampling/measurement/
+        generation_method_parameters containers never affects the original."""
+        new_ensemble = PulseBlockEnsemble(
+            name=self.name, block_list=list(self.block_list), rotating_frame=self.rotating_frame
+        )
+        new_ensemble.sampling_information = self.sampling_information.copy()
+        new_ensemble.measurement_information = self.measurement_information.copy()
+        new_ensemble.generation_method_parameters = GenerationMethodParameters(self.generation_method_parameters)
+        return new_ensemble
+
     def get_dict_representation(self):
         dict_repr = dict()
         dict_repr['name'] = self.name
@@ -1000,6 +1011,27 @@ class PulseSequence(object):
         self.measurement_information = MeasurementInformation()
         self.generation_method_parameters = GenerationMethodParameters()
         return
+
+    def copy(self):
+        """Independent copy: mutating the copy's ensemble_list or its sampling/measurement/
+        generation_method_parameters containers never affects the original.
+
+        Unlike PulseBlockEnsemble.block_list (immutable (name, repetitions) tuples),
+        ensemble_list entries are SequenceStep - a mutable dict subclass - and
+        PulseSequence.insert() stores whatever SequenceStep instance it's given by reference
+        (no internal copy, unlike PulseBlock.insert()'s copy.deepcopy). A shallow list() copy
+        here would leave the copy and the original sharing the same SequenceStep objects, so
+        each step is copied individually via its own existing .copy() method instead.
+        """
+        new_sequence = PulseSequence(
+            name=self.name,
+            ensemble_list=[step.copy() for step in self.ensemble_list],
+            rotating_frame=self.rotating_frame,
+        )
+        new_sequence.sampling_information = self.sampling_information.copy()
+        new_sequence.measurement_information = self.measurement_information.copy()
+        new_sequence.generation_method_parameters = GenerationMethodParameters(self.generation_method_parameters)
+        return new_sequence
 
     def get_dict_representation(self):
         dict_repr = dict()

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -420,6 +420,13 @@ class PulseBlockEnsemble(object):
     This object is used as a construction plan to create one sampled file.
     """
 
+    #: Distinguishes the two loadable asset types without an isinstance check, for callers holding
+    #: an asset whose kind they do not know (see PulseSequence.is_sequence). Declared on the class
+    #: rather than assigned in __init__ deliberately: a class attribute is not part of pickled
+    #: instance state, so every .ensemble/.sequence already saved to disk gains it with no
+    #: migration, and it can never drift out of sync with the object's actual type.
+    is_sequence = False
+
     def __init__(self, name, block_list=None, rotating_frame=True):
         """
         The constructor for a Pulse_Block_Ensemble needs to have:
@@ -746,6 +753,12 @@ class PulseSequence(object):
     Represents a playback procedure for a number of PulseBlockEnsembles. Unused for pulse
     generator hardware without sequencing functionality.
     """
+
+    #: True here, False on PulseBlockEnsemble - see the note there for why this is a class
+    #: attribute. Note this asks whether the *object* is a sequence, which is a different question
+    #: from sigPredefinedSequenceGenerated's `produced_sequence` payload (whether a generate method
+    #: returned any sequences).
+    is_sequence = True
 
     def __init__(self, name, ensemble_list=None, rotating_frame=False):
         """
@@ -1088,7 +1101,7 @@ class PredefinedGeneratorBase:
     Also provides helper methods to simplify sequence/ensemble generation.
     """
 
-    def __init__(self, sequencegeneratorlogic):
+    def __init__(self, sequencegeneratorlogic): 
         # Keep protected reference to the SequenceGeneratorLogic
         self.__sequencegeneratorlogic = sequencegeneratorlogic
 
@@ -1178,6 +1191,7 @@ class PredefinedGeneratorBase:
         channel = self.generator_settings.generation_parameters.microwave_channel
         return None if channel == '' else channel
 
+ 
     @property
     def microwave_frequency(self):
         return self.generator_settings.generation_parameters.microwave_frequency
@@ -1193,6 +1207,7 @@ class PredefinedGeneratorBase:
     @property
     def wait_time(self):
         return self.generator_settings.generation_parameters.wait_time
+    
 
     @property
     def rabi_period(self):

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -30,6 +30,8 @@ import warnings
 
 from qudi.logic.pulsed.sampling_functions import SamplingFunctions, PulseEnvelope, PulseEnvelopeType
 from qudi.util.helpers import natural_sort, iter_modules_recursive
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import MeasurementInformation, GenerationMethodParameters
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 
 
 class PulseBlockElement(object):
@@ -419,21 +421,21 @@ class PulseBlockEnsemble(object):
         else:
             self.block_list = list()
 
-        # Dictionary container to store information related to the actually sampled
-        # Waveform like pulser settings used during sampling (sample_rate, activation_config etc.)
-        # and additional information about the discretization of the waveform (timebin positions of
-        # the PulseBlockElement transitions etc.) as well as the names of the created waveforms.
+        # Container to store information related to the actually sampled Waveform like pulser
+        # settings used during sampling (sample_rate, activation_config etc.) and additional
+        # information about the discretization of the waveform (timebin positions of the
+        # PulseBlockElement transitions etc.) as well as the names of the created waveforms.
         # This container will be populated during sampling and will be emptied upon deletion of the
         # corresponding waveforms from the pulse generator
-        self.sampling_information = dict()
-        # Dictionary container to store additional information about for measurement settings
+        self.sampling_information = SamplingInformation()
+        # Container to store additional information about for measurement settings
         # (ignore_lasers, controlled_variable, alternating etc.).
         # This container needs to be populated by the script creating the PulseBlockEnsemble
         # before saving it. (e.g. in generate methods in PulsedObjectGenerator class)
-        self.measurement_information = dict()
-        # Dictionary container to store parameters (eg. XY8 order) of the function (eg. predefined method) that
+        self.measurement_information = MeasurementInformation()
+        # Container to store parameters (eg. XY8 order) of the function (eg. predefined method) that
         # generated the pulse block ensemble.
-        self.generation_method_parameters = dict()
+        self.generation_method_parameters = GenerationMethodParameters()
 
     def __repr__(self):
         repr_str = 'PulseBlockEnsemble(name=\'{0}\', block_list={1}, rotating_frame={2})'.format(
@@ -495,9 +497,9 @@ class PulseBlockEnsemble(object):
         else:
             raise TypeError('PulseBlockEnsemble indices must be int or slice, not {0}'.format(type(key)))
         self.block_list[key] = tuple(value)
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def __delitem__(self, key):
@@ -505,9 +507,9 @@ class PulseBlockEnsemble(object):
             raise TypeError('PulseBlockEnsemble indices must be int or slice, not {0}'.format(type(key)))
 
         del self.block_list[key]
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def pop(self, position=None):
@@ -515,8 +517,8 @@ class PulseBlockEnsemble(object):
             raise IndexError('pop from empty PulseBlockEnsemble')
 
         if position is None:
-            self.sampling_information = dict()
-            self.measurement_information = dict()
+            self.sampling_information = SamplingInformation()
+            self.measurement_information = MeasurementInformation()
             return self.block_list.pop()
 
         if not isinstance(position, int):
@@ -528,9 +530,9 @@ class PulseBlockEnsemble(object):
         if len(self.block_list) <= position or position < 0:
             raise IndexError('PulseBlockEnsemble block list index out of range')
 
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return self.block_list.pop(position)
 
     def insert(self, position, element):
@@ -555,9 +557,9 @@ class PulseBlockEnsemble(object):
             raise IndexError('PulseBlockEnsemble block list index out of range')
 
         self.block_list.insert(position, tuple(element))
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def append(self, element):
@@ -572,16 +574,16 @@ class PulseBlockEnsemble(object):
 
     def clear(self):
         del self.block_list[:]
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def reverse(self):
         self.block_list.reverse()
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def get_dict_representation(self):
@@ -589,9 +591,9 @@ class PulseBlockEnsemble(object):
         dict_repr['name'] = self.name
         dict_repr['rotating_frame'] = self.rotating_frame
         dict_repr['block_list'] = self.block_list
-        dict_repr['sampling_information'] = self.sampling_information
-        dict_repr['measurement_information'] = self.measurement_information
-        dict_repr['generation_method_parameters'] = self.generation_method_parameters
+        dict_repr['sampling_information'] = self.sampling_information.to_dict()
+        dict_repr['measurement_information'] = self.measurement_information.to_dict()
+        dict_repr['generation_method_parameters'] = self.generation_method_parameters.to_dict()
         return dict_repr
 
     @staticmethod
@@ -601,9 +603,11 @@ class PulseBlockEnsemble(object):
             block_list=ensemble_dict['block_list'],
             rotating_frame=ensemble_dict['rotating_frame'],
         )
-        new_ens.sampling_information = ensemble_dict['sampling_information']
-        new_ens.measurement_information = ensemble_dict['measurement_information']
-        new_ens.generation_method_parameters = ensemble_dict['generation_method_parameters']
+        new_ens.sampling_information = SamplingInformation.from_dict(ensemble_dict['sampling_information'])
+        new_ens.measurement_information = MeasurementInformation.from_dict(ensemble_dict['measurement_information'])
+        new_ens.generation_method_parameters = GenerationMethodParameters.from_dict(
+            ensemble_dict['generation_method_parameters']
+        )
         return new_ens
 
 
@@ -763,19 +767,19 @@ class PulseSequence(object):
         self.refresh_parameters()
 
         # self.sampled_ensembles = OrderedDict()
-        # Dictionary container to store information related to the actually sampled
-        # Waveforms like pulser settings used during sampling (sample_rate, activation_config etc.)
-        # and additional information about the discretization of the waveform (timebin positions of
-        # the PulseBlockElement transitions etc.)
+        # Container to store information related to the actually sampled Waveforms like pulser
+        # settings used during sampling (sample_rate, activation_config etc.) and additional
+        # information about the discretization of the waveform (timebin positions of the
+        # PulseBlockElement transitions etc.)
         # This container is not necessary for the sampling process but serves only the purpose of
         # holding optional information for different modules.
-        self.sampling_information = dict()
-        # Dictionary container to store additional information about for measurement settings
+        self.sampling_information = SamplingInformation()
+        # Container to store additional information about for measurement settings
         # (ignore_lasers, controlled_values, alternating etc.).
         # This container needs to be populated by the script creating the PulseSequence
         # before saving it.
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def refresh_parameters(self):
@@ -879,9 +883,9 @@ class PulseSequence(object):
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
         self.ensemble_list[key] = value
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         if stage_refresh:
             self.refresh_parameters()
         return
@@ -898,8 +902,8 @@ class PulseSequence(object):
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
         del self.ensemble_list[key]
-        self.sampling_information = dict()
-        self.measurement_information = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
         if stage_refresh:
             self.refresh_parameters()
         return
@@ -921,9 +925,9 @@ class PulseSequence(object):
         if len(self.ensemble_list) <= position or position < 0:
             raise IndexError('PulseSequence ensemble list index out of range')
 
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         if self.ensemble_list[position].repetitions < 0:
             stage_refresh = True
         popped_element = self.ensemble_list.pop(position)
@@ -967,9 +971,9 @@ class PulseSequence(object):
         self.ensemble_list.insert(position, element)
         if element.repetitions < 0:
             self.is_finite = False
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def append(self, element):
@@ -984,17 +988,17 @@ class PulseSequence(object):
 
     def clear(self):
         del self.ensemble_list[:]
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         self.is_finite = True
         return
 
     def reverse(self):
         self.ensemble_list.reverse()
-        self.sampling_information = dict()
-        self.measurement_information = dict()
-        self.generation_method_parameters = dict()
+        self.sampling_information = SamplingInformation()
+        self.measurement_information = MeasurementInformation()
+        self.generation_method_parameters = GenerationMethodParameters()
         return
 
     def get_dict_representation(self):
@@ -1002,9 +1006,9 @@ class PulseSequence(object):
         dict_repr['name'] = self.name
         dict_repr['rotating_frame'] = self.rotating_frame
         dict_repr['ensemble_list'] = self.ensemble_list
-        dict_repr['sampling_information'] = self.sampling_information
-        dict_repr['measurement_information'] = self.measurement_information
-        dict_repr['generation_method_parameters'] = self.generation_method_parameters
+        dict_repr['sampling_information'] = self.sampling_information.to_dict()
+        dict_repr['measurement_information'] = self.measurement_information.to_dict()
+        dict_repr['generation_method_parameters'] = self.generation_method_parameters.to_dict()
         return dict_repr
 
     @staticmethod
@@ -1014,9 +1018,11 @@ class PulseSequence(object):
             ensemble_list=sequence_dict['ensemble_list'],
             rotating_frame=sequence_dict['rotating_frame'],
         )
-        new_seq.sampling_information = sequence_dict['sampling_information']
-        new_seq.measurement_information = sequence_dict['measurement_information']
-        new_seq.generation_method_parameters = sequence_dict['generation_method_parameters']
+        new_seq.sampling_information = SamplingInformation.from_dict(sequence_dict['sampling_information'])
+        new_seq.measurement_information = MeasurementInformation.from_dict(sequence_dict['measurement_information'])
+        new_seq.generation_method_parameters = GenerationMethodParameters.from_dict(
+            sequence_dict['generation_method_parameters']
+        )
         return new_seq
 
 
@@ -1049,8 +1055,10 @@ class PredefinedGeneratorBase:
         return self.__sequencegeneratorlogic.analyze_sequence
 
     @property
-    def pulse_generator_settings(self):
-        return self.__sequencegeneratorlogic.pulse_generator_settings
+    def generator_settings(self):
+        """The full SequenceGeneratorSettings object (generation_parameters,
+        pulse_generator_settings, pulser_benchmarks bundled together)."""
+        return self.__sequencegeneratorlogic.generator_settings
 
     @property
     def save_block(self):
@@ -1066,7 +1074,7 @@ class PredefinedGeneratorBase:
 
     @property
     def generation_parameters(self):
-        return self.__sequencegeneratorlogic.generation_parameters
+        return self.generator_settings.generation_parameters.to_dict()
 
     @generation_parameters.setter
     def generation_parameters(self, param_dict):
@@ -1083,77 +1091,74 @@ class PredefinedGeneratorBase:
 
     @property
     def channel_set(self):
-        channels = self.pulse_generator_settings.get('activation_config')
-        if channels is None:
-            channels = ('', set())
-        return channels[1]
+        return self.generator_settings.pulse_generator_settings.activation_config.channels
 
     @property
     def analog_channels(self):
-        return {chnl for chnl in self.channel_set if chnl.startswith('a')}
+        return self.generator_settings.pulse_generator_settings.analog_channels
 
     @property
     def digital_channels(self):
-        return {chnl for chnl in self.channel_set if chnl.startswith('d')}
+        return self.generator_settings.pulse_generator_settings.digital_channels
 
     @property
     def laser_channel(self):
-        return self.generation_parameters.get('laser_channel')
+        return self.generator_settings.generation_parameters.laser_channel
 
     @property
     def sync_channel(self):
-        channel = self.generation_parameters.get('sync_channel')
+        channel = self.generator_settings.generation_parameters.sync_channel
         return None if channel == '' else channel
 
     @property
     def gate_channel(self):
-        channel = self.generation_parameters.get('gate_channel')
+        channel = self.generator_settings.generation_parameters.gate_channel
         return None if channel == '' else channel
 
     @property
     def analog_trigger_voltage(self):
-        return self.generation_parameters.get('analog_trigger_voltage')
+        return self.generator_settings.generation_parameters.analog_trigger_voltage
 
     @property
     def laser_delay(self):
-        return self.generation_parameters.get('laser_delay')
+        return self.generator_settings.generation_parameters.laser_delay
 
     @property
     def microwave_channel(self):
-        channel = self.generation_parameters.get('microwave_channel')
+        channel = self.generator_settings.generation_parameters.microwave_channel
         return None if channel == '' else channel
 
     @property
     def microwave_frequency(self):
-        return self.generation_parameters.get('microwave_frequency')
+        return self.generator_settings.generation_parameters.microwave_frequency
 
     @property
     def microwave_amplitude(self):
-        return self.generation_parameters.get('microwave_amplitude')
+        return self.generator_settings.generation_parameters.microwave_amplitude
 
     @property
     def laser_length(self):
-        return self.generation_parameters.get('laser_length')
+        return self.generator_settings.generation_parameters.laser_length
 
     @property
     def wait_time(self):
-        return self.generation_parameters.get('wait_time')
+        return self.generator_settings.generation_parameters.wait_time
 
     @property
     def rabi_period(self):
-        return self.generation_parameters.get('rabi_period')
+        return self.generator_settings.generation_parameters.rabi_period
 
     @property
     def sample_rate(self):
-        return self.pulse_generator_settings.get('sample_rate')
+        return self.generator_settings.pulse_generator_settings.sample_rate
 
     @property
     def optimal_control_assets_path(self) -> str:
-        return self.generation_parameters.get('optimal_control_assets_path')
+        return self.generator_settings.generation_parameters.optimal_control_assets_path
 
     @property
     def pulse_envelope(self) -> PulseEnvelope:
-        return self.generation_parameters.get("pulse_envelope")
+        return self.generator_settings.generation_parameters.pulse_envelope
 
     ################################################################################################
     #                                   Helper methods                                          ####

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -1134,10 +1134,15 @@ def _as_generation_parameter_contributor(entry, owner):
                 f'{owner.__name__}.generation_parameter_contributors: "{name}" is not a valid '
                 f'parameter name.'
             )
-        # Mutable defaults need a factory; dataclass rejects them outright.
+        # Mutable defaults need a factory; dataclass rejects them outright. Test hashability
+        # rather than listing concrete types, because that is the test dataclasses itself applies
+        # ("mutable default ... is not allowed") and an enumerated list silently drifts from it:
+        # Python <= 3.10 rejected only list/dict/set, 3.11+ rejects anything unhashable. That
+        # widens the rule to numpy arrays, deques, and - most easily missed - any instance of a
+        # class defining __eq__, since that sets __hash__ to None.
         spec = (
             field(default_factory=lambda value=default: copy.deepcopy(value))
-            if isinstance(default, (dict, list, set, bytearray))
+            if default.__class__.__hash__ is None
             else field(default=default)
         )
         specs.append((name, type(default), spec))

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -644,15 +644,25 @@ class PulseBlockEnsemble(object):
 
     @staticmethod
     def ensemble_from_dict(ensemble_dict):
+        # The three info containers are read with .get(): each one's from_dict() already returns an
+        # empty container for None, and a dict that is missing one must not raise. Besides the
+        # convention that from_dict() tolerates absent keys, this is load-bearing for the trimmed
+        # dicts PulseObjects.to_metadata_dict() writes into saved file headers - those deliberately
+        # leave containers out, and reading one back should give a partial object, not a KeyError.
+        # name/block_list stay required: without them there is no ensemble to build.
         new_ens = PulseBlockEnsemble(
             name=ensemble_dict['name'],
             block_list=ensemble_dict['block_list'],
-            rotating_frame=ensemble_dict['rotating_frame'],
+            rotating_frame=ensemble_dict.get('rotating_frame', False),
         )
-        new_ens.sampling_information = SamplingInformation.from_dict(ensemble_dict['sampling_information'])
-        new_ens.measurement_information = MeasurementInformation.from_dict(ensemble_dict['measurement_information'])
+        new_ens.sampling_information = SamplingInformation.from_dict(
+            ensemble_dict.get('sampling_information')
+        )
+        new_ens.measurement_information = MeasurementInformation.from_dict(
+            ensemble_dict.get('measurement_information')
+        )
         new_ens.generation_method_parameters = GenerationMethodParameters.from_dict(
-            ensemble_dict['generation_method_parameters']
+            ensemble_dict.get('generation_method_parameters')
         )
         return new_ens
 
@@ -1079,15 +1089,20 @@ class PulseSequence(object):
 
     @staticmethod
     def sequence_from_dict(sequence_dict):
+        # .get() for the three info containers - see ensemble_from_dict() for why.
         new_seq = PulseSequence(
             name=sequence_dict['name'],
             ensemble_list=sequence_dict['ensemble_list'],
-            rotating_frame=sequence_dict['rotating_frame'],
+            rotating_frame=sequence_dict.get('rotating_frame', False),
         )
-        new_seq.sampling_information = SamplingInformation.from_dict(sequence_dict['sampling_information'])
-        new_seq.measurement_information = MeasurementInformation.from_dict(sequence_dict['measurement_information'])
+        new_seq.sampling_information = SamplingInformation.from_dict(
+            sequence_dict.get('sampling_information')
+        )
+        new_seq.measurement_information = MeasurementInformation.from_dict(
+            sequence_dict.get('measurement_information')
+        )
         new_seq.generation_method_parameters = GenerationMethodParameters.from_dict(
-            sequence_dict['generation_method_parameters']
+            sequence_dict.get('generation_method_parameters')
         )
         return new_seq
 

--- a/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
+++ b/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
@@ -48,6 +48,8 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         bin_width = self.fast_counter_settings.get('bin_width')
 
         if not isinstance(bin_width, float):
+            self.log.warning('Analysis aborted: fast counter bin_width is not a valid float '
+                             '(got {0!r}) - returning zero signal.'.format(bin_width))
             return np.zeros(num_of_lasers), np.zeros(num_of_lasers)
 
         # Convert the times in seconds to bins (i.e. array indices)
@@ -100,6 +102,8 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         bin_width = self.fast_counter_settings.get('bin_width')
 
         if not isinstance(bin_width, float):
+            self.log.warning('Analysis aborted: fast counter bin_width is not a valid float '
+                             '(got {0!r}) - returning zero signal.'.format(bin_width))
             return np.zeros(num_of_lasers), np.zeros(num_of_lasers)
 
         # Convert the times in seconds to bins (i.e. array indices)
@@ -140,6 +144,8 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         bin_width = self.fast_counter_settings.get('bin_width')
 
         if not isinstance(bin_width, float):
+            self.log.warning('Analysis aborted: fast counter bin_width is not a valid float '
+                             '(got {0!r}) - returning zero signal.'.format(bin_width))
             return np.zeros(num_of_lasers), np.zeros(num_of_lasers)
 
         # Convert the times in seconds to bins (i.e. array indices)
@@ -206,6 +212,8 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         bin_width = self.fast_counter_settings.get('bin_width')
 
         if not isinstance(bin_width, float):
+            self.log.warning('Analysis aborted: fast counter bin_width is not a valid float '
+                             '(got {0!r}) - returning zero signal.'.format(bin_width))
             return np.zeros(num_of_lasers), np.zeros(num_of_lasers)
 
         # Convert the times in seconds to bins (i.e. array indices)

--- a/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
+++ b/src/qudi/logic/pulsed/pulsed_analysis_methods/basic_analysis_methods.py
@@ -34,13 +34,13 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
     def analyse_mean_norm(self, laser_data, signal_start=0.0, signal_end=200e-9, norm_start=300e-9,
                           norm_end=500e-9):
         """
-
-        @param laser_data:
-        @param signal_start:
-        @param signal_end:
-        @param norm_start:
-        @param norm_end:
-        @return:
+        Parameters
+        ----------
+        laser_data
+        signal_start
+        signal_end
+        norm_start
+        norm_end
         """
         # Get number of lasers
         num_of_lasers = laser_data.shape[0]
@@ -91,10 +91,11 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
 
     def analyse_sum(self, laser_data, signal_start=0.0, signal_end=200e-9):
         """
-        @param laser_data:
-        @param signal_start:
-        @param signal_end:
-        @return:
+        Parameters
+        ----------
+        laser_data
+        signal_start
+        signal_end
         """
         # Get number of lasers
         num_of_lasers = laser_data.shape[0]
@@ -132,11 +133,11 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
 
     def analyse_mean(self, laser_data, signal_start=0.0, signal_end=200e-9):
         """
-
-        @param laser_data:
-        @param signal_start:
-        @param signal_end:
-        @return:
+        Parameters
+        ----------
+        laser_data
+        signal_start
+        signal_end
         """
         # Get number of lasers
         num_of_lasers = laser_data.shape[0]
@@ -178,10 +179,18 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         This method does not actually analyze anything.
         For 1 D data the output is raveled: for 2 D data, the output is the mean along the second axis.
 
-        @param 2D numpy.ndarray laser_data: the raw timetrace data from a gated fast counter
-                                            dim 0: gate number; dim 1: time bin
+        Parameters
+        ----------
+        laser_data : 2D numpy.ndarray
+            The raw timetrace data from a gated fast counter
+            dim 0: gate number; dim 1: time bin.
 
-        @return numpy.ndarray, numpy.ndarray: analyzed data per laser pulse, error per laser pulse
+        Returns
+        -------
+        numpy.ndarray
+            Analyzed data per laser pulse.
+        numpy.ndarray
+            Error per laser pulse.
         """
         length = len(laser_data)
         if len(np.shape(laser_data)) > 1:
@@ -197,14 +206,26 @@ class BasicPulseAnalyzer(PulseAnalyzerBase):
         It then does not divide by the background window to normalize
         but rather substracts the background window to generate the output.
 
-        @param 2D numpy.ndarray laser_data: the raw timetrace data from a gated fast counter
-                                            dim 0: gate number; dim 1: time bin
-        @param float signal_start: Beginning of the signal window in s
-        @param float signal_end: End of the signal window in s
-        @param float norm_start: Beginning of the background window in s
-        @param float norm_end: End of the background window in s
+        Parameters
+        ----------
+        laser_data : 2D numpy.ndarray
+            The raw timetrace data from a gated fast counter
+            dim 0: gate number; dim 1: time bin.
+        signal_start : float
+            Beginning of the signal window in s.
+        signal_end : float
+            End of the signal window in s.
+        norm_start : float
+            Beginning of the background window in s.
+        norm_end : float
+            End of the background window in s.
 
-        @return numpy.ndarray, numpy.ndarray: analyzed data per laser pulse, error per laser pulse
+        Returns
+        -------
+        numpy.ndarray
+            Analyzed data per laser pulse.
+        numpy.ndarray
+            Error per laser pulse.
         """
         # Get number of lasers
         num_of_lasers = laser_data.shape[0]

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -1,0 +1,982 @@
+# `pulsed_data` — typed containers for the pulsed toolchain
+
+This package holds the dataclasses that the three pulsed logic modules use to store their settings,
+their measurement data, and the metadata attached to generated pulse objects. Before this package
+existed, all of it was loose dictionaries and ~20 separately-declared `StatusVar`s per module; a typo
+in a settings key was silently accepted and a missing key in a saved file could reset every setting
+you had.
+
+**If you are here to add a lab-specific global generation parameter, you only need one file:**
+[`generation_parameter_extensions.py`](generation_parameter_extensions.py). Skip to
+[Extending this](#extending-this--notes-for-physicists).
+
+There is no `__init__.py` in this folder. That is deliberate and matches the rest of `qudi/logic/`
+(they are implicit namespace packages), so everything is imported by its full module path:
+
+```python
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import GenerationParameters
+```
+
+---
+
+## The six files at a glance
+
+| File | Owns the data for | Classes |
+|---|---|---|
+| [`generation_parameter_extensions.py`](generation_parameter_extensions.py) | **Your lab's** extra generation parameters | 2 |
+| [`sequence_generator_logic_data.py`](sequence_generator_logic_data.py) | `SequenceGeneratorLogic` — generation parameters, pulser hardware mirror, sampling results | 14 |
+| [`pulsed_measurement_logic_data.py`](pulsed_measurement_logic_data.py) | `PulsedMeasurementLogic` — microwave, fast counter, readout, live measurement state | 13 |
+| [`pulsed_measurement.py`](pulsed_measurement.py) | The top-level snapshot of one complete measurement | 4 |
+| [`pulsed_master_logic_data.py`](pulsed_master_logic_data.py) | `PulsedMasterLogic` — busy flags, fit containers | 2 |
+| [`settings_coercion.py`](settings_coercion.py) | Shared helper every settings setter calls | 1 class + 2 functions |
+
+---
+
+## Read this first — five conventions
+
+Almost every oddity in these files follows from one of these five rules. Learning them here saves
+reading three dozen class docstrings.
+
+### 1. `frozen=True` means the object can never be changed
+
+```python
+@dataclass(frozen=True)
+class MicrowaveSettings:
+    power: float
+    frequency: float
+    use_ext_microwave: bool
+```
+
+`frozen=True` makes Python refuse `settings.power = -20`. To "change" a value you build a **new**
+object with `dataclasses.replace()`, which copies everything and overrides only what you name:
+
+```python
+from dataclasses import replace
+new_settings = replace(old_settings, power=-20.0)   # old_settings is untouched
+```
+
+**Why bother?** Three concrete reasons, all of which bit the old dict-based code:
+
+- These objects are read from more than one Qt thread. An immutable object cannot be half-updated
+  while another thread is reading it.
+- They get pickled into every saved `.ensemble`/`.sequence` file. If they were mutable, a later edit
+  in the GUI would retroactively change what a "saved" snapshot means.
+- A settings object handed to a caller cannot be corrupted by that caller.
+
+Some classes here are deliberately **not** frozen. See rule 4.
+
+### 2. Every persisted class implements the same three methods
+
+| Method | Direction | Missing keys behave as | Called by |
+|---|---|---|---|
+| `to_dict(self)` | object → plain dict | — | saving to the status file; the GUI; measurement metadata headers |
+| `from_dict(cls, data)` | dict → **new** object | fall back to the **field default** | restoring at module activation |
+| `update_from_dict(self, data)` | dict → **new** object, patched onto `self` | **keep the current value** | every live edit from the GUI or a script |
+
+`from_dict` is a `@classmethod` — it is called on the class (`MicrowaveSettings.from_dict({...})`)
+because there is no instance yet; that is why its first argument is `cls` and not `self`.
+
+The difference between the last two is the whole point:
+
+```python
+current = MicrowaveSettings(power=-30.0, frequency=2.87e9, use_ext_microwave=True)
+
+MicrowaveSettings.from_dict({'power': -20.0})   # frequency → its DEFAULT
+current.update_from_dict({'power': -20.0})      # frequency → stays 2.87e9
+```
+
+So `from_dict` is for *"rebuild this from a file"* and `update_from_dict` is for *"the user just moved
+one slider"*.
+
+### 3. `from_dict()` must tolerate keys that are not there
+
+A status file written last year does not contain a field added last week. If `from_dict` indexed
+`data['new_field']` directly it would raise `KeyError` — and because the `StatusVar` constructor
+catches that and falls back to the default *object*, **every** setting in that file would silently
+revert. That is a real bug this package was written to kill; see the docstring on
+`_generation_parameters_from_dict` in [`sequence_generator_logic_data.py`](sequence_generator_logic_data.py).
+
+The rule for anyone adding a field: use `data.get('name', fallback)` or an
+`if 'name' in data else default` guard, never `data['name']`, and **ignore** unknown keys rather than
+rejecting them, so that removing a lab extension does not make its old status file unloadable.
+
+The two aggregate classes go one step further and fall back per *sub-object*:
+`PulsedMeasurementSettings.from_dict()` and `SequenceGeneratorSettings.from_dict()` substitute the
+shared `_DEFAULT_*` instances for whole missing sections.
+
+### 4. Some classes are mutable **on purpose** — do not "fix" them
+
+| Class | Why it is not frozen |
+|---|---|
+| `AnalysisParameters`, `ExtractionParameters` | `PulseAnalyzer`/`PulseExtractor` hold **this exact object** and mutate it in place as their live state |
+| `AlternativeSignalSettings` | same, for `AltPlotAnalyzer` |
+| `PulsedMeasurementData` | the measurement loop writes into these arrays on every analysis tick |
+| `ExecutionState`, `DataStashCache`, `SequenceSamplingState` | per-run scratch state, never persisted |
+| `MeasurementInformation`, `SamplingInformation`, `GenerationMethodParameters` | live **on** a pulse object and are written by the generate/sample step |
+| `PulsedMeasurement`, `PulsedData`, `PulseObjects` | freezing the container would not freeze the mutable things inside it, only imply it misleadingly |
+
+The consequence shows up in `PulsedMeasurementSettings.update_from_dict()`: for the shared ones it
+calls `.update(...)` **in place** and never rebinds the reference, because rebinding would silently
+disconnect `PulseAnalyzer` from the settings the rest of the app thinks it is using.
+
+### 5. `class X(dict)` is a compatibility shim, not a mistake
+
+Five classes subclass `dict` instead of being dataclasses:
+`AnalysisParameters`, `ExtractionParameters`, `GenerationMethodParameters`,
+`MetadataDictRepresentation`, `PulsedMasterStatus`.
+
+They exist where old call sites index and assign directly and were not worth rewriting:
+
+```python
+# pulsed_maingui.py does this, and still can:
+pulsedmasterlogic().status_dict['benchmark_busy'] = True
+# while PulsedMasterLogic itself gets typo-proof named access to the same data:
+self.status_dict.benchmark_busy = True
+```
+
+**Gotcha this creates:** for these classes `isinstance(x, dict)` is `True`. Any code that branches on
+"is this a dict or a settings object?" must check the specific class **first**. `coerce_settings()`
+does exactly that, and says so in a comment.
+
+---
+
+## Hierarchy
+
+### Containment — what holds what
+
+`PulsedMeasurement` is the root of everything that describes one measurement.
+
+```
+PulsedMeasurement                                   [mutable]  pulsed_measurement.py
+│
+├── settings : Settings                             [frozen]
+│   │
+│   ├── measurement_settings : PulsedMeasurementSettings          [frozen]
+│   │   ├── microwave_settings        : MicrowaveSettings         [frozen]
+│   │   ├── fast_counter_settings     : FastCounterSettings       [frozen]
+│   │   ├── readout_settings          : ReadoutSettings           [frozen]
+│   │   ├── alternate_signal_settings : AlternativeSignalSettings (shared, mutable)
+│   │   ├── extraction_parameters     : ExtractionParameters      (dict subclass, shared)
+│   │   └── analysis_parameters       : AnalysisParameters        (dict subclass, shared)
+│   │
+│   └── generator_settings : SequenceGeneratorSettings | None     [frozen]
+│       ├── generation_parameters     : GenerationParameters      [frozen, BUILT AT IMPORT]
+│       │   ├── ... CoreGenerationParameters' 14 fields
+│       │   └── ... every lab extension's fields
+│       └── pulse_generator_settings  : PulseGeneratorSettings    [frozen]
+│           ├── activation_config     : ActivationConfig          [frozen]
+│           ├── analog_levels         : AnalogLevels              [frozen]
+│           ├── digital_levels        : DigitalLevels             [frozen]
+│           └── sample_rate / interleave / flags / upload_speed
+│
+├── data : PulsedData | None                        [mutable]
+│   ├── measurement_data : PulsedMeasurementData    [mutable]   raw/laser/signal arrays
+│   ├── fit_result       : lmfit ModelResult | None             (one-way export only)
+│   └── fit_result_alt   : lmfit ModelResult | None             (one-way export only)
+│
+└── objects : PulseObjects                          [mutable]
+    ├── sequence  : PulseBlockEnsemble | PulseSequence | None    ← lives in pulse_objects.py
+    ├── ensembles : {name: PulseBlockEnsemble}                   independent copies
+    └── blocks    : {name: PulseBlock}                           independent copies
+```
+
+Each pulse object in `objects` carries three more containers from this package, attached as plain
+attributes rather than nested here:
+
+```
+PulseBlockEnsemble / PulseSequence          (pulse_objects.py)
+├── .sampling_information          : SamplingInformation           [mutable, dict-like]
+├── .measurement_information       : MeasurementInformation        [mutable, dict-like]
+└── .generation_method_parameters  : GenerationMethodParameters    (dict subclass)
+```
+
+Standing on their own, not part of the tree above:
+
+```
+SequenceGeneratorLogic                          PulsedMeasurementLogic       PulsedMasterLogic
+├── pulser_benchmarks : PulserBenchmarks        ├── __execution_state :      ├── status_dict :
+│   ├── write : BenchmarkTool                   │   ExecutionState           │   PulsedMasterStatus
+│   └── load  : BenchmarkTool                   └── _data_stash :            └── fit_containers :
+├── (returned) EnsembleAnalysisResult               DataStashCache               FitContainers
+├── (returned) SequenceAnalysisResult                                            (property — a new
+├── (returned) AssetInfo, LoadedAsset                                             one per access)
+└── (per-run)  SequenceSamplingState
+```
+
+### Inheritance — there is almost none, and that is on purpose
+
+These are containers, not a class hierarchy. Two exceptions:
+
+```
+BaseGenerationParameters                    generation_parameter_extensions.py
+├── CoreGenerationParameters                sequence_generator_logic_data.py  (built-in, 14 fields)
+├── TestParameters                          generation_parameter_extensions.py (example, 1 field)
+└── <your lab's class here>                 generation_parameter_extensions.py
+        │
+        └──► merged at import time by _build_generation_parameters()
+             into ONE class:  GenerationParameters
+             (a real subclass of all of the above, with all of their fields)
+
+dict
+├── AnalysisParameters             ┐
+├── ExtractionParameters           │ compatibility shims — see convention 5
+├── GenerationMethodParameters     │
+├── PulsedMasterStatus             │
+└── MetadataDictRepresentation     ┘ (pretty-printing wrapper only)
+```
+
+---
+
+## File-by-file catalogue
+
+### `generation_parameter_extensions.py`
+
+**This is the file to edit** when your lab needs an extra global generation setting. Everything else
+adapts automatically: a widget appears on the Predefined Methods tab, the value is saved to and
+restored from the status file, and predefined generate methods can read it.
+
+#### `BaseGenerationParameters` — the marker base class
+
+Declares no fields. Anything inheriting from it is collected and merged into `GenerationParameters`.
+Provides three helpers to subclasses:
+
+| Member | What it does |
+|---|---|
+| `_coerce_fields(cls, data, current=None)` | **You must override this.** Returns `{field_name: value}` for this class's own fields only, reading from `data`, else `current`, else the default. |
+| `_own_field_names(cls)` | The names this class itself declared (not inherited ones). Used for the duplicate-name check and for `to_dict()` ordering. |
+| `_pick(data, current, name, default)` | The 3-step fallback: `data` → `current` → `default`. |
+
+`_coerce_fields` backs **both** `from_dict` (called with `current=None`, so missing keys become
+defaults) and `update_from_dict` (called with `current=self`, so missing keys keep their value). That
+is why you write the per-field conversion exactly once.
+
+`_own_field_names` reads `cls.__dict__['__annotations__']` rather than `cls.__annotations__` or
+`dataclasses.fields()` — plain attribute access and `fields()` both walk up to parent classes and
+would return inherited fields too.
+
+**Why this class lives here and not next to `CoreGenerationParameters`:** so this file never has to
+import from `sequence_generator_logic_data.py`. A circular import between the two would make the merge
+silently skip extensions depending on which module happened to be imported first.
+
+#### `TestParameters` — a live example
+
+```python
+@dataclass(frozen=True)
+class TestParameters(BaseGenerationParameters):
+    time_delay: float = 4.0
+
+    @classmethod
+    def _coerce_fields(cls, data, current=None):
+        pick = cls._pick
+        return {'time_delay': float(pick(data, current, 'time_delay', 4.0))}
+```
+
+> **Note:** this is currently active, so `time_delay` really is a field of `GenerationParameters` and
+> really does get a spin box on the Predefined Methods tab. It is scaffolding from the refactor — if
+> your setup does not want it, delete the class.
+
+---
+
+### `sequence_generator_logic_data.py`
+
+Everything `SequenceGeneratorLogic` stores: what pulses to build, what hardware to build them on, and
+what came out of building them.
+
+#### `CoreGenerationParameters` *(frozen)* — the built-in generation settings
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `laser_channel` | str | `'d_ch1'` | channel that triggers the laser |
+| `sync_channel` | str | `''` | optional sync-out channel, empty = unused |
+| `gate_channel` | str | `''` | gate channel for a gated fast counter, empty = ungated |
+| `microwave_channel` | str | `'a_ch1'` | channel carrying the MW pulses |
+| `microwave_frequency` | float | `2.87e9` | Hz — NV zero-field splitting by default |
+| `microwave_amplitude` | float | `0.0` | V |
+| `rabi_period` | float | `100e-9` | s — one full Rabi cycle; π-pulses are derived from it |
+| `laser_length` | float | `3e-6` | s — readout laser pulse duration |
+| `laser_delay` | float | `500e-9` | s — delay between laser trigger and actual light |
+| `wait_time` | float | `1e-6` | s — relaxation wait after readout |
+| `analog_trigger_voltage` | float | `0.0` | V |
+| `optimal_control_assets_path` | str | `C:\Software\qudi_data\optimal_control_assets` | where OC pulse files live |
+| `pulse_envelope` | `PulseEnvelope` | rectangle | pulse shape (see `sampling_functions.py`) |
+| `pulse_envelope_order` | int | `1` | shape order parameter |
+
+**This class is not the type the rest of the toolchain uses** — that is the merged
+`GenerationParameters` below. `CoreGenerationParameters` is one *contributor* to it.
+
+#### `GenerationParameters` *(frozen, built at import time)*
+
+Not written out as a class. It is constructed by `_build_generation_parameters()` at the bottom of the
+module, which:
+
+1. collects `CoreGenerationParameters` plus every `BaseGenerationParameters` subclass currently
+   declared, sorted by class name so the result never depends on import order;
+2. raises `TypeError` if two contributors declare the same field name — a silent last-wins would
+   change a measurement parameter with no other signal;
+3. builds the merged class with `type('GenerationParameters', contributors, {})`;
+4. attaches `_CONTRIBUTORS` (the tuple of classes) and the three dict methods.
+
+`to_dict()` walks `_CONTRIBUTORS` rather than `dataclasses.fields()`, because a merged dataclass lays
+its fields out in reverse-MRO order — extension fields would come out *before* the built-in ones, and
+the GUI builds the Predefined Methods widget grid by iterating this dict in order.
+
+Two constraints on the merged class that are easy to break accidentally:
+
+- **Every field needs a default.** Python forbids a no-default field following a defaulted one, and
+  after merging you cannot control the ordering.
+- **The result must be bound to the module-level name `GenerationParameters`**, matching the class's
+  own `__name__`, so that `pickle` can resolve it. A `GenerationParameters` instance is pickled into
+  every saved `.ensemble`/`.sequence` via `SamplingInformation`.
+
+Accessed everywhere through `SequenceGeneratorLogic.generation_parameters`, which returns
+`.to_dict()` — so most call sites see a plain dict:
+
+```python
+self.generation_parameters['rabi_period']                 # predefined generate methods
+self.generator_settings.generation_parameters.rabi_period # the dataclass directly
+```
+
+#### `ActivationConfig` *(frozen)*, `AnalogLevels` *(frozen)*, `DigitalLevels` *(frozen)*
+
+Thin named wrappers over what used to be anonymous tuples.
+
+| Class | Fields | Also has |
+|---|---|---|
+| `ActivationConfig` | `name: str`, `channels: set` | `as_tuple`, `from_tuple()` |
+| `AnalogLevels` | `amplitude: dict`, `offset: dict` | `as_tuple`, `from_tuple()` |
+| `DigitalLevels` | `low: dict`, `high: dict` | `as_tuple`, `from_tuple()` |
+
+The `as_tuple`/`from_tuple` pair exists because `PulserInterface` still speaks in tuples — these
+convert at the boundary without forcing every hardware module to change.
+
+#### `PulseGeneratorSettings` *(frozen)* — the local mirror of the pulser hardware
+
+| Field | Type | Meaning |
+|---|---|---|
+| `activation_config` | `ActivationConfig` | which channels are switched on |
+| `sample_rate` | float | Sa/s |
+| `analog_levels` | `AnalogLevels` | pp-amplitude and offset per analog channel |
+| `digital_levels` | `DigitalLevels` | low/high voltage per digital channel |
+| `interleave` | bool | interleave mode |
+| `flags` | set | pulser flag names |
+| `upload_speed` | float | Sa/s, from the benchmark |
+
+Properties `analog_channels` / `digital_channels` filter `activation_config.channels` by the
+`a_ch`/`d_ch` prefix.
+
+Mirrored locally because reading it back from hardware is slow. `SequenceGeneratorLogic.on_activate()`
+re-derives it from hardware on every activation, which is why it is *not* migrated from legacy status
+files — there would be no point.
+
+#### `AssetInfo` *(frozen)* and `LoadedAsset` *(frozen)*
+
+| Class | Fields | Purpose |
+|---|---|---|
+| `AssetInfo` | `length_s`, `length_bins`, `number_of_lasers` | summary of a sampled ensemble/sequence |
+| `LoadedAsset` | `name`, `asset_type` | what is currently on the pulser; `asset_type` is `'PulseBlockEnsemble'`, `'PulseSequence'` or `''` |
+
+Both implement `__iter__`/`__len__`/`__getitem__` so old tuple-style call sites still work
+(`*loaded_asset`, `loaded_asset[0]`). `LoadedAsset` also defines `__bool__` — falsy unless *both* a
+name and a recognized type are set — and a `LoadedAsset.empty()` constructor.
+
+#### `SequenceSamplingState` *(mutable)* — per-run scratch space
+
+Created fresh for each `PulseSequence` sampling run and thrown away when it ends, successfully or not.
+Never persisted.
+
+| Field | Purpose |
+|---|---|
+| `in_progress` | set by `start()` / cleared by `finish()` |
+| `offset_bin` | running sample offset across steps |
+| `written_waveforms` | every waveform name written so far this run |
+| `generated_ensembles` | per-step ensemble info, keyed by name tag |
+| `step_results` | `(waveform_names, seq_step)` per step |
+
+#### `PulserBenchmarks` *(mutable)* — upload/load speed telemetry
+
+Holds two `BenchmarkTool` instances (`write`, `load`) and combines them:
+
+```python
+1 / (1/write_speed + 1/load_speed)     # → estimate_combined_speed(), NaN if not enough data
+```
+
+Persisted as its **own independent** `StatusVar` on `SequenceGeneratorLogic`, deliberately *not*
+inside `SequenceGeneratorSettings` — it is runtime telemetry about the hardware, not a
+measurement-defining setting, and should not appear in a saved measurement's settings.
+
+#### `EnsembleAnalysisResult` *(frozen)* and `SequenceAnalysisResult` *(frozen)*
+
+Pure return values, never persisted, produced by `SequenceGeneratorLogic.analyze_block_ensemble()`
+and `analyze_sequence()`.
+
+`EnsembleAnalysisResult`: `number_of_samples`, `number_of_elements`, `elements_length_bins`,
+`digital_rising_bins`, `digital_falling_bins`, `analog_channels`, `digital_channels`, `channel_set`,
+`generation_parameters`, `ideal_length`, `laser_rising_bins`, `laser_falling_bins`.
+
+`SequenceAnalysisResult`: the same information aggregated over a whole sequence, plus per-step
+breakdowns (`number_of_steps`, `number_of_samples_per_step`, `number_of_ensembles`, `ensemble_names`,
+`number_of_elements_per_step`, `elements_length_bins_per_step`, `ideal_length_per_step`).
+
+Both carry the `generation_parameters` in force at analysis time, which is how those end up in a saved
+measurement's metadata.
+
+#### `SamplingInformation` *(mutable, dict-like)*
+
+Attached to every `PulseBlockEnsemble`/`PulseSequence` as `.sampling_information`. Records what
+happened when that object was sampled.
+
+| Field | Meaning |
+|---|---|
+| `waveforms` | waveform names written to the pulser |
+| `pulse_generator_settings` | **a plain dict, not the dataclass** — see below |
+| `number_of_samples`, `number_of_elements`, `elements_length_bins`, `ideal_length` | sampling geometry |
+| `laser_rising_bins`, `laser_falling_bins` | laser pulse edges, read by the extraction methods |
+| `step_waveform_list`, `ensemble_info` | sequence-specific |
+| `_legacy_data` | catch-all for keys that are not declared fields |
+
+Three things to know:
+
+- **`__bool__` returns `bool(self.waveforms)`.** Logic all over the toolchain does
+  `if ensemble.sampling_information:` to mean *"has this actually been sampled?"* — do not add fields
+  that would change that meaning.
+- **`pulse_generator_settings` is typed `Optional[dict]` on purpose**, even though it conceptually is
+  a `PulseGeneratorSettings`. Two call sites depend on it being a plain dict: the sampling-cache
+  comparison in `sample_pulse_sequence()` (dict equality) and
+  `pulse_extraction_methods/basic_extraction_methods.py` (dict subscripting).
+- **`_legacy_data` absorbs unknown keys** so nothing is ever lost round-tripping an old file. It also
+  means a typo'd key is silently accepted — check `_field_names()` if something you set does not seem
+  to take effect.
+
+This is the only class in the package with a YAML representer and constructor registered for it
+(in [`../sequence_generator_logic.py`](../sequence_generator_logic.py), just after the imports), so it
+can be written into and read back out of `.ensemble`/`.sequence` files.
+
+#### `SequenceGeneratorSettings` *(frozen)* — the aggregate
+
+```python
+generation_parameters    : GenerationParameters
+pulse_generator_settings : PulseGeneratorSettings
+```
+
+Persisted as the single `_generator_settings` `StatusVar`. Also carries `LEGACY_STATUS_VAR_KEYS` and
+`from_legacy_dict()` for reading pre-refactor status files, where `_generation_parameters` was its own
+top-level key.
+
+#### Module-level defaults
+
+`_DEFAULT_GENERATION_PARAMETERS` and `_DEFAULT_PULSE_GENERATOR_SETTINGS` are single shared instances
+used both as `from_dict()`'s per-section fallbacks and as `_default_generator_settings()`'s values.
+They live here rather than in `sequence_generator_logic.py` because this is the lower-level file — the
+import can only go one way.
+
+Sharing one instance is safe precisely *because* these classes are frozen (rule 1).
+
+---
+
+### `pulsed_measurement_logic_data.py`
+
+Everything `PulsedMeasurementLogic` stores: how to acquire, how to analyze, and the data itself.
+
+#### `FastCounterSettings` *(frozen)*
+
+| Field | Type | Meaning |
+|---|---|---|
+| `bin_width` | float | s per time bin |
+| `record_length` | float | s recorded after each trigger |
+| `number_of_gates` | int | gates per sweep; forced to 0 when the counter is ungated |
+| `is_gated` | bool | never persisted — always re-read from hardware on activation |
+
+#### `MicrowaveSettings` *(frozen)*
+
+`power` (dBm), `frequency` (Hz), `use_ext_microwave` (bool). These describe the **external** CW
+microwave source, not the pulsed MW on the AWG.
+
+#### `ReadoutSettings` *(frozen)* — how the measurement is interpreted
+
+| Field | Type | Meaning |
+|---|---|---|
+| `invoke_settings` | bool | if True, auto-fill the rest from the loaded asset's `MeasurementInformation` |
+| `controlled_variable` | `np.ndarray` | the x-axis: tau values, frequencies, ... |
+| `number_of_lasers` | int | laser pulses per sweep |
+| `laser_ignore_list` | `list[int]` | indices to drop (e.g. reference pulses) |
+| `alternating` | bool | two interleaved signals per point |
+| `units` | `(str, str)` | x/y units for plots and saved files |
+| `labels` | `(str, str)` | x/y axis labels |
+
+`__post_init__` enforces two invariants on every construction path: `controlled_variable` is copied
+and its `writeable` flag cleared (so a frozen settings object really is read-only, and a caller's live
+array is never affected), and `laser_ignore_list` is sorted.
+
+> **Numpy gotcha:** because a `np.ndarray` field is present, the auto-generated `__eq__` raises
+> *"truth value of an array is ambiguous"* the moment two instances are compared. `ReadoutSettings`
+> — and therefore `PulsedMeasurementSettings`, which contains one — has **not** been given a custom
+> `__eq__`, so `settings_a == settings_b` will blow up; the round-trip tests work around it by
+> spot-checking individual fields instead. `MeasurementInformation` hit the same problem and *did*
+> get a custom `__eq__` built on `np.array_equal`. If you add an array field to a class anything
+> compares, do the same.
+
+#### `PulsedMeasurementData` *(mutable)* — the data itself
+
+`raw_data`, `laser_data`, `signal_data`, `signal_alt_data`, `measurement_error` (all `np.ndarray`),
+plus `elapsed_time` and `elapsed_sweeps`.
+
+Mutated in place by the analysis loop. `copy()` deep-copies every array, so a snapshot never keeps
+changing under its holder.
+
+#### `DataStashCache` *(mutable)*
+
+Stash/recall for raw data the user wants to keep across a re-run: `cache: dict` keyed by a user tag,
+plus `active_tag`. `stash()` copies the array in; `recall()` sets the active tag and returns the entry.
+Runtime only, never persisted.
+
+#### `AlternativeSignalSettings` *(mutable)*
+
+`method: Optional[str]` plus a free-form `parameters: dict`. The parameters are not fixed fields
+because `AltPlotAnalyzer` discovers them at runtime from whichever `AltPlotMethodBase` subclasses are
+loaded — including lab-supplied ones via `alt_plot_import_path` — so the valid key set is unknown at
+class-definition time.
+
+Note `update_from_dict()` here mutates and returns `self`, unlike the frozen classes which return a
+new object. That is required: `AltPlotAnalyzer` holds this exact instance.
+
+#### `ExecutionState` *(mutable)* — the pause-aware clock
+
+`is_paused`, `start_time`, `time_of_pause`, `elapsed_pause`, with `start()`, `pause()`, `unpause()`
+and `get_live_elapsed_time()`.
+
+The trick worth knowing: `unpause()` pushes `start_time` *forward* by the pause duration, so elapsed
+time never counts paused seconds and no separate accumulator is needed.
+
+#### `MeasurementInformation` *(mutable, dict-like)*
+
+Attached to a pulse object as `.measurement_information`, written by predefined generate methods to
+describe what they built. Feeds `ReadoutSettings` when `invoke_settings` is on.
+
+Fields: `number_of_lasers`, `controlled_variable`, `laser_ignore_list`, `alternating`,
+`counting_length`, `units`, `labels` — all default to `None`, meaning "not yet known".
+
+- `_MANDATORY_FIELDS` (a `ClassVar`, so it is *not* a dataclass field) lists the five needed to invoke
+  settings; `is_valid` and `__bool__` check them. This replaced a "check 5 keys exist in a dict"
+  convention scattered across call sites.
+- Implements `__getitem__`/`__setitem__`/`get`/`update`/`__contains__` so predefined methods can keep
+  writing `block_ensemble.measurement_information['alternating'] = False`. Unlike a raw dict, an
+  unknown key raises `KeyError` listing the valid field names — typos are caught immediately.
+- Defines a custom `__eq__` for the numpy reason described above.
+
+#### `AnalysisParameters`, `ExtractionParameters` *(dict subclasses)*
+
+Persisted settings for `PulseAnalyzer` / `PulseExtractor`: the selected method under the `'method'`
+key plus that method's keyword arguments alongside it. Both expose `.method` and `.parameters`
+(everything except `'method'`) as read-only properties.
+
+Shared live objects — see convention 4.
+
+#### `GenerationMethodParameters` *(dict subclass)*
+
+The keyword arguments used to generate the loaded asset, e.g. `{'xy8_order': 8}`. Kept a dict because
+the key set depends entirely on which predefined generate method ran, and because
+`PulseBlockEnsemble`/`PulseSequence` already store it as a plain dict.
+
+#### `MetadataDictRepresentation` *(dict subclass)*
+
+Pure display helper. `qudi.util.datastorage`'s header writer renders each metadata value with
+`repr()` and prefixes every resulting line with the comment marker. A plain dict's `repr()` never
+breaks lines, so a big settings dict became one unreadable wall of text. This subclass overrides
+`__repr__` to return `pprint.pformat(...)`, which does contain real newlines — so the existing
+line-prefixing logic handles it with no changes to `DataStorage`.
+
+#### `PulsedMeasurementSettings` *(frozen)* — the aggregate
+
+```python
+microwave_settings        : MicrowaveSettings
+fast_counter_settings     : FastCounterSettings
+readout_settings          : ReadoutSettings
+alternate_signal_settings : AlternativeSignalSettings   # shared, mutated in place
+extraction_parameters     : ExtractionParameters        # shared, mutated in place
+analysis_parameters       : AnalysisParameters          # shared, mutated in place
+```
+
+Deliberately **not** here: `timer_interval_s`, `fit_configs` — operational bookkeeping, persisted as
+their own `StatusVar`s. Also not here: `sampling_information`, `measurement_information`,
+`generation_method_parameters` — those live on the loaded asset and are exposed as properties over
+that one reference rather than copied, which removed a save/load race.
+
+Carries `LEGACY_STATUS_VAR_KEYS` (the ~20 old `StatusVar` names, including the name-mangled
+`_PulsedMeasurementLogic__microwave_power` style ones) and `from_legacy_dict()`.
+
+#### Module-level defaults
+
+`_DEFAULT_MICROWAVE_SETTINGS`, `_DEFAULT_FAST_COUNTER_SETTINGS`, `_DEFAULT_READOUT_SETTINGS` — shared
+frozen instances, same rationale as in the generator file.
+
+Note the mutable defaults are **not** shared: `_default_measurement_settings()` builds a fresh
+`AlternativeSignalSettings()`/`ExtractionParameters()`/`AnalysisParameters()` on every call, so one
+measurement's live state can never leak into another's defaults.
+
+---
+
+### `pulsed_measurement.py`
+
+The top-level snapshot. Read the containment tree above alongside this section.
+
+#### `Settings` *(frozen)*
+
+```python
+measurement_settings : PulsedMeasurementSettings
+generator_settings   : Optional[SequenceGeneratorSettings] = None
+```
+
+Bundles the two independently-persisted settings containers. Each stays owned by its own logic
+module's `StatusVar`; this only holds references. `generator_settings` is `Optional` because
+`PulsedMeasurementLogic` has no `Connector` to `SequenceGeneratorLogic` and cannot fetch it alone —
+it is `None` whenever the snapshot was built by code with only measurement-logic access.
+
+#### `PulsedData` *(mutable)*
+
+`measurement_data: PulsedMeasurementData` plus `fit_result` / `fit_result_alt`.
+
+The fit results are `lmfit.model.ModelResult` objects with a **one-way** export path:
+`FitContainer.dict_result()` gives model name and parameter values/stderr for the saved metadata, and
+there is no reconstruction path — lmfit does not offer a simple one. So `from_dict()` deliberately
+does not restore them, and a `to_dict()`/`from_dict()` round trip loses them. This is expected, and
+the round-trip test asserts it.
+
+#### `PulseObjects` *(mutable)*
+
+`sequence` (the loaded top-level asset), plus `ensembles` and `blocks` — independent copies of
+everything `sequence` references **by name**. The real objects live in `SequenceGeneratorLogic`'s
+saved-asset registries and are untouched; these copies are resolved via
+`SequenceGeneratorLogic.resolve_asset_closure()`.
+
+The point is that a saved measurement's dict shows every block/ensemble definition in full rather than
+just a name, and stays frozen in time — editing a same-named asset later never changes an
+already-taken snapshot.
+
+- `elements` is a **property**, not a field: every `PulseBlockElement` across every block, flattened.
+  It is not exported by `to_dict()` because each element already appears inside its block's
+  `element_list`; exporting it would duplicate all of them.
+- `to_metadata_dict()` is a trimmed, display-only variant for saved-file headers. It drops per-sample
+  arrays (`laser_rising_bins`, `elements_length_bins`, `_legacy_data`) and duplicated sections so the
+  header shows sequence *structure* rather than thousands of numbers. There is no
+  `from_metadata_dict()`.
+
+#### `PulsedMeasurement` *(mutable)* — the root
+
+```python
+settings : Settings
+data     : Optional[PulsedData] = None
+objects  : PulseObjects = field(default_factory=PulseObjects)
+```
+
+(`field(default_factory=...)` rather than `= PulseObjects()`: a dataclass refuses a mutable default
+outright, because one shared instance would be handed to every object ever constructed. The same
+applies to every `dict`/`list`/`set`/`np.ndarray` default in this package.)
+
+Built by `PulsedMeasurementLogic.get_pulsed_measurement()` / `PulsedMasterLogic.get_pulsed_measurement()`
+as a frozen-in-time snapshot — `data` and `objects` are populated from `.copy()` calls, not live
+references.
+
+It doubles as `PulsedMeasurementLogic`'s **actual live storage**: the module's `_settings`,
+`measurement_data`, `_loaded_asset`, `_fit_result` and `_fit_result_alt` are all properties reading
+through one `_pulsed_measurement` instance rather than independent attributes.
+
+---
+
+### `pulsed_master_logic_data.py`
+
+#### `PulsedMasterStatus` *(dict subclass)*
+
+Ten busy/running flags, all defaulting to `False`: `sampling_ensemble_busy`, `sampling_sequence_busy`,
+`sampload_busy`, `loading_busy`, `pulser_running`, `measurement_running`, `microwave_running`,
+`predefined_generation_busy`, `fitting_busy`, `benchmark_busy`.
+
+Each has a property getter/setter over the dict entry, so `PulsedMasterLogic` gets typo-proof named
+access while `pulsed_maingui.py`'s existing `status_dict['flag']` reads and writes keep working.
+
+#### `FitContainers` *(frozen)*
+
+`primary` and `alternative` `FitContainer` instances, replacing an anonymous `(fc, alt_fc)` tuple.
+Implements `__iter__`/`__len__`/`__getitem__` so `fit_containers[0]` still works.
+
+---
+
+### `settings_coercion.py`
+
+Not dataclasses, but the shared front door every settings setter goes through.
+
+Every setter has the signature `def set_x_settings(self, settings=None, **kwargs)` and must accept
+four calling styles, all legal for backward compatibility:
+
+```python
+logic.set_generation_parameters(rabi_period=50e-9)                          # kwargs
+logic.set_generation_parameters({'rabi_period': 50e-9})                     # dict
+logic.set_generation_parameters(generation_parameters_instance)             # dataclass
+logic.set_generation_parameters({'rabi_period': 50e-9}, laser_length=2e-6)  # both
+```
+
+#### `coerce_settings(value, kwargs, current, cls)` → an instance of `cls`
+
+| `value` is... | result |
+|---|---|
+| an instance of `cls` | **full replacement** — `current` is ignored (`replace(value, **kwargs)` if kwargs given) |
+| a dict | **partial patch** — `current.update_from_dict({**value, **kwargs})` |
+| `None` | `current.update_from_dict(kwargs)`; with no kwargs at all this is a harmless refresh |
+| anything else | `SettingsTypeError` |
+
+Three details that are not obvious:
+
+- **The `cls` check comes before the dict check** because of convention 5 — for a dict-subclass
+  settings object both are true, and dict-first would misread a full replacement as a patch.
+- **`kwargs` is a plain positional argument, not `**kwargs`.** If it were `**kwargs`, a setting
+  literally named `value`, `current` or `cls` would collide with the helper's own parameter names.
+- **Passing a bare `BaseGenerationParameters` subclass is rejected**, because a contributor is not an
+  instance of the merged `GenerationParameters`. That is intentional: a contributor describes a
+  *fragment* of the schema, and treating it as a full replacement would reset every other parameter to
+  its default.
+
+#### `as_settings_dict(value, kwargs, cls=None)` → a plain dict
+
+The relay-layer counterpart. `PulsedMasterLogic` forwards settings to the owning logic module across a
+queued cross-thread connection, and a `QtCore.Signal(dict)` cannot carry a dataclass — so it must
+flatten first. It has no `current` parameter because a relay has nothing to patch against; it just
+forwards whatever partial information it was handed.
+
+#### `SettingsTypeError(TypeError)` — the two-tier error design
+
+| Exception | Means | Handling |
+|---|---|---|
+| `SettingsTypeError` | bad **input** from a user or script | caught, logged, settings left untouched |
+| plain `TypeError` | a **bug in the calling module** (wrong `cls`, unknown kwarg name) | not caught — propagates loudly |
+
+Because `SettingsTypeError` inherits from `TypeError`, `except SettingsTypeError` catches only the
+recoverable kind.
+
+The queued `@QtCore.Slot(dict)` setters **log instead of raising**: an exception inside a queued slot
+has no caller to propagate to, so at best Qt swallows it and at worst it takes the application down
+mid-measurement. They log the error, re-emit the unchanged settings so the GUI snaps back, and return.
+The plain property setters *do* raise, because those are called directly from Python where a traceback
+is useful.
+
+---
+
+## Where instances come from
+
+The docstrings explain what each class *is* better than they explain who *builds* it. There are four
+routes.
+
+### Route 1 — defaults at startup
+
+```
+_default_measurement_settings()   in ../pulsed_measurement_logic.py
+_default_generator_settings()     in ../sequence_generator_logic.py
+```
+
+Both are factory functions reusing the module-level `_DEFAULT_*` frozen instances, plus fresh mutable
+ones. They serve as the `StatusVar` default *and* as the fallback when a stored value turns out to be
+malformed.
+
+### Route 2 — restored from the status file at activation
+
+Three `StatusVar` declarations do all persistence. qudi-core calls the `representer` on shutdown and
+the `constructor` on activation.
+
+| StatusVar | Module | On-disk key | Round trip |
+|---|---|---|---|
+| `_pulsed_measurement` | `PulsedMeasurementLogic` | `_settings` | representer writes only `settings.measurement_settings.to_dict()`; `data`/`objects` are transient and rebuilt each activation |
+| `_generator_settings` | `SequenceGeneratorLogic` | `_generator_settings` | `SequenceGeneratorSettings.to_dict()` / `.from_dict()` |
+| `pulser_benchmarks` | `SequenceGeneratorLogic` | `pulser_benchmarks` | `PulserBenchmarks.to_dict()` / `.from_dict()` |
+
+Plus the independent ones that are deliberately outside the settings objects: `timer_interval_s` and
+`fit_configs` on `PulsedMeasurementLogic`.
+
+**Legacy migration** runs once, before the normal path: `_migrate_legacy_settings_if_needed()` in each
+logic module reads the raw status file, checks it against that class's `LEGACY_STATUS_VAR_KEYS`, and
+if it matches the old format, backs the file up and rebuilds via `from_legacy_dict()`.
+
+### Route 3 — a live edit from the GUI or a script
+
+```
+you change a widget on the Predefined Methods tab
+  └─► pulsed_maingui.generation_parameters_changed()      collects widgets into a plain dict
+      └─► PulsedMasterLogic.set_generation_parameters(dict)
+          └─► as_settings_dict(...)                      normalize to a DICT (a Signal can carry it)
+              └─► sigSamplingSettingsChanged.emit(dict)   [queued — thread hop]
+                  └─► SequenceGeneratorLogic.set_generation_parameters(dict)
+                      └─► coerce_settings(...)            normalize to a DATACLASS
+                          └─► current.update_from_dict()  per-field, keeps unmentioned fields
+                              └─► replace(self._generator_settings, generation_parameters=new)
+                                  └─► sigSamplingSettingsUpdated.emit(...)   GUI redraws
+```
+
+Two normalizations, one per layer: the relay needs a dict because that is all a signal can carry, the
+owner needs a dataclass because that is what it stores.
+
+The same shape applies to `set_fast_counter_settings`, `set_ext_microwave_settings`,
+`set_measurement_settings` and `set_pulse_generator_settings`.
+
+### Route 4 — attached to pulse objects
+
+`SamplingInformation()`, `MeasurementInformation()` and `GenerationMethodParameters()` are constructed
+**empty** in every `PulseBlock` / `PulseBlockEnsemble` / `PulseSequence` `__init__` and
+`*_from_dict()` in [`../pulse_objects.py`](../pulse_objects.py) — around fifteen sites. They are then
+filled in by `SequenceGeneratorLogic`:
+
+- `generate_predefined_sequence()` sets `generation_method_parameters` from the method's kwargs;
+- the predefined generate method itself writes `measurement_information`;
+- `sample_pulse_block_ensemble()` / `sample_pulse_sequence()` write `sampling_information`;
+- `clear_pulser()` and the various invalidation paths reset them to fresh empty instances.
+
+---
+
+## Neighbour map
+
+Classes referenced from here that live elsewhere. Named, not documented — see their own files.
+
+| Class | Lives in | Relationship |
+|---|---|---|
+| `PulseBlock`, `PulseBlockEnsemble`, `PulseSequence`, `PulseBlockElement` | [`../pulse_objects.py`](../pulse_objects.py) | held by `PulseObjects`; carry `SamplingInformation`/`MeasurementInformation`/`GenerationMethodParameters` |
+| `PulseEnvelope`, `PulseEnvelopeType` | [`../sampling_functions.py`](../sampling_functions.py) | the type of `CoreGenerationParameters.pulse_envelope` |
+| `BenchmarkTool` | `qudi.util.benchmark` | the two fields of `PulserBenchmarks` |
+| `FitContainer` | `qudi.util.datafitting` | the two fields of `FitContainers`; `dict_result()` is the one-way fit export |
+| `dataclass_representer`, `sampling_information_constructor` | `qudi.util.yaml_helpers` | YAML round trip for `SamplingInformation`, registered in `../sequence_generator_logic.py` |
+
+### The layering rule
+
+`pulsed_data/` sits **below** `pulse_objects.py`. `pulse_objects.py` imports from here; nothing here
+may import from it at module level. Where a type hint needs one, `pulsed_measurement.py` uses
+`if TYPE_CHECKING:` and quoted annotations, and `PulseObjects.from_dict()` imports inside the
+function body.
+
+The same rule applies between this folder and the logic modules: `sequence_generator_logic_data.py`
+cannot import from `sequence_generator_logic.py`, which is why the shared `_DEFAULT_*` literals are
+defined down here.
+
+And within this folder, `generation_parameter_extensions.py` must never import from
+`sequence_generator_logic_data.py` — a cycle there would make the contributor merge silently skip
+extensions depending on import order.
+
+---
+
+## Extending this — notes for physicists
+
+### Adding a global generation parameter (the common case)
+
+Edit **only** [`generation_parameter_extensions.py`](generation_parameter_extensions.py). Add one
+frozen dataclass inheriting `BaseGenerationParameters`:
+
+```python
+@dataclass(frozen=True)
+class NVCentreParameters(BaseGenerationParameters):
+    """Extra generation parameters for the NV setup."""
+
+    green_aom_delay: float = 700e-9
+    readout_channel: str = 'd_ch4'
+
+    @classmethod
+    def _coerce_fields(cls, data, current=None):
+        pick = cls._pick
+        return {
+            'green_aom_delay': float(pick(data, current, 'green_aom_delay', 700e-9)),
+            'readout_channel': str(pick(data, current, 'readout_channel', 'd_ch4')),
+        }
+```
+
+That is the whole change. A widget appears on the Predefined Methods tab, the value persists across
+restarts, and predefined methods read it as:
+
+```python
+self.generation_parameters['green_aom_delay']                        # dict style
+self.generator_settings.generation_parameters.green_aom_delay        # attribute style
+```
+
+**Rules, each with a real consequence if broken:**
+
+| Rule | What happens otherwise |
+|---|---|
+| Every field needs a default | `TypeError` at import — a merged dataclass cannot have a no-default field after a defaulted one |
+| Field names must be unique across all contributors | `TypeError` at import naming both classes. This is a *feature* — silent last-wins would change a measurement parameter with no warning |
+| Types must be `str`/`int`/`float`/`bool`/`Enum`/`PulseEnvelope` | no widget is built for it (see `_create_pm_global_params` in [`../../../gui/pulsed/pulsed_maingui.py`](../../../gui/pulsed/pulsed_maingui.py)); the parameter still works from scripts |
+| Implement `_coerce_fields()` | `NotImplementedError` the first time settings are loaded or changed |
+| Declare the class at import time, not from a config path | the merge runs at module import, long before qudi-core restores status variables |
+| Never pass a bare contributor to `set_generation_parameters()` | rejected by `coerce_settings` — see the note in the `settings_coercion.py` section |
+
+Suffix conventions the GUI picks up automatically: a float whose name contains `amp` or `volt` gets a
+`V` suffix, `freq` gets `Hz`, and `tau`/`period`/`time`/`delay`/`laser_length` get `s`.
+
+Also note: any generation parameter whose name **ends in `_channel`** is treated as a channel
+specifier by `set_pulse_generator_settings()` and will be auto-corrected if it names a channel that is
+not in the active activation config.
+
+### Adding a field to any other settings dataclass
+
+Six steps, in order. Skipping any of the middle ones fails silently rather than loudly.
+
+1. **Declare the field** with a type and a default.
+2. **`to_dict()`** — add the key. Copy mutable values (`dict(...)`, `list(...)`, `.copy()`).
+3. **`from_dict()`** — add the key *tolerantly*: `data.get('name', default)`, never `data['name']`.
+4. **`update_from_dict()`** — add the key with `data.get('name', self.name)`.
+5. **`_DEFAULT_*`** — update the module-level literal if the class has one.
+6. **Widget** — if it is user-facing, add it in `pulsed_maingui.py`.
+
+If the field is a `np.ndarray`, also check whether anything compares two instances of the class; if so
+you need a custom `__eq__` (see `MeasurementInformation.__eq__`).
+
+If the class is one of the *shared mutable* ones, remember its `update_from_dict()` must mutate and
+return `self`, not build a new object.
+
+### Why your old status file still works — and what to do when it does not
+
+Loading is tolerant at three levels: unknown keys are ignored, missing keys fall back to defaults, and
+whole missing sections fall back to the shared `_DEFAULT_*` objects. `SamplingInformation` goes
+further and keeps unknown keys in `_legacy_data`.
+
+If settings do reset unexpectedly:
+
+1. Find the status file — `qudi/`'s app data dir, one file per logic module.
+2. Check whether it is the pre-refactor format: if its top-level keys match a class's
+   `LEGACY_STATUS_VAR_KEYS`, the migration path should have converted it and left the original
+   alongside it as `<status file>.legacy_backup`.
+3. If a `from_dict` raised, the `StatusVar` constructor swallowed it and returned the default object —
+   check the qudi log for the traceback rather than assuming the file was empty.
+
+### Pitfalls worth knowing before you debug something
+
+- **`replace()` returns a new object.** `replace(settings, power=-20)` on its own does nothing; you
+  must assign the result. Frozen classes will not let you assign the field directly.
+- **Numpy fields break the generated `__eq__`.** Symptom: *"The truth value of an array with more than
+  one element is ambiguous."*
+- **`if sampling_information:` means "has been sampled"**, not "is not None" — `__bool__` checks
+  `waveforms`. Same for `LoadedAsset` (needs both name and type) and `MeasurementInformation` (needs
+  all five mandatory fields).
+- **Shared mutable objects must not be rebound.** If you replace `analysis_parameters` with a new
+  object instead of `.update(...)`-ing it, `PulseAnalyzer` keeps using the old one and your change
+  appears to be ignored.
+- **`GenerationParameters` is pickled into every saved `.ensemble`/`.sequence`.** Renaming the
+  module-level name, or building the class somewhere pickle cannot resolve, breaks every existing
+  saved asset.
+- **`.copy()` is not uniform.** `PulsedMeasurementData.copy()` deep-copies every array;
+  `SamplingInformation.copy()` copies each mutable field individually; `MeasurementInformation.copy()`
+  copies the list and the array. Check the method before assuming a snapshot is independent.
+- **`_legacy_data` silently absorbs typos.** A key you set on a `SamplingInformation` that is not a
+  declared field lands there and is never read by the code you expected to read it.
+
+### Tests
+
+| File | Pins |
+|---|---|
+| [`../../../../../tests/test_pulsed_measurement.py`](../../../../../tests/test_pulsed_measurement.py) | the bulk of it — `to_dict()`/`from_dict()` round trips for `PulsedMeasurement`/`PulsedMeasurementSettings`/`SequenceGeneratorSettings`/`SamplingInformation`; tolerance of a dict missing a key; that fit results are deliberately *not* restored; both `from_legacy_dict()` paths against realistic pre-refactor status dicts; that `LEGACY_STATUS_VAR_KEYS` is not a dataclass field; `.copy()` independence for pulse objects and `PulsedMeasurementData`; pickle round trip of a whole snapshot; block/ensemble closure resolution |
+| [`../../../../../tests/test_pulsed_measurement_logic_data.py`](../../../../../tests/test_pulsed_measurement_logic_data.py) | `ExecutionState` pause behaviour, `DataStashCache` stash/recall, `AnalysisParameters`/`ExtractionParameters` round trip |
+
+Run them with:
+
+```
+python -m pytest tests/test_pulsed_measurement.py tests/test_pulsed_measurement_logic_data.py
+```
+
+> `tests/test_migration.py` is **not** part of this suite despite the name. It is a scratch script
+> with a hardcoded absolute path to one person's `rabi.ensemble`, containing no test function and
+> doing its work at import time — pytest will error collecting it on any other machine. If you want a
+> real regression test for unpickling a legacy `.ensemble`, it needs rewriting around a fixture file.
+
+If you add a field, add it to the relevant round-trip test — that is what catches a `to_dict()` and
+`from_dict()` that have drifted apart.

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -6,6 +6,10 @@ existed, all of it was loose dictionaries and ~20 separately-declared `StatusVar
 in a settings key was silently accepted and a missing key in a saved file could reset every setting
 you had.
 
+**If you are here to add a new sequence to the Predefined Methods tab,** you do not need any of the
+dataclass detail below — skip to
+[Writing a predefined generate method](#writing-a-predefined-generate-method).
+
 **If you are here to add a lab-specific global generation parameter, you only need one file:**
 [`generation_parameter_extensions.py`](generation_parameter_extensions.py). Skip to
 [Extending this](#extending-this--notes-for-physicists).
@@ -25,7 +29,7 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import Generati
 |---|---|---|
 | [`generation_parameter_extensions.py`](generation_parameter_extensions.py) | **Your lab's** extra generation parameters | 2 |
 | [`sequence_generator_logic_data.py`](sequence_generator_logic_data.py) | `SequenceGeneratorLogic` — generation parameters, pulser hardware mirror, sampling results | 14 |
-| [`pulsed_measurement_logic_data.py`](pulsed_measurement_logic_data.py) | `PulsedMeasurementLogic` — microwave, fast counter, readout, live measurement state | 13 |
+| [`pulsed_measurement_logic_data.py`](pulsed_measurement_logic_data.py) | `PulsedMeasurementLogic` — microwave, fast counter, readout, live measurement state | 13 classes + 1 function |
 | [`pulsed_measurement.py`](pulsed_measurement.py) | The top-level snapshot of one complete measurement | 4 |
 | [`pulsed_master_logic_data.py`](pulsed_master_logic_data.py) | `PulsedMasterLogic` — busy flags, fit containers | 2 |
 | [`settings_coercion.py`](settings_coercion.py) | Shared helper every settings setter calls | 1 class + 2 functions |
@@ -658,6 +662,45 @@ breaks lines, so a big settings dict became one unreadable wall of text. This su
 `__repr__` to return `pprint.pformat(...)`, which does contain real newlines — so the existing
 line-prefixing logic handles it with no changes to `DataStorage`.
 
+#### `to_plain_metadata()` *(function)*
+
+The other half of the save boundary, and the one that decides whether a header can be **read back**.
+
+`qudi.util.datastorage` writes each metadata value with `repr()` and restores it with a bare
+`eval()`. `repr()` does not produce a description of a value — it produces *code that rebuilds it* —
+so a repr that names a tool rather than spelling the value out raises `NameError` on the way back
+in. `str_dict_to_metadata()` catches that and silently keeps the raw string, so the value looks
+correct in the file but arrives as a `str`, and a caller doing
+`metadata['generation parameters']['rabi_period']` fails far from the cause with *"string indices
+must be integers"*. Three such reprs really occur:
+
+| repr in the header | comes from | why the parser's one import retry cannot rescue it |
+|---|---|---|
+| `array([0., 1., ...])` | any `np.ndarray`, e.g. `controlled_variable` | it imports the *stdlib* `array` module, whose `array()` then rejects the argument |
+| `np.int64(5943750)` | numpy scalars, numpy ≥ 2.0 | there is no module called `np` — it is a convention, not a name |
+| `qudi.logic.pulsed.sampling_functions.PulseEnvelope(...)` | `pulse_envelope`, plus the `PulseEnvelopeType` enum inside it | importing `qudi` binds only the top-level package, not that submodule |
+
+`to_plain_metadata()` converts recursively — arrays to lists, numpy scalars to `int`/`float`/`bool`,
+`Enum` to its value, sets to sorted lists, anything with `to_dict()` through it — so the header
+becomes self-describing and needs no imports at all to parse. It is applied by
+`PulsedMeasurementLogic._finalize_metadata()`, which sanitizes **then** wraps in
+`MetadataDictRepresentation`.
+
+Two things worth knowing:
+
+- **This is not about the pretty-printing.** Line breaks never affected whether a value parses: a
+  dict literal spanning lines is a valid `eval` expression and `ConfigParser` rejoins continuation
+  lines first. `eval` cares about undefined *names*. A pretty-printed `fast counter settings` parses
+  back to a `dict` perfectly, while a single-line `generation parameters` does not.
+- **It also prevents silent data loss.** numpy summarises the repr of arrays longer than
+  `np.get_printoptions()['threshold']` (1000) as `array([0., 1., ..., 1498., 1499.])`. A controlled
+  variable with more than 1000 points used to reach the header with its middle values already gone,
+  unrecoverably — the text no longer contained them.
+
+**Branch order in the implementation is load-bearing:** `dict`/`list`/`tuple`/`set` are matched
+before the `to_dict()` duck-type, because `AnalysisParameters`, `ExtractionParameters` and
+`GenerationMethodParameters` are dict subclasses that also define `to_dict()` — convention 5 again.
+
 #### `PulsedMeasurementSettings` *(frozen)* — the aggregate
 
 ```python
@@ -975,6 +1018,177 @@ extensions depending on import order.
 ---
 
 ## Extending this — notes for physicists
+
+### Writing a predefined generate method
+
+Everything else in this file is about the dataclasses. This section is about the task most people
+actually come here for: adding a new sequence to the **Predefined Methods** tab. The methods
+themselves live one folder up, in
+[`../predefined_generate_methods/`](../predefined_generate_methods/).
+
+Almost every way of getting this wrong fails **silently** — no error, no log line, the method or the
+widget simply is not there. So each rule below is paired with what you see when you break it.
+
+#### How qudi finds your method
+
+Four conditions, all required:
+
+| Condition | If you break it |
+|---|---|
+| The method sits on a class inheriting `PredefinedGeneratorBase` ([`../pulse_objects.py`](../pulse_objects.py)) | the class is not collected; none of its methods appear |
+| Its name starts with `generate_` | not recognised as a generate method |
+| Its module is under `qudi.logic.pulsed.predefined_generate_methods`, **or** under a path listed in the `additional_predefined_methods_path` ConfigOption of `SequenceGeneratorLogic` | never imported, so never discovered |
+| The module imports cleanly | collection skips it |
+
+The group box on the tab is labelled with the name minus the `generate_` prefix, so
+`generate_rabi` shows up as **rabi**.
+
+#### The contract every method must honour
+
+```python
+def generate_my_sequence(self, name='my_seq', tau_start=10.0e-9, num_of_points=50):
+    ...
+    return created_blocks, created_ensembles, created_sequences
+```
+
+- **Return exactly three lists** — blocks, ensembles, sequences — any of which may be empty.
+  `SequenceGeneratorLogic.generate_predefined_sequence()` unpacks all three
+  ([`../sequence_generator_logic.py`](../sequence_generator_logic.py)).
+- **A `name` argument is mandatory.** Without one, generation is aborted with an error and nothing
+  is created. It is the only argument checked for.
+- **Arguments you do not declare are discarded.** Anything passed that is not in your signature is
+  dropped, recorded only at `debug` level — which nobody sees by default. A typo'd parameter name
+  therefore behaves exactly like a parameter that is ignored.
+
+#### The boxes next to the Generate button
+
+The GUI builds one input widget per argument by inspecting its **default value**, so:
+
+- **Every argument needs a default.** No default, no widget.
+- **Only `bool`, `float`, `int`, `str` and `Enum` are supported.** Anything else logs an error and
+  that one widget is skipped, while the rest of the method still works — see
+  `_create_predefined_methods` in
+  [`../../../gui/pulsed/pulsed_maingui.py`](../../../gui/pulsed/pulsed_maingui.py).
+- **Units come from the name.** A `float` whose name contains `amp` or `volt` gets a `V` suffix,
+  `freq` gets `Hz`, and `time`, `period` or `tau` get `s`.
+
+#### Where does a parameter belong?
+
+Three tiers, and picking the wrong one is the usual mistake:
+
+| Your value is… | Declare it as | Example |
+|---|---|---|
+| changed on every generation | an ordinary method argument (above) | `tau_start`, `num_of_points` |
+| a property of the whole setup, used by several methods | a `BaseGenerationParameters` subclass — see [Adding a global generation parameter](#adding-a-global-generation-parameter-the-common-case) | `green_aom_delay` |
+| needed by one generator only | `generation_parameter_contributors` — see [Adding a parameter only one generator needs](#adding-a-parameter-only-one-generator-needs) | `rf_amplitude` |
+
+Both of the lower two tiers become ordinary `GenerationParameters` fields: a widget in the tab's
+global parameter grid, a slot in the status file, and readable from any generate method as
+
+```python
+self.generation_parameters['green_aom_delay']     # dict style
+self.microwave_amplitude                          # named helper properties, for the built-ins
+```
+
+The global grid supports a slightly wider set of types than the per-method widgets do — `str`,
+`int`, `float`, `bool`, `Enum` and `PulseEnvelope`, with anything else logged and skipped
+(`_create_pm_global_params`). Two behaviours specific to the global grid:
+
+- A parameter whose name **ends in `_channel`** is rendered as a drop-down of the currently active
+  channels, and is auto-corrected by `set_pulse_generator_settings()` if it names a channel that is
+  not in the active activation config.
+- `laser_channel`, `sync_channel` and `gate_channel` deliberately get no widget here — they are
+  already on the Pulse Editor tab.
+
+#### Telling the analysis what you built
+
+If you want **invoke settings** to configure the measurement automatically, attach a
+`MeasurementInformation` to your ensemble or sequence. Five fields are mandatory
+(`MeasurementInformation._MANDATORY_FIELDS`); miss any one and invoke settings silently does
+nothing, because `is_valid` stays `False`:
+
+```python
+block_ensemble.measurement_information.number_of_lasers    = num_of_points
+block_ensemble.measurement_information.controlled_variable = tau_array
+block_ensemble.measurement_information.laser_ignore_list   = list()
+block_ensemble.measurement_information.alternating         = False
+block_ensemble.measurement_information.counting_length     = self._get_ensemble_count_length(
+    ensemble=block_ensemble, created_blocks=created_blocks)
+# optional, but they label the plot axes
+block_ensemble.measurement_information.units  = ('s', '')
+block_ensemble.measurement_information.labels = ('Tau', 'Signal')
+```
+
+Unlike a plain dict, an unknown field name raises `KeyError` listing the valid ones, so typos here
+are caught immediately. `generate_rabi` in
+[`../predefined_generate_methods/basic_predefined_methods.py`](../predefined_generate_methods/basic_predefined_methods.py)
+is the shortest complete example to copy from.
+
+#### A skeleton to start from
+
+```python
+import numpy as np
+from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble
+from qudi.logic.pulsed.pulse_objects import PredefinedGeneratorBase
+
+
+class MyLabGenerator(PredefinedGeneratorBase):
+    """Sequences specific to our setup."""
+
+    # Optional - only if this generator needs its own global parameters (tier 3 above)
+    generation_parameter_contributors = ({'rf_amplitude': 1e-3, 'rf_channel': 'a_ch2'},)
+
+    def generate_my_sequence(self, name='my_seq', tau_start=10.0e-9, tau_step=10.0e-9,
+                             num_of_points=50):
+        """One-line summary shown nowhere, but write it anyway."""
+        created_blocks, created_ensembles, created_sequences = list(), list(), list()
+
+        tau_array = tau_start + np.arange(num_of_points) * tau_step
+
+        mw_element      = self._get_mw_element(length=tau_start, increment=tau_step,
+                                               amp=self.microwave_amplitude,
+                                               freq=self.microwave_frequency, phase=0)
+        laser_element   = self._get_laser_gate_element(length=self.laser_length, increment=0)
+        delay_element   = self._get_delay_gate_element()
+        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
+
+        block = PulseBlock(name=name)
+        block.append(mw_element)
+        block.append(laser_element)
+        block.append(delay_element)
+        block.append(waiting_element)
+        created_blocks.append(block)
+
+        block_ensemble = PulseBlockEnsemble(name=name, rotating_frame=False)
+        block_ensemble.append((block.name, num_of_points - 1))
+        self._add_trigger(created_blocks=created_blocks, block_ensemble=block_ensemble)
+
+        block_ensemble.measurement_information.number_of_lasers    = num_of_points
+        block_ensemble.measurement_information.controlled_variable = tau_array
+        block_ensemble.measurement_information.laser_ignore_list   = list()
+        block_ensemble.measurement_information.alternating         = False
+        block_ensemble.measurement_information.units               = ('s', '')
+        block_ensemble.measurement_information.labels              = ('Tau', 'Signal')
+        block_ensemble.measurement_information.counting_length     = \
+            self._get_ensemble_count_length(ensemble=block_ensemble,
+                                            created_blocks=created_blocks)
+
+        created_ensembles.append(block_ensemble)
+        return created_blocks, created_ensembles, created_sequences
+```
+
+#### When something does not work
+
+| Symptom | Cause |
+|---|---|
+| The method does not appear on the tab at all | one of the four discovery conditions above — most often the class does not inherit `PredefinedGeneratorBase`, or the module is outside both search paths |
+| The method appears but one parameter has no box | that argument has no default, or its type is outside `bool`/`float`/`int`/`str`/`Enum`. The error is in the qudi log |
+| A parameter you pass is ignored | it is not in the method signature — check the spelling; the discard is only logged at `debug` level |
+| A new global parameter has no widget | its type is outside `str`/`int`/`float`/`bool`/`Enum`/`PulseEnvelope`. It still works from scripts |
+| Two generators declare the same parameter name | rejected on purpose. In `generation_parameter_extensions.py` this raises at import; from `generation_parameter_contributors` it is logged and skipped so a faulty lab module cannot block activation |
+| "Invoke settings" does nothing | one of the five mandatory `measurement_information` fields is missing |
+| Your ensemble-only method produces a **sequence** | on a pulser whose constraints report `SequenceOption.FORCED`, `_add_default_sequence()` wraps your ensemble in a generated `PulseSequence` of the same name, and that sequence is what gets loaded |
+| The generated object ignores a parameter you changed | generation parameters are read when the method runs; change them *before* pressing Generate, and re-sample after changing them |
 
 ### Adding a global generation parameter (the common case)
 

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -132,9 +132,9 @@ disconnect `PulseAnalyzer` from the settings the rest of the app thinks it is us
 
 ### 5. `class X(dict)` is a compatibility shim, not a mistake
 
-Five classes subclass `dict` instead of being dataclasses:
+Four classes subclass `dict` instead of being dataclasses:
 `AnalysisParameters`, `ExtractionParameters`, `GenerationMethodParameters`,
-`MetadataDictRepresentation`, `PulsedMasterStatus`.
+`PulsedMasterStatus`.
 
 They exist where old call sites index and assign directly and were not worth rewriting:
 
@@ -186,7 +186,9 @@ PulsedMeasurement                                   [mutable]  pulsed_measuremen
 │   └── fit_result_alt   : lmfit ModelResult | None             (one-way export only)
 │
 └── objects : PulseObjects                          [mutable]
-    ├── sequence  : PulseBlockEnsemble | PulseSequence | None    ← lives in pulse_objects.py
+    ├── loaded_asset : PulseBlockEnsemble | PulseSequence | None ← lives in pulse_objects.py
+    │   ├── loaded_sequence : PulseSequence | None      ┐ properties over the one slot above,
+    │   └── loaded_ensemble : PulseBlockEnsemble | None ┘ not fields — see PulseObjects
     ├── ensembles : {name: PulseBlockEnsemble}                   independent copies
     └── blocks    : {name: PulseBlock}                           independent copies
 ```
@@ -221,8 +223,7 @@ These are containers, not a class hierarchy. Two exceptions:
 ```
 BaseGenerationParameters                    generation_parameter_extensions.py
 ├── CoreGenerationParameters                sequence_generator_logic_data.py  (built-in, 14 fields)
-├── TestParameters                          generation_parameter_extensions.py (example, 1 field)
-├── <your setup's class here>               generation_parameter_extensions.py
+├── <your setup's class here>               generation_parameter_extensions.py (none right now)
 └── <one generator's own parameters>        declared via generation_parameter_contributors
         │
         ├──► merged at import time by _build_generation_parameters()
@@ -237,8 +238,7 @@ dict
 ├── AnalysisParameters             ┐
 ├── ExtractionParameters           │ compatibility shims — see convention 5
 ├── GenerationMethodParameters     │
-├── PulsedMasterStatus             │
-└── MetadataDictRepresentation     ┘ (pretty-printing wrapper only)
+└── PulsedMasterStatus             ┘
 ```
 
 ---
@@ -330,27 +330,26 @@ since `fields()` never reports `ClassVar`/`InitVar`.
 import from `sequence_generator_logic_data.py`. A circular import between the two would make the merge
 silently skip extensions depending on which module happened to be imported first.
 
-#### `TestParameters` — a live example
+#### Writing an extension — the shape
 
 ```python
 @dataclass(frozen=True)
-class TestParameters(BaseGenerationParameters):
+class MySetupParameters(BaseGenerationParameters):
     time_delay: float = 4.0
-
-    @classmethod
-    def _coerce_fields(cls, data, current=None):
-        pick = cls._pick
-        return {'time_delay': float(pick(data, current, 'time_delay', 4.0))}
 ```
 
-> **Note:** this is currently active, so `time_delay` really is a field of `GenerationParameters` and
-> really does get a spin box on the Predefined Methods tab — `GenerationParameters` has 15 fields
-> here, not 14. It is scaffolding from the refactor and marked for removal; if your setup does not
-> want it, delete the class.
+That is the whole thing, and there is no registration step: `_build_generation_parameters()` finds
+every contributor through `BaseGenerationParameters.__subclasses__()`, so simply defining the class
+in this file puts it in effect. Coercion is driven by the annotated type, a spin box appears on the
+Predefined Methods tab, and the value is saved to and restored from the status file.
+
+> **Note:** `generation_parameter_extensions.py` currently defines **no** extension classes, so
+> `GenerationParameters` has exactly the 14 fields of `CoreGenerationParameters`. The example above
+> is illustrative — writing it into that file is what activates it.
 >
-> Its `_coerce_fields` predates the automatic version and does exactly what the base class would now
-> do for a `float` field. **Do not copy it into a new class** — the two lines of `time_delay: float =
-> 4.0` are the whole modern form.
+> Older extensions carry a hand-written `_coerce_fields()` classmethod. It predates the automatic,
+> type-driven version and does exactly what the base class now does for a `float` field. **Do not
+> write one in a new class.**
 
 ---
 
@@ -488,14 +487,18 @@ and `analyze_sequence()`.
 
 `EnsembleAnalysisResult`: `number_of_samples`, `number_of_elements`, `elements_length_bins`,
 `digital_rising_bins`, `digital_falling_bins`, `analog_channels`, `digital_channels`, `channel_set`,
-`generation_parameters`, `ideal_length`, `laser_rising_bins`, `laser_falling_bins`.
+`ideal_length`, `laser_rising_bins`, `laser_falling_bins`.
 
 `SequenceAnalysisResult`: the same information aggregated over a whole sequence, plus per-step
 breakdowns (`number_of_steps`, `number_of_samples_per_step`, `number_of_ensembles`, `ensemble_names`,
 `number_of_elements_per_step`, `elements_length_bins_per_step`, `ideal_length_per_step`).
 
-Both carry the `generation_parameters` in force at analysis time, which is how those end up in a saved
-measurement's metadata.
+Neither carries `generation_parameters`, and that absence is load-bearing. `_dataclass_to_dict()`
+dumps **every** field of one of these straight into `SamplingInformation.from_dict()`, so a field
+here is a field that ends up pickled onto every sampled asset. A `generation_parameters` snapshot
+used to ride along that way, read by nothing and free to diverge from the live settings — see
+`SamplingInformation._REJECTED_KEYS` above. Think twice before adding a field here: it is not a
+private return value, it is an input to what gets persisted.
 
 #### `SamplingInformation` *(mutable, dict-like)*
 
@@ -510,8 +513,9 @@ happened when that object was sampled.
 | `laser_rising_bins`, `laser_falling_bins` | laser pulse edges, read by the extraction methods |
 | `step_waveform_list`, `ensemble_info` | sequence-specific |
 | `_legacy_data` | catch-all for keys that are not declared fields |
+| `_REJECTED_KEYS` | `ClassVar` — keys refused outright instead of being absorbed |
 
-Three things to know:
+Four things to know:
 
 - **`__bool__` returns `bool(self.waveforms)`.** Logic all over the toolchain does
   `if ensemble.sampling_information:` to mean *"has this actually been sampled?"* — do not add fields
@@ -523,6 +527,21 @@ Three things to know:
 - **`_legacy_data` absorbs unknown keys** so nothing is ever lost round-tripping an old file. It also
   means a typo'd key is silently accepted — check `_field_names()` if something you set does not seem
   to take effect.
+- **`_REJECTED_KEYS` is the escape hatch from that**, for a key that must never live here at all.
+  `generation_parameters` is the one entry. It used to arrive by accident: `analyze_block_ensemble()`
+  returned it as one field among many, and `_dataclass_to_dict()` dumps every field of that result
+  through `from_dict()` — so an undeclared key landed in `_legacy_data`, got pickled into every
+  `.ensemble`/`.sequence`, and then diverged from the live `SequenceGeneratorSettings` the moment
+  anyone edited a generation parameter (nothing re-samples on that change, and the sequence sampling
+  cache does not key on it). Nothing read it back except one save-time fallback. Generation
+  parameters now have exactly one home. `__setitem__` and `from_dict()` both drop the key; for assets
+  pickled before this, `SequenceGeneratorLogic._migrate_legacy_info_container()` strips it on load,
+  since `pickle` bypasses `from_dict()` entirely.
+
+  Note this is a *targeted* refusal, not a general tightening — every other unknown key still lands
+  in `_legacy_data` as before. Promoting a key to a declared field (as `laser_rising_bins` /
+  `laser_falling_bins` were) is the right move when it has a real reader; refusing it is right when
+  it has none and a rightful owner elsewhere.
 
 This is the only class in the package with a YAML representer and constructor registered for it
 (in [`../sequence_generator_logic.py`](../sequence_generator_logic.py), just after the imports), so it
@@ -654,17 +673,9 @@ The keyword arguments used to generate the loaded asset, e.g. `{'xy8_order': 8}`
 the key set depends entirely on which predefined generate method ran, and because
 `PulseBlockEnsemble`/`PulseSequence` already store it as a plain dict.
 
-#### `MetadataDictRepresentation` *(dict subclass)*
-
-Pure display helper. `qudi.util.datastorage`'s header writer renders each metadata value with
-`repr()` and prefixes every resulting line with the comment marker. A plain dict's `repr()` never
-breaks lines, so a big settings dict became one unreadable wall of text. This subclass overrides
-`__repr__` to return `pprint.pformat(...)`, which does contain real newlines — so the existing
-line-prefixing logic handles it with no changes to `DataStorage`.
-
 #### `to_plain_metadata()` *(function)*
 
-The other half of the save boundary, and the one that decides whether a header can be **read back**.
+The save boundary: the function that decides whether a header can be **read back**.
 
 `qudi.util.datastorage` writes each metadata value with `repr()` and restores it with a bare
 `eval()`. `repr()` does not produce a description of a value — it produces *code that rebuilds it* —
@@ -672,26 +683,50 @@ so a repr that names a tool rather than spelling the value out raises `NameError
 in. `str_dict_to_metadata()` catches that and silently keeps the raw string, so the value looks
 correct in the file but arrives as a `str`, and a caller doing
 `metadata['generation parameters']['rabi_period']` fails far from the cause with *"string indices
-must be integers"*. Three such reprs really occur:
+must be integers"*. Four such reprs really occur:
 
 | repr in the header | comes from | why the parser's one import retry cannot rescue it |
 |---|---|---|
 | `array([0., 1., ...])` | any `np.ndarray`, e.g. `controlled_variable` | it imports the *stdlib* `array` module, whose `array()` then rejects the argument |
 | `np.int64(5943750)` | numpy scalars, numpy ≥ 2.0 | there is no module called `np` — it is a convention, not a name |
 | `qudi.logic.pulsed.sampling_functions.PulseEnvelope(...)` | `pulse_envelope`, plus the `PulseEnvelopeType` enum inside it | importing `qudi` binds only the top-level package, not that submodule |
+| `nan`, `inf`, `-inf` | `upload_speed`, and any measured array with a gap in it | there is no module called `nan` either — and no Python *literal* for it, which is what makes this one different |
 
 `to_plain_metadata()` converts recursively — arrays to lists, numpy scalars to `int`/`float`/`bool`,
 `Enum` to its value, sets to sorted lists, anything with `to_dict()` through it — so the header
-becomes self-describing and needs no imports at all to parse. It is applied by
-`PulsedMeasurementLogic._finalize_metadata()`, which sanitizes **then** wraps in
-`MetadataDictRepresentation`.
+becomes self-describing and needs no imports at all to parse. It is the whole of
+`PulsedMeasurementLogic._finalize_metadata()`.
 
-Two things worth knowing:
+##### The non-finite floats are the one case that changes the value's *type*
 
-- **This is not about the pretty-printing.** Line breaks never affected whether a value parses: a
-  dict literal spanning lines is a valid `eval` expression and `ConfigParser` rejoins continuation
-  lines first. `eval` cares about undefined *names*. A pretty-printed `fast counter settings` parses
-  back to a `dict` perfectly, while a single-line `generation parameters` does not.
+Every other conversion above lands on a type whose repr is already a literal. NaN has no literal at
+all, so no value that is still a `float` can repr as something `eval()` resolves. They are therefore
+written as the **strings** `'nan'` / `'inf'` / `'-inf'`, and a reader recovers the number with
+`float(v)`. Writing `None` instead would have collapsed the three cases together; a `float` subclass
+with a constructor-shaped `__repr__` would have kept the type but was not worth a class.
+
+This was not a rare edge case. `PulseGeneratorSettings.upload_speed` is NaN until the pulse
+generator has been benchmarked — `PulserBenchmarks.estimate_combined_speed()` returns
+`np.nan` until it has samples, and `_DEFAULT_PULSE_GENERATOR_SETTINGS` seeds it that way. Before this
+branch existed, **every** saved file on a fresh install had its entire `pulsed measurement settings`
+block come back as an unparsed `str`, in all three `.dat` files. One leaf poisons the whole key, and
+nothing anywhere reports it. (`pulsed_maingui.py` has long guarded the same value with
+`if np.isnan(...): = 0.` for display, which is the clue that NaN is a normal state here.)
+
+The YAML status file was never affected — ruamel writes `.nan` natively — nor is the
+`.pulsedmeasurement` pickle, which keeps a real `float('nan')`. Only the `eval()`-based header path
+needed this.
+
+Two more things worth knowing:
+
+- **Line breaks were never part of this.** Whether a value parses back has nothing to do with how
+  it is laid out: a dict literal spanning lines is a valid `eval` expression and `ConfigParser`
+  rejoins continuation lines first. `eval` cares about undefined *names*. A wall-of-text
+  `fast counter settings` parses back to a `dict` perfectly, while a `generation parameters` naming
+  `np.int64` does not, however it is formatted. There used to be a `MetadataDictRepresentation`
+  wrapper here whose `repr()` returned `pprint.pformat(...)` so big dicts wrapped across lines —
+  it bought readability and nothing else, and was removed. Every metadata value is now written on
+  one line.
 - **It also prevents silent data loss.** numpy summarises the repr of arrays longer than
   `np.get_printoptions()['threshold']` (1000) as `array([0., 1., ..., 1498., 1499.])`. A controlled
   variable with more than 1000 points used to reach the header with its middle values already gone,
@@ -747,6 +782,30 @@ module's `StatusVar`; this only holds references. `generator_settings` is `Optio
 `PulsedMeasurementLogic` has no `Connector` to `SequenceGeneratorLogic` and cannot fetch it alone —
 it is `None` whenever the snapshot was built by code with only measurement-logic access.
 
+##### One copy of a container per file
+
+`to_metadata_dict(omit=...)` is the display-only variant used for `.dat` headers; `to_dict()` stays
+lossless for the `.pulsedmeasurement` pickle.
+
+Each header writes some settings containers out flat at its top level (`fast counter settings`,
+`generation parameters`, …) and also carries the whole `Settings` dump under
+`pulsed measurement settings`. Writing a container in both places is a standing invitation for the
+two copies to drift, with no way for a reader to tell which to believe — so `omit` names the
+containers this particular file already wrote flat, as dotted paths, and they are dropped from the
+nested block. Paths naming something absent are ignored, so a caller can list
+`generator_settings.generation_parameters` even when `generator_settings` is `None`.
+
+Which paths go with which file lives in one place: the `_RAW_METADATA_OMIT` /
+`_LASER_METADATA_OMIT` / `_SIGNAL_METADATA_OMIT` constants in
+[`../pulsed_measurement_logic.py`](../pulsed_measurement_logic.py). The nested block's contents
+therefore vary per file, while every file stays complete on its own.
+
+The rule is deliberately **container-level**. Scalar overlap is left alone — `bin width (s)` beside
+`fast_counter_settings['bin_width']` in the raw/laser files, `loaded asset name` beside the asset's
+own `name`. Those flat keys are the long-standing readable convention, their nested homes cannot be
+removed without breaking reconstruction, and both copies are read off one object in one call, so
+they cannot diverge.
+
 #### `PulsedData` *(mutable)*
 
 `measurement_data: PulsedMeasurementData` plus `fit_result` / `fit_result_alt`.
@@ -759,10 +818,24 @@ the round-trip test asserts it.
 
 #### `PulseObjects` *(mutable)*
 
-`sequence` (the loaded top-level asset), plus `ensembles` and `blocks` — independent copies of
-everything `sequence` references **by name**. The real objects live in `SequenceGeneratorLogic`'s
-saved-asset registries and are untouched; these copies are resolved via
+`loaded_asset` (the loaded top-level asset, either kind), plus `ensembles` and `blocks` —
+independent copies of everything `loaded_asset` references **by name**. The real objects live in
+`SequenceGeneratorLogic`'s saved-asset registries and are untouched; these copies are resolved via
 `SequenceGeneratorLogic.resolve_asset_closure()`.
+
+`loaded_sequence` and `loaded_ensemble` are `Optional` **properties** over that one slot, each
+reading `None` for the other kind. Deliberately not two fields: one slot cannot contradict itself,
+so there is no "at most one is set" invariant for `replace()` or a stray assignment to break. They
+follow the tri-state `getattr(x, 'is_sequence', None)` pattern, so an object that is not a pulse
+asset at all reads `None` from both rather than raising.
+
+`to_dict()` writes the asset under `loaded_sequence` or `loaded_ensemble` — the key names the kind,
+so a saved file never reads `sequence` while describing a `PulseBlockEnsemble` — and shows
+`ensembles` **only** for a sequence. A bare ensemble resolves nothing one level up, so the key is
+left out rather than written as an empty dict; an empty `ensembles` beside an ensemble was exactly
+the reading that used to confuse people. `from_dict()` branches on which key is present, and still
+reads the pre-split single `sequence` key by its `type` tag; `__setstate__` does the same for a
+`.pulsedmeasurement` pickled before the rename.
 
 The point is that a saved measurement's dict shows every block/ensemble definition in full rather than
 just a name, and stays frozen in time — editing a same-named asset later never changes an
@@ -773,8 +846,10 @@ already-taken snapshot.
   `element_list`; exporting it would duplicate all of them.
 - `to_metadata_dict()` is a trimmed, display-only variant for saved-file headers. It drops per-sample
   arrays (`laser_rising_bins`, `elements_length_bins`, `_legacy_data`) and duplicated sections so the
-  header shows sequence *structure* rather than thousands of numbers. There is no
-  `from_metadata_dict()`.
+  header shows sequence *structure* rather than thousands of numbers. Its
+  `omit_generation_method_parameters` flag additionally drops the loaded asset's own
+  `generation_method_parameters` for the signal file, which writes that container flat at its top
+  level — see **One copy of a container per file** below. There is no `from_metadata_dict()`.
 
 #### `PulsedMeasurement` *(mutable)* — the root
 
@@ -976,9 +1051,11 @@ would have defaulted it to `False` on every pre-existing file, silently reclassi
 `PulseSequence` as an ensemble.
 
 It is therefore **not** in `to_dict()`, `to_metadata_dict()` or any pickle. The saved form carries the
-distinction as a class-name string instead — `PulseObjects.to_dict()['sequence']['type']`, which is
-what `from_dict()` branches on, and `'loaded asset type'` in each `.dat` header. Keep those as strings:
-they must survive without the classes present, and a name still works if a third asset type appears.
+distinction as strings instead, in three places: the key name `PulseObjects.to_dict()` files the asset
+under (`loaded_sequence` / `loaded_ensemble`), which is what `from_dict()` branches on; a `'type'` tag
+holding the class name inside that value; and `'loaded asset type'` in each `.dat` header. Keep all
+three as strings: they must survive without the classes present, and the `'type'` tag in particular
+is what a third asset type would extend — the key name alone would not generalise as cleanly.
 
 Three places it deliberately does **not** replace `isinstance`:
 

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -218,11 +218,16 @@ These are containers, not a class hierarchy. Two exceptions:
 BaseGenerationParameters                    generation_parameter_extensions.py
 ├── CoreGenerationParameters                sequence_generator_logic_data.py  (built-in, 14 fields)
 ├── TestParameters                          generation_parameter_extensions.py (example, 1 field)
-└── <your lab's class here>                 generation_parameter_extensions.py
+├── <your setup's class here>               generation_parameter_extensions.py
+└── <one generator's own parameters>        declared via generation_parameter_contributors
         │
-        └──► merged at import time by _build_generation_parameters()
-             into ONE class:  GenerationParameters
-             (a real subclass of all of the above, with all of their fields)
+        ├──► merged at import time by _build_generation_parameters()
+        │    into ONE class:  GenerationParameters
+        │    (a real subclass of all of the above, with all of their fields)
+        │
+        └──► re-merged during activation by rebuild_generation_parameters(), once the
+             predefined generator modules have been imported and can be asked what
+             they declare
 
 dict
 ├── AnalysisParameters             ┐
@@ -283,13 +288,19 @@ def _coerce_fields(cls, data, current=None):
     return coerced
 ```
 
-`_own_field_names` intersects two sources. `cls.__dict__['__annotations__']` gives ownership and
-declaration order — plain `cls.__annotations__` and `dataclasses.fields()` both walk up to parent
-classes and would return inherited fields too. `dataclasses.fields()` then gives membership, which is
-what drops `ClassVar`/`InitVar` declarations: those are annotations but **not** fields, so without the
-intersection a lab constant like `CHANNEL_MAP: ClassVar[dict] = {...}` would be exported by
-`to_dict()` as though it were a measurement parameter, compared by the duplicate-name check, and
-passed to the merged constructor as an unexpected keyword argument.
+`_own_field_names` takes `dataclasses.fields(cls)` and subtracts whatever the bases already
+contribute. `fields()` reports base-first then own, each group in declaration order, so the
+subtraction leaves this class's own fields in the order it declared them — which `to_dict()` needs for
+the widget grid layout. A lab constant like `CHANNEL_MAP: ClassVar[dict] = {...}` stays out for free,
+since `fields()` never reports `ClassVar`/`InitVar`.
+
+> **Do not reintroduce `cls.__dict__['__annotations__']` here.** An earlier version read it for
+> ownership. Under [PEP 649](https://peps.python.org/pep-0649/) (Python 3.14+) class annotations are
+> computed lazily from `__annotate__` and that key is simply absent until something forces it, which
+> `dataclasses` does not. `_own_field_names` then returned `()` and every caller — `to_dict()`, the
+> duplicate-name check, `_coerce_fields` — quietly agreed the class had no fields, while `fields()`
+> still listed all of them. Nothing raised: the module activated normally, the Predefined Methods tab
+> drew an empty parameter grid, and the status file was written with `generation_parameters: {}`.
 
 **Why this class lives here and not next to `CoreGenerationParameters`:** so this file never has to
 import from `sequence_generator_logic_data.py`. A circular import between the two would make the merge
@@ -309,8 +320,9 @@ class TestParameters(BaseGenerationParameters):
 ```
 
 > **Note:** this is currently active, so `time_delay` really is a field of `GenerationParameters` and
-> really does get a spin box on the Predefined Methods tab. It is scaffolding from the refactor — if
-> your setup does not want it, delete the class.
+> really does get a spin box on the Predefined Methods tab — `GenerationParameters` has 15 fields
+> here, not 14. It is scaffolding from the refactor and marked for removal; if your setup does not
+> want it, delete the class.
 >
 > Its `_coerce_fields` predates the automatic version and does exactly what the base class would now
 > do for a `float` field. **Do not copy it into a new class** — the two lines of `time_delay: float =
@@ -975,12 +987,38 @@ self.generator_settings.generation_parameters.green_aom_delay        # attribute
 | Decorate the class `@dataclass(frozen=True)` | `TypeError` at import naming the class. Without the decorator its annotations never become fields, so it would contribute nothing and its parameters would simply not exist |
 | Every field needs a default | `TypeError` at import — a merged dataclass cannot have a no-default field after a defaulted one |
 | Field names must be unique across all contributors | `TypeError` at import naming both classes. This is a *feature* — silent last-wins would change a measurement parameter with no warning |
+| The class must declare at least one field | `TypeError` at import naming the class. A contributor that declares nothing is always a fault, and the symptom otherwise shows up far away as an empty parameter grid |
 | Types must be `str`/`int`/`float`/`bool`/`Enum`/`PulseEnvelope` | a warning is logged at import and no widget is built for it (see `_create_pm_global_params` in [`../../../gui/pulsed/pulsed_maingui.py`](../../../gui/pulsed/pulsed_maingui.py)); the parameter still works from scripts |
-| Declare the class at import time, not from a config path | the merge runs at module import, long before qudi-core restores status variables |
 | Never pass a bare contributor to `set_generation_parameters()` | rejected by `coerce_settings` — see the note in the `settings_coercion.py` section |
 
 Suffix conventions the GUI picks up automatically: a float whose name contains `amp` or `volt` gets a
 `V` suffix, `freq` gets `Hz`, and `tau`/`period`/`time`/`delay`/`laser_length` get `s`.
+
+### Adding a parameter only one generator needs
+
+A parameter that belongs to one predefined generator rather than the whole setup is declared on that
+generator class instead, which also works for generators loaded through the
+`additional_predefined_methods_path` config option — nothing in this package has to be edited:
+
+```python
+class MyLabGenerator(PredefinedGeneratorBase):
+
+    generation_parameter_contributors = ({'rf_amplitude': 1e-3, 'rf_channel': 'a_ch2'},)
+
+    def generate_my_sequence(self, name='my_seq'):
+        amplitude = self.generation_parameters['rf_amplitude']
+        ...
+```
+
+Each dict entry's type is taken from its default, which covers `str`/`int`/`float`/`bool`. For an
+`Enum`, a `PulseEnvelope` or custom coercion, list a `BaseGenerationParameters` subclass instead —
+`generation_parameter_contributors = (MyLabParameters,)`. The same uniqueness and type rules apply,
+except that a rejected declaration is logged and skipped rather than raised: activation must survive a
+faulty lab module.
+
+These are collected during `SequenceGeneratorLogic.on_activate()`, after the generator modules are
+imported, and merged by `rebuild_generation_parameters()`. Values already in the status file are read
+back at that point, so a generator-declared parameter persists across restarts like any other.
 
 Also note: any generation parameter whose name **ends in `_channel`** is treated as a channel
 specifier by `set_pulse_generator_settings()` and will be auto-corrected if it names a channel that is

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -302,6 +302,26 @@ since `fields()` never reports `ClassVar`/`InitVar`.
 > still listed all of them. Nothing raised: the module activated normally, the Predefined Methods tab
 > drew an empty parameter grid, and the status file was written with `generation_parameters: {}`.
 
+> **A field of a mutable type needs `field(default_factory=...)`, not a plain default.** One default
+> object is shared by every instance that does not override it, so Python refuses the declaration
+> outright: `ValueError: mutable default <class 'PulseEnvelope'> for field envelope is not allowed:
+> use default_factory`. `PulseEnvelope` trips this despite being a supported parameter type — it is a
+> plain `@dataclass` carrying a `parameters` dict, so it counts as mutable. Write it the way
+> `CoreGenerationParameters.pulse_envelope` does:
+>
+> ```python
+> envelope: PulseEnvelope = field(
+>     default_factory=lambda: PulseEnvelope(PulseEnvelopeType.rectangle)
+> )
+> ```
+>
+> The same applies to a `dict`, a `list`, a numpy array, or an instance of any class defining
+> `__eq__` — defining `__eq__` sets `__hash__` to `None`, and unhashable is exactly the test
+> `dataclasses` applies to decide a default is mutable. Note this test *widened* after Python 3.10,
+> which rejected only `list`/`dict`/`set`: a contributor that was accepted on 3.10 can be rejected on
+> 3.11+. The import of this module in `sequence_generator_logic_data.py` is wrapped to add that
+> explanation to the raw error.
+
 **Why this class lives here and not next to `CoreGenerationParameters`:** so this file never has to
 import from `sequence_generator_logic_data.py`. A circular import between the two would make the merge
 silently skip extensions depending on which module happened to be imported first.

--- a/src/qudi/logic/pulsed/pulsed_data/README.md
+++ b/src/qudi/logic/pulsed/pulsed_data/README.md
@@ -65,6 +65,13 @@ new_settings = replace(old_settings, power=-20.0)   # old_settings is untouched
 
 Some classes here are deliberately **not** frozen. See rule 4.
 
+When using a jupyter notebook, it is adviced to change frozen settings dataclasses using their setters, which accept 4 different input formats:
+-Keywoard Arguments
+-Plain dict (must be compatible)
+-The dataclass itself
+
+All setters use update_from_dict or replace, which will always create a brand new clean object.
+
 ### 2. Every persisted class implements the same three methods
 
 | Method | Direction | Missing keys behave as | Called by |
@@ -242,17 +249,47 @@ Provides three helpers to subclasses:
 
 | Member | What it does |
 |---|---|
-| `_coerce_fields(cls, data, current=None)` | **You must override this.** Returns `{field_name: value}` for this class's own fields only, reading from `data`, else `current`, else the default. |
-| `_own_field_names(cls)` | The names this class itself declared (not inherited ones). Used for the duplicate-name check and for `to_dict()` ordering. |
+| `_coerce_fields(cls, data, current=None)` | **Already implemented — you normally do not touch it.** Returns `{field_name: value}` for this class's own fields only, reading from `data`, else `current`, else the default, and converting each value according to the type its field declares. |
+| `_own_field_names(cls)` | The names this class itself declared (not inherited ones). Used for the duplicate-name check, for `to_dict()` ordering, and to drive the coercion loop. |
 | `_pick(data, current, name, default)` | The 3-step fallback: `data` → `current` → `default`. |
 
 `_coerce_fields` backs **both** `from_dict` (called with `current=None`, so missing keys become
 defaults) and `update_from_dict` (called with `current=self`, so missing keys keep their value). That
-is why you write the per-field conversion exactly once.
+is why the per-field conversion is expressed exactly once.
 
-`_own_field_names` reads `cls.__dict__['__annotations__']` rather than `cls.__annotations__` or
-`dataclasses.fields()` — plain attribute access and `fields()` both walk up to parent classes and
-would return inherited fields too.
+The conversion it applies comes from the field's declared type, so declaring the field *is* declaring
+how it is restored:
+
+| Declared type | Conversion applied to the saved value |
+|---|---|
+| `int`, `float`, `str` | `int(value)`, `float(value)`, `str(value)` |
+| `bool` | `as_bool(value)` — `'False'`/`'no'`/`'off'`/`'0'` are False. A plain `bool('False')` is `True`, which is why this exists |
+| an `Enum` subclass | looked up by member name, else by member value |
+| any other class | an instance passes through as-is; a `dict` goes through that class's `from_dict()` if it has one — this is how `PulseEnvelope` round-trips |
+
+A value that cannot be converted (a corrupted status file) is **logged and skipped**, and that one
+field falls back to its current value, else its default. It deliberately does not raise: the
+`StatusVar` constructor swallows an exception and returns the whole default object, so one bad key
+would otherwise silently reset every generation parameter — convention 3 again.
+
+Type detection cannot know that a fraction must stay within [0, 1]. For a field like that, override
+`_coerce_fields`, let `super()` handle everything else, and patch only the key concerned:
+
+```python
+@classmethod
+def _coerce_fields(cls, data, current=None):
+    coerced = super()._coerce_fields(data, current)
+    coerced['laser_power_fraction'] = min(1.0, max(0.0, coerced['laser_power_fraction']))
+    return coerced
+```
+
+`_own_field_names` intersects two sources. `cls.__dict__['__annotations__']` gives ownership and
+declaration order — plain `cls.__annotations__` and `dataclasses.fields()` both walk up to parent
+classes and would return inherited fields too. `dataclasses.fields()` then gives membership, which is
+what drops `ClassVar`/`InitVar` declarations: those are annotations but **not** fields, so without the
+intersection a lab constant like `CHANNEL_MAP: ClassVar[dict] = {...}` would be exported by
+`to_dict()` as though it were a measurement parameter, compared by the duplicate-name check, and
+passed to the merged constructor as an unexpected keyword argument.
 
 **Why this class lives here and not next to `CoreGenerationParameters`:** so this file never has to
 import from `sequence_generator_logic_data.py`. A circular import between the two would make the merge
@@ -274,6 +311,10 @@ class TestParameters(BaseGenerationParameters):
 > **Note:** this is currently active, so `time_delay` really is a field of `GenerationParameters` and
 > really does get a spin box on the Predefined Methods tab. It is scaffolding from the refactor — if
 > your setup does not want it, delete the class.
+>
+> Its `_coerce_fields` predates the automatic version and does exactly what the base class would now
+> do for a `float` field. **Do not copy it into a new class** — the two lines of `time_delay: float =
+> 4.0` are the whole modern form.
 
 ---
 
@@ -830,15 +871,59 @@ filled in by `SequenceGeneratorLogic`:
 
 ## Neighbour map
 
-Classes referenced from here that live elsewhere. Named, not documented — see their own files.
+Classes referenced from here that live elsewhere. Named, not documented — see their own files. The
+one exception is `is_sequence` below, which is documented here because *why* it is not a field of any
+class in this package is the interesting part.
 
 | Class | Lives in | Relationship |
 |---|---|---|
-| `PulseBlock`, `PulseBlockEnsemble`, `PulseSequence`, `PulseBlockElement` | [`../pulse_objects.py`](../pulse_objects.py) | held by `PulseObjects`; carry `SamplingInformation`/`MeasurementInformation`/`GenerationMethodParameters` |
+| `PulseBlock`, `PulseBlockEnsemble`, `PulseSequence`, `PulseBlockElement` | [`../pulse_objects.py`](../pulse_objects.py) | held by `PulseObjects`; carry `SamplingInformation`/`MeasurementInformation`/`GenerationMethodParameters`. The two loadable ones expose `is_sequence` — see below |
 | `PulseEnvelope`, `PulseEnvelopeType` | [`../sampling_functions.py`](../sampling_functions.py) | the type of `CoreGenerationParameters.pulse_envelope` |
 | `BenchmarkTool` | `qudi.util.benchmark` | the two fields of `PulserBenchmarks` |
 | `FitContainer` | `qudi.util.datafitting` | the two fields of `FitContainers`; `dict_result()` is the one-way fit export |
 | `dataclass_representer`, `sampling_information_constructor` | `qudi.util.yaml_helpers` | YAML round trip for `SamplingInformation`, registered in `../sequence_generator_logic.py` |
+
+#### `is_sequence` — telling the two loadable assets apart
+
+`PulseBlockEnsemble.is_sequence` is `False`, `PulseSequence.is_sequence` is `True`. Use it when you
+hold an asset object whose kind you do not know:
+
+```python
+if asset.is_sequence:
+    ...
+```
+
+**It is a class attribute, not an instance attribute, and that is the whole point.** A class attribute
+is not part of pickled instance state, so every `.ensemble`/`.sequence` already saved to disk gained
+it the moment the classes were updated — no migration, and it cannot drift out of sync with the
+object's actual type. Had it been a persisted field instead, convention 3's missing-key tolerance
+would have defaulted it to `False` on every pre-existing file, silently reclassifying every saved
+`PulseSequence` as an ensemble.
+
+It is therefore **not** in `to_dict()`, `to_metadata_dict()` or any pickle. The saved form carries the
+distinction as a class-name string instead — `PulseObjects.to_dict()['sequence']['type']`, which is
+what `from_dict()` branches on, and `'loaded asset type'` in each `.dat` header. Keep those as strings:
+they must survive without the classes present, and a name still works if a third asset type appears.
+
+Three places it deliberately does **not** replace `isinstance`:
+
+| Pattern | Why |
+|---|---|
+| `if not isinstance(x, PulseBlockEnsemble): error` | asks *"is this the right type at all"* — `is_sequence == False` doesn't rule out `None`, a `str` or a dict |
+| `if isinstance(x, PulseSequence): x = x.name` | object-or-name coercion; the other branch is a `str`, which has no `is_sequence` |
+| anywhere only a name or `LoadedAsset.asset_type` is available | there is no object to ask — `asset_type` comes from the pulser hardware |
+
+Where the object *is* in hand but might not be a pulse asset at all, use the tri-state form so an
+unrelated object still reaches your error branch instead of raising `AttributeError` (see
+`_resolve_asset_closure` in [`../sequence_generator_logic.py`](../sequence_generator_logic.py)):
+
+```python
+asset_is_sequence = getattr(asset, 'is_sequence', None)   # None -> not a pulse asset
+```
+
+> **Not to be confused with** `sigPredefinedSequenceGenerated`'s `produced_sequence` payload, which
+> asks whether a *generate method returned* any sequences — a different question about a different
+> subject.
 
 ### The layering rule
 
@@ -871,18 +956,12 @@ class NVCentreParameters(BaseGenerationParameters):
 
     green_aom_delay: float = 700e-9
     readout_channel: str = 'd_ch4'
-
-    @classmethod
-    def _coerce_fields(cls, data, current=None):
-        pick = cls._pick
-        return {
-            'green_aom_delay': float(pick(data, current, 'green_aom_delay', 700e-9)),
-            'readout_channel': str(pick(data, current, 'readout_channel', 'd_ch4')),
-        }
 ```
 
-That is the whole change. A widget appears on the Predefined Methods tab, the value persists across
-restarts, and predefined methods read it as:
+That is the whole change — there is no restore method to write, because the declared types already
+say how each value is converted on the way back in (see the
+[`_coerce_fields` table above](#basegenerationparameters--the-marker-base-class)). A widget appears on
+the Predefined Methods tab, the value persists across restarts, and predefined methods read it as:
 
 ```python
 self.generation_parameters['green_aom_delay']                        # dict style
@@ -893,10 +972,10 @@ self.generator_settings.generation_parameters.green_aom_delay        # attribute
 
 | Rule | What happens otherwise |
 |---|---|
+| Decorate the class `@dataclass(frozen=True)` | `TypeError` at import naming the class. Without the decorator its annotations never become fields, so it would contribute nothing and its parameters would simply not exist |
 | Every field needs a default | `TypeError` at import — a merged dataclass cannot have a no-default field after a defaulted one |
 | Field names must be unique across all contributors | `TypeError` at import naming both classes. This is a *feature* — silent last-wins would change a measurement parameter with no warning |
-| Types must be `str`/`int`/`float`/`bool`/`Enum`/`PulseEnvelope` | no widget is built for it (see `_create_pm_global_params` in [`../../../gui/pulsed/pulsed_maingui.py`](../../../gui/pulsed/pulsed_maingui.py)); the parameter still works from scripts |
-| Implement `_coerce_fields()` | `NotImplementedError` the first time settings are loaded or changed |
+| Types must be `str`/`int`/`float`/`bool`/`Enum`/`PulseEnvelope` | a warning is logged at import and no widget is built for it (see `_create_pm_global_params` in [`../../../gui/pulsed/pulsed_maingui.py`](../../../gui/pulsed/pulsed_maingui.py)); the parameter still works from scripts |
 | Declare the class at import time, not from a config path | the merge runs at module import, long before qudi-core restores status variables |
 | Never pass a bare contributor to `set_generation_parameters()` | rejected by `coerce_settings` — see the note in the `settings_coercion.py` section |
 

--- a/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
+++ b/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
@@ -335,17 +335,3 @@ class BaseGenerationParameters:
 #                                                                            #
 ##############################################################################
 
-#Test
-@dataclass(frozen=True)
-class TestParameters(BaseGenerationParameters):
-    time_delay: float = 4.0
-
-    @classmethod
-    def _coerce_fields(cls, data, current=None):
-        pick = cls._pick
-        return {
-            'time_delay': float(pick(data, current, 'time_delay', 4.0)),
-        }
-    #Plan to remove this
-
-    #GenerationParameters

--- a/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
+++ b/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
@@ -25,17 +25,47 @@ Worked example
         green_aom_delay: float = 700e-9
         readout_channel: str = 'd_ch4'
 
-        @classmethod
-        def _coerce_fields(cls, data, current=None):
-            pick = cls._pick
-            return {
-                'green_aom_delay': float(pick(data, current, 'green_aom_delay', 700e-9)),
-                'readout_channel': str(pick(data, current, 'readout_channel', 'd_ch4')),
-            }
-
-A predefined generate method then reads it as
+That is the whole class. A predefined generate method then reads it as
 `self.generation_parameters['green_aom_delay']`, or directly off the settings object as
 `self.generator_settings.generation_parameters.green_aom_delay`.
+
+How a saved value gets back into a field
+----------------------------------------
+A status file holds text, so a value read back out of it may not have the type its field declares -
+a float can arrive as '700e-9', a bool as 'False'. `_coerce_fields()` converts it, choosing how from
+the declared type alone:
+
+    declared type      conversion applied to the saved value
+    -----------------  ------------------------------------------------------------------
+    int, float, str    int(value), float(value), str(value)
+    bool               as_bool(value)   - 'False'/'no'/'off'/'0' are False, not True
+    an Enum subclass   looked up by member name, else by member value
+    any other class    an instance passes through as-is; a dict goes through that class's
+                       from_dict() if it has one - this is how PulseEnvelope round-trips
+
+You write none of that; it follows from the annotation you already wrote, which is also why a
+field's default can no longer drift out of sync with its restore path - there is only one of each.
+
+If a value cannot be converted (a corrupted status file), the failure is logged and that one field
+falls back to its current value, else its default. It is deliberately not raised: a StatusVar
+constructor swallows an exception and returns the whole default object, so one bad key would
+otherwise silently reset every generation parameter.
+
+Custom handling for one awkward field
+-------------------------------------
+Type detection cannot know that a fraction must stay within [0, 1]. Override `_coerce_fields()`, let
+`super()` do the automatic work for everything, and patch only the field that needs it:
+
+    @dataclass(frozen=True)
+    class NVCentreParameters(BaseGenerationParameters):
+        green_aom_delay: float = 700e-9        # still fully automatic
+        laser_power_fraction: float = 0.5
+
+        @classmethod
+        def _coerce_fields(cls, data, current=None):
+            coerced = super()._coerce_fields(data, current)
+            coerced['laser_power_fraction'] = min(1.0, max(0.0, coerced['laser_power_fraction']))
+            return coerced
 
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
@@ -53,9 +83,76 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from enum import Enum
+from logging import getLogger
+from typing import get_origin, get_type_hints
 
-__all__ = ['BaseGenerationParameters']
+__all__ = ['BaseGenerationParameters', 'as_bool']
+
+_logger = getLogger(__name__)
+
+
+def as_bool(value):
+    """Converts a value to a boolean. If the value is a string, it checks for common truthy values.
+
+    Needed because `bool('False')` is True, so a bool round-tripped through a status file as text
+    would come back inverted under a plain `bool()`.
+
+    Parameters
+    ----------
+    value : object
+        The value to interpret as a boolean.
+
+    Returns
+    -------
+    bool
+        For a string, whether it is one of '1', 'true', 'yes' or 'on', case-insensitively.
+        Otherwise `bool(value)`.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+def _coerce_value(value, declared_type):
+    """Convert one saved value to the type its generation parameter field declares.
+
+    Parameters
+    ----------
+    value : object
+        The raw value, as read from a status file or handed over by a GUI widget.
+    declared_type : type
+        The field's declared type.
+
+    Returns
+    -------
+    object
+        `value` converted to `declared_type`, or `value` unchanged where `declared_type` carries no
+        usable conversion rule - a parameterised generic, a Union, or an annotation that could not
+        be resolved to a real type object.
+
+    Raises
+    ------
+    TypeError, ValueError, KeyError
+        If the conversion itself fails. `_coerce_fields()` handles these.
+    """
+    if get_origin(declared_type) is not None or not isinstance(declared_type, type):
+        return value
+    if declared_type is bool:
+        # Must precede int: bool is a subclass of int, and bool('False') is True.
+        return as_bool(value)
+    if declared_type in (int, float, str):
+        return declared_type(value)
+    if isinstance(value, declared_type):
+        return value
+    if issubclass(declared_type, Enum) and isinstance(value, str):
+        return declared_type[value] if value in declared_type.__members__ else declared_type(value)
+    if isinstance(value, dict) and hasattr(declared_type, 'from_dict'):
+        # The convention every persisted class in this package follows, so a nested settings object
+        # round-trips through its own from_dict() without this layer knowing anything about it.
+        return declared_type.from_dict(value)
+    return declared_type(value)
 
 
 @dataclass(frozen=True)
@@ -66,13 +163,17 @@ class BaseGenerationParameters:
     the single `GenerationParameters` dataclass the rest of the toolchain annotates against.
 
     Rules for a subclass:
+      * decorate it with `@dataclass(frozen=True)` - without the decorator its annotations never
+        become fields and the class contributes nothing at all, which the merge rejects by name;
       * every field needs a default - Python forbids a no-default field following a defaulted one
         in the merged class;
       * field names must not collide with another contributor's - checked at merge time, which
         raises naming both classes rather than letting one silently win;
       * field types should be str / int / float / bool / Enum / PulseEnvelope, the set the GUI can
         build a widget for (see pulsed_maingui._create_pm_global_params);
-      * override `_coerce_fields()` to declare how each field is read back from a saved dict.
+      * nothing else. How each field is read back from a saved dict follows from its declared type -
+        see `_coerce_fields()`, and override it only for a field whose type cannot express the
+        handling it needs.
 
     Do not instantiate a subclass on its own and hand it to set_generation_parameters(): a
     contributor describes a *fragment* of the schema, not a complete settings object. It is
@@ -90,8 +191,15 @@ class BaseGenerationParameters:
         of raising and losing every saved parameter.
 
         This single hook backs both from_dict() (current=None, so absent keys fall back to
-        defaults) and update_from_dict() (current=self, so absent keys keep their current value),
-        which is why a contributor writes its explicit per-field coercion exactly once.
+        defaults) and update_from_dict() (current=self, so absent keys keep their current value).
+
+        The conversion applied to each value follows from that field's declared type, so a
+        contributor normally does not override this at all. One that must should call
+        `super()._coerce_fields(data, current)` for everything else and patch only the key
+        concerned. A value that cannot be converted is logged and replaced by that field's current
+        value, else its default, rather than raising - the StatusVar constructor swallows an
+        exception and returns the whole default object, so one bad key would otherwise silently
+        reset every parameter.
 
         Parameters
         ----------
@@ -105,16 +213,81 @@ class BaseGenerationParameters:
         dict
             Keyword arguments for this contributor's fields only.
         """
-        raise NotImplementedError(f'{cls.__name__} must implement _coerce_fields()')
+        try:
+            hints = get_type_hints(cls)
+        except (NameError, TypeError):
+            hints = {}
+        # Every contributor field must have a default, so a bare instance is simply all of them.
+        defaults = cls()
+        coerced = {}
+        for name in cls._own_field_names():
+            default = getattr(defaults, name)
+            raw = cls._pick(data, current, name, default)
+            if raw is default:
+                # Nothing was saved for this field, so `raw` is the declared default object itself
+                # - already the intended value, and converting it would only invent a complaint
+                # about a field the user never touched (a `dict` default of None, say).
+                coerced[name] = raw
+                continue
+            try:
+                coerced[name] = _coerce_value(raw, hints.get(name, object))
+            except (TypeError, ValueError, KeyError) as err:
+                live = default if current is None else getattr(current, name, default)
+                # `raw` may itself have come off `current` (the key was absent from `data`), in
+                # which case reusing it would fail identically and only the default is sound.
+                fallback = default if live is raw else live
+                _logger.warning(
+                    '%s.%s: cannot coerce %r to %s (%s). Ignoring that saved value and using %r '
+                    'instead; every other generation parameter is unaffected.',
+                    cls.__name__, name, raw, getattr(hints.get(name), '__name__', '?'), err,
+                    fallback
+                )
+                coerced[name] = fallback
+        return coerced
 
     @classmethod
     def _own_field_names(cls):
-        """Names of the fields this contributor itself declares, excluding inherited ones."""
-        return tuple(cls.__dict__.get('__annotations__', {}))
+        """Names of the fields this contributor itself declares, excluding inherited ones.
+
+        Built from two sources. The raw annotations dict gives ownership and declaration order: it
+        holds only what this class body declared, unlike `dataclasses.fields()` or plain
+        `cls.__annotations__`, which both walk up the MRO and would report inherited fields too.
+        `fields()` then gives membership - the dataclass machinery's own verdict on which of those
+        annotations actually became fields. Intersecting the two is what drops `ClassVar`/`InitVar`
+        declarations, which are annotations but not fields; without it a lab constant such as
+        `CHANNEL_MAP: ClassVar[dict] = {...}` would be exported by `to_dict()` as though it were a
+        measurement parameter, compared by the duplicate-name check, and passed to the merged
+        class's constructor as an unexpected keyword argument.
+
+        Returns
+        -------
+        tuple of str
+            Field names, in declaration order.
+        """
+        own_annotations = cls.__dict__.get('__annotations__', {})
+        field_names = {f.name for f in fields(cls)}
+        return tuple(name for name in own_annotations if name in field_names)
 
     @staticmethod
     def _pick(data, current, name, default):
-        """Raw value for `name`: from `data`, else from `current`, else `default`."""
+        """Raw value for `name`: from `data`, else from `current`, else `default`.
+
+        Parameters
+        ----------
+        data : dict
+            The saved/incoming values.
+        current : GenerationParameters or None
+            The settings currently in effect, or None to fall back to `default`.
+        name : str
+            Field name to look up.
+        default : object
+            Value to use when `name` appears in neither source.
+
+        Returns
+        -------
+        object
+            The value, uncoerced.
+        """
         if name in data:
             return data[name]
         if current is not None:
@@ -128,3 +301,18 @@ class BaseGenerationParameters:
 #                See the module docstring for a worked example.              #
 #                                                                            #
 ##############################################################################
+
+#Test
+@dataclass(frozen=True)
+class TestParameters(BaseGenerationParameters):
+    time_delay: float = 4.0
+
+    @classmethod
+    def _coerce_fields(cls, data, current=None):
+        pick = cls._pick
+        return {
+            'time_delay': float(pick(data, current, 'time_delay', 4.0)),
+        }
+    #Plan to remove this
+
+    #GenerationParameters

--- a/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
+++ b/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
@@ -72,6 +72,35 @@ Type detection cannot know that a fraction must stay within [0, 1]. Override `_c
             coerced['laser_power_fraction'] = min(1.0, max(0.0, coerced['laser_power_fraction']))
             return coerced
 
+A field whose type is mutable
+-----------------------------
+`str`, `int`, `float`, `bool` and `Enum` members are immutable, so writing the default straight
+after the annotation is fine. A mutable type is not: one default object would be shared by every
+instance of the class that did not override it, so whichever code mutated it first would change
+the default everyone else sees. Python refuses the declaration outright rather than let that
+happen:
+
+    ValueError: mutable default <class 'PulseEnvelope'> for field envelope is not allowed:
+                use default_factory
+
+`PulseEnvelope` is the one to watch here, because it is a supported field type but is *not*
+immutable - it is a plain `@dataclass` carrying a `parameters` dict. So give it a factory, which
+builds a fresh envelope per instance:
+
+    from dataclasses import dataclass, field
+    from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
+
+    @dataclass(frozen=True)
+    class NVCentreParameters(BaseGenerationParameters):
+        envelope: PulseEnvelope = field(
+            default_factory=lambda: PulseEnvelope(PulseEnvelopeType.rectangle)
+        )
+
+`CoreGenerationParameters.pulse_envelope` is written exactly this way. The same applies to a
+`dict`, a `list`, a numpy array, or an instance of any class that defines `__eq__` - defining
+`__eq__` sets `__hash__` to None, which is precisely the test Python applies to decide a default
+is mutable. If in doubt, use `field(default_factory=...)`; it is never wrong.
+
 Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
 distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
 
@@ -172,6 +201,10 @@ class BaseGenerationParameters:
         become fields and the class contributes nothing at all, which the merge rejects by name;
       * every field needs a default - Python forbids a no-default field following a defaulted one
         in the merged class;
+      * a field of a mutable type needs `field(default_factory=...)` rather than a plain default,
+        or Python rejects the class with "mutable default ... is not allowed". This catches
+        `PulseEnvelope` despite it being a supported type, along with dict, list, numpy arrays and
+        any class defining `__eq__` - see "A field whose type is mutable" in the module docstring;
       * field names must not collide with another contributor's - checked at merge time, which
         raises naming both classes rather than letting one silently win;
       * field types should be str / int / float / bool / Enum / PulseEnvelope, the set the GUI can

--- a/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
+++ b/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
@@ -12,6 +12,11 @@ Nothing else needs to change. sequence_generator_logic_data.py imports this modu
 subclass declared here with the built-in `CoreGenerationParameters` into the single
 `GenerationParameters` class the rest of the pulsed toolchain uses.
 
+For a parameter only one predefined generator needs, declare it on that generator class instead - see
+`PredefinedGeneratorBase.generation_parameter_contributors` in pulse_objects.py. That route also
+reaches generators loaded through the additional_predefined_methods_path config option, which cannot
+edit this file.
+
 `BaseGenerationParameters` lives here rather than in sequence_generator_logic_data.py purely so
 this file has no import back into it - a cycle would make the merge silently skip extensions
 depending on which module got imported first.
@@ -83,7 +88,7 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
 from logging import getLogger
 from typing import get_origin, get_type_hints
@@ -249,24 +254,19 @@ class BaseGenerationParameters:
     def _own_field_names(cls):
         """Names of the fields this contributor itself declares, excluding inherited ones.
 
-        Built from two sources. The raw annotations dict gives ownership and declaration order: it
-        holds only what this class body declared, unlike `dataclasses.fields()` or plain
-        `cls.__annotations__`, which both walk up the MRO and would report inherited fields too.
-        `fields()` then gives membership - the dataclass machinery's own verdict on which of those
-        annotations actually became fields. Intersecting the two is what drops `ClassVar`/`InitVar`
-        declarations, which are annotations but not fields; without it a lab constant such as
-        `CHANNEL_MAP: ClassVar[dict] = {...}` would be exported by `to_dict()` as though it were a
-        measurement parameter, compared by the duplicate-name check, and passed to the merged
-        class's constructor as an unexpected keyword argument.
+        `fields()` reports base-first then own, each in declaration order, so subtracting the bases
+        preserves this class's own order - which `to_dict()` relies on for the Predefined Methods
+        grid layout. `ClassVar`/`InitVar` never appear, since `fields()` does not report them.
 
         Returns
         -------
         tuple of str
             Field names, in declaration order.
         """
-        own_annotations = cls.__dict__.get('__annotations__', {})
-        field_names = {f.name for f in fields(cls)}
-        return tuple(name for name in own_annotations if name in field_names)
+        inherited = {
+            f.name for base in cls.__mro__[1:] if is_dataclass(base) for f in fields(base)
+        }
+        return tuple(f.name for f in fields(cls) if f.name not in inherited)
 
     @staticmethod
     def _pick(data, current, name, default):

--- a/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
+++ b/src/qudi/logic/pulsed/pulsed_data/generation_parameter_extensions.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""
+Lab-specific extensions to the global pulse generation parameters.
+
+THIS IS THE FILE TO EDIT if your lab needs an extra global generation setting (an AOM delay, a
+second microwave channel, a calibration factor, ...). Declare one frozen dataclass inheriting from
+`BaseGenerationParameters` and its fields become first-class generation parameters everywhere: a
+widget appears on the Predefined Methods tab, the value is saved to and restored from the status
+file, and predefined generate methods can read it.
+
+Nothing else needs to change. sequence_generator_logic_data.py imports this module and merges every
+subclass declared here with the built-in `CoreGenerationParameters` into the single
+`GenerationParameters` class the rest of the pulsed toolchain uses.
+
+`BaseGenerationParameters` lives here rather than in sequence_generator_logic_data.py purely so
+this file has no import back into it - a cycle would make the merge silently skip extensions
+depending on which module got imported first.
+
+Worked example
+--------------
+    @dataclass(frozen=True)
+    class NVCentreParameters(BaseGenerationParameters):
+        '''Extra generation parameters for the NV setup.'''
+
+        green_aom_delay: float = 700e-9
+        readout_channel: str = 'd_ch4'
+
+        @classmethod
+        def _coerce_fields(cls, data, current=None):
+            pick = cls._pick
+            return {
+                'green_aom_delay': float(pick(data, current, 'green_aom_delay', 700e-9)),
+                'readout_channel': str(pick(data, current, 'readout_channel', 'd_ch4')),
+            }
+
+A predefined generate method then reads it as
+`self.generation_parameters['green_aom_delay']`, or directly off the settings object as
+`self.generator_settings.generation_parameters.green_aom_delay`.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from dataclasses import dataclass
+
+__all__ = ['BaseGenerationParameters']
+
+
+@dataclass(frozen=True)
+class BaseGenerationParameters:
+    """Marker base for everything that contributes fields to `GenerationParameters`.
+
+    Every subclass of this class is collected by sequence_generator_logic_data.py and merged into
+    the single `GenerationParameters` dataclass the rest of the toolchain annotates against.
+
+    Rules for a subclass:
+      * every field needs a default - Python forbids a no-default field following a defaulted one
+        in the merged class;
+      * field names must not collide with another contributor's - checked at merge time, which
+        raises naming both classes rather than letting one silently win;
+      * field types should be str / int / float / bool / Enum / PulseEnvelope, the set the GUI can
+        build a widget for (see pulsed_maingui._create_pm_global_params);
+      * override `_coerce_fields()` to declare how each field is read back from a saved dict.
+
+    Do not instantiate a subclass on its own and hand it to set_generation_parameters(): a
+    contributor describes a *fragment* of the schema, not a complete settings object. It is
+    deliberately not an instance of the merged class, so coerce_settings() rejects it instead of
+    treating it as a full replacement and resetting every other field to its default.
+    """
+
+    @classmethod
+    def _coerce_fields(cls, data, current=None):
+        """Return {field_name: coerced value} for this contributor's own fields only.
+
+        Each value is taken from `data` when present, otherwise from `current` (an existing merged
+        instance) when one is given, otherwise from the field's declared default. Being tolerant of
+        missing keys is what lets a status file written before a field existed still load, instead
+        of raising and losing every saved parameter.
+
+        This single hook backs both from_dict() (current=None, so absent keys fall back to
+        defaults) and update_from_dict() (current=self, so absent keys keep their current value),
+        which is why a contributor writes its explicit per-field coercion exactly once.
+
+        Parameters
+        ----------
+        data : dict
+            The saved/incoming values. May be missing any or all of this class's fields.
+        current : GenerationParameters or None
+            The settings currently in effect, or None to fall back to defaults.
+
+        Returns
+        -------
+        dict
+            Keyword arguments for this contributor's fields only.
+        """
+        raise NotImplementedError(f'{cls.__name__} must implement _coerce_fields()')
+
+    @classmethod
+    def _own_field_names(cls):
+        """Names of the fields this contributor itself declares, excluding inherited ones."""
+        return tuple(cls.__dict__.get('__annotations__', {}))
+
+    @staticmethod
+    def _pick(data, current, name, default):
+        """Raw value for `name`: from `data`, else from `current`, else `default`."""
+        if name in data:
+            return data[name]
+        if current is not None:
+            return getattr(current, name, default)
+        return default
+
+
+##############################################################################
+#                                                                            #
+#             Add your lab's generation parameter classes below.             #
+#                See the module docstring for a worked example.              #
+#                                                                            #
+##############################################################################

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_master_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_master_logic_data.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains dataclasses used by PulsedMasterLogic to store and manage its busy/running
+status flags and the fit containers it exposes to the GUI.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from dataclasses import dataclass
+
+from qudi.util.datafitting import FitContainer
+
+
+##############################################################################
+#   The following classes are for the PulsedMasterLogic class and are used  #
+#         to store and manage its status flags and fit containers.          #
+##############################################################################
+
+class PulsedMasterStatus(dict):
+    """dict-based structured container for PulsedMasterLogic's busy/running status flags.
+
+    Kept as a dict subclass (the same pattern as AnalysisParameters/ExtractionParameters/
+    GenerationMethodParameters in pulsed_measurement_logic_data.py, and SequenceStep in
+    pulse_objects.py) rather than a plain dataclass, because
+    qudi.gui.pulsed.pulsed_maingui.PulsedMeasurementGui reads AND writes these flags directly
+    via "pulsedmasterlogic().status_dict['flag_name']" (including plain assignment, e.g.
+    "status_dict['benchmark_busy'] = True"). Subclassing dict keeps that GUI code working
+    unchanged while giving PulsedMasterLogic itself named, typo-proof attribute access
+    (self.status_dict.sampload_busy instead of self.status_dict['sampload_busy']).
+
+    All flags default to False.
+    """
+
+    _FLAG_NAMES = (
+        'sampling_ensemble_busy',
+        'sampling_sequence_busy',
+        'sampload_busy',
+        'loading_busy',
+        'pulser_running',
+        'measurement_running',
+        'microwave_running',
+        'predefined_generation_busy',
+        'fitting_busy',
+        'benchmark_busy',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__({name: False for name in self._FLAG_NAMES})
+        self.update(dict(*args, **kwargs))
+
+    @property
+    def sampling_ensemble_busy(self) -> bool:
+        """True while a PulseBlockEnsemble is being sampled."""
+        return self['sampling_ensemble_busy']
+
+    @sampling_ensemble_busy.setter
+    def sampling_ensemble_busy(self, value: bool):
+        self['sampling_ensemble_busy'] = bool(value)
+
+    @property
+    def sampling_sequence_busy(self) -> bool:
+        """True while a PulseSequence is being sampled."""
+        return self['sampling_sequence_busy']
+
+    @sampling_sequence_busy.setter
+    def sampling_sequence_busy(self, value: bool):
+        self['sampling_sequence_busy'] = bool(value)
+
+    @property
+    def sampload_busy(self) -> bool:
+        """True while a sample-and-load operation (sample immediately followed by load) is in
+        progress."""
+        return self['sampload_busy']
+
+    @sampload_busy.setter
+    def sampload_busy(self, value: bool):
+        self['sampload_busy'] = bool(value)
+
+    @property
+    def loading_busy(self) -> bool:
+        """True while a waveform/sequence is being loaded onto the pulse generator."""
+        return self['loading_busy']
+
+    @loading_busy.setter
+    def loading_busy(self, value: bool):
+        self['loading_busy'] = bool(value)
+
+    @property
+    def pulser_running(self) -> bool:
+        """True while the pulse generator output is switched on."""
+        return self['pulser_running']
+
+    @pulser_running.setter
+    def pulser_running(self, value: bool):
+        self['pulser_running'] = bool(value)
+
+    @property
+    def measurement_running(self) -> bool:
+        """True while a pulsed measurement is running."""
+        return self['measurement_running']
+
+    @measurement_running.setter
+    def measurement_running(self, value: bool):
+        self['measurement_running'] = bool(value)
+
+    @property
+    def microwave_running(self) -> bool:
+        """True while the external microwave source is switched on."""
+        return self['microwave_running']
+
+    @microwave_running.setter
+    def microwave_running(self, value: bool):
+        self['microwave_running'] = bool(value)
+
+    @property
+    def predefined_generation_busy(self) -> bool:
+        """True while a predefined generator method is generating blocks/ensembles/sequences."""
+        return self['predefined_generation_busy']
+
+    @predefined_generation_busy.setter
+    def predefined_generation_busy(self, value: bool):
+        self['predefined_generation_busy'] = bool(value)
+
+    @property
+    def fitting_busy(self) -> bool:
+        """True while a data fit is being calculated."""
+        return self['fitting_busy']
+
+    @fitting_busy.setter
+    def fitting_busy(self, value: bool):
+        self['fitting_busy'] = bool(value)
+
+    @property
+    def benchmark_busy(self) -> bool:
+        """True while a pulse generator upload/load speed benchmark is running."""
+        return self['benchmark_busy']
+
+    @benchmark_busy.setter
+    def benchmark_busy(self, value: bool):
+        self['benchmark_busy'] = bool(value)
+
+    def to_dict(self) -> dict:
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data) if isinstance(data, dict) else cls()
+
+
+@dataclass(frozen=True)
+class FitContainers:
+    """Bundles the primary and alternative-data FitContainer instances exposed by
+    PulsedMeasurementLogic, so callers can use named access (.primary/.alternative) instead of
+    an anonymous (fc, alt_fc) tuple.
+
+    Supports iteration/indexing so existing tuple-style call sites (fit_containers[0],
+    fit_containers[1]) keep working unchanged.
+    """
+
+    primary: FitContainer
+    alternative: FitContainer
+
+    @property
+    def as_tuple(self):
+        return (self.primary, self.alternative)
+
+    def __iter__(self):
+        return iter(self.as_tuple)
+
+    def __len__(self):
+        return len(self.as_tuple)
+
+    def __getitem__(self, index):
+        return self.as_tuple[index]

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
@@ -60,6 +60,29 @@ class Settings:
             ),
         }
 
+    def to_metadata_dict(self, omit=()):
+        """Trimmed variant of to_dict() for saved-measurement metadata: drops any nested settings
+        container that the calling header already writes out in full at its own top level, so no
+        container is ever written twice into one file and the two copies cannot drift apart.
+
+        `omit` holds dotted paths into the dict to_dict() returns, e.g.
+        'measurement_settings.fast_counter_settings' or 'generator_settings.generation_parameters'.
+        A path naming something absent is ignored, so a caller may list a key that only exists when
+        generator_settings is not None.
+
+        Which paths each saved file omits is decided by its metadata builder - see the
+        _*_METADATA_OMIT constants in pulsed_measurement_logic.py. One-way/display-only, mirroring
+        PulseObjects.to_metadata_dict() below - no from_metadata_dict(); to_dict() stays lossless
+        for the .pulsedmeasurement snapshot.
+        """
+        data = self.to_dict()
+        for path in omit:
+            container_key, _, field_key = path.partition('.')
+            container = data.get(container_key)
+            if isinstance(container, dict):
+                container.pop(field_key, None)
+        return data
+
     @classmethod
     def from_dict(cls, data):
         generator_data = data.get('generator_settings')
@@ -76,12 +99,12 @@ class PulsedData:
     """Bundles this measurement's raw/laser/signal arrays with any fit results computed for it.
 
     fit_result/fit_result_alt are lmfit.model.ModelResult objects (or None) - the output of
-    PulsedMeasurementLogic.do_fit(). Like `sequence` on PulsedMeasurement, these have only a
+    PulsedMeasurementLogic.do_fit(). Like `loaded_asset` on PulseObjects, these have only a
     one-way, lossy export path: FitContainer.dict_result() (model name + parameter values/
     stderr, already used in saved metadata today via _get_signal_metadata()) - there is no
     reconstruction path anywhere in this codebase, and lmfit does not offer a simple one either,
     so from_dict() cannot restore live ModelResult objects; round-tripping through to_dict()/
-    from_dict() loses them, same as `sequence` on PulsedMeasurement.
+    from_dict() loses them, same as `loaded_asset` on PulseObjects.
 
     """
 
@@ -118,20 +141,50 @@ class PulseObjects:
 
     Frozen-in-time: mutating SequenceGeneratorLogic's live registries after a snapshot was taken
     never affects an already-built PulseObjects instance.
+
+    One slot holds the loaded asset (`loaded_asset`) whichever kind it is; `loaded_sequence` and
+    `loaded_ensemble` are Optional views over it that read as None for the other kind. to_dict()
+    names the saved key after the kind, and shows `ensembles` only when they mean something.
     """
 
-    #: The loaded top-level asset - independent copy (PulseBlockEnsemble.copy()/
-    #: PulseSequence.copy()), or None if nothing is loaded. Also carries that asset's own
-    #: sampling_information/measurement_information/generation_method_parameters - deliberately
-    #: not duplicated as separate fields here.
-    sequence: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
-    #: Every PulseBlockEnsemble `sequence` references by name, keyed by name - independent copies.
-    #: Empty if `sequence` is itself a bare PulseBlockEnsemble (or nothing is loaded): there is
-    #: nothing to resolve one level up in that case.
+    #: The loaded top-level asset, whichever kind it is - independent copy
+    #: (PulseBlockEnsemble.copy()/PulseSequence.copy()), or None if nothing is loaded. Named for
+    #: the concept rather than for one of the two types it can hold, matching
+    #: PulsedMeasurementLogic/PulsedMasterLogic/SequenceGeneratorLogic, which all call it
+    #: `loaded_asset` too. Read it through `loaded_sequence`/`loaded_ensemble` below when you care
+    #: which kind it is. Also carries that asset's own sampling_information/
+    #: measurement_information/generation_method_parameters - deliberately not duplicated as
+    #: separate fields here.
+    loaded_asset: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
+    #: Every PulseBlockEnsemble `loaded_asset` references by name, keyed by name - independent
+    #: copies. Empty if `loaded_asset` is itself a bare PulseBlockEnsemble (or nothing is loaded):
+    #: there is nothing to resolve one level up in that case, which is why to_dict() leaves the key
+    #: out entirely rather than writing an empty dict.
     ensembles: Dict[str, 'PulseBlockEnsemble'] = field(default_factory=dict)
-    #: Every PulseBlock referenced by `ensembles` (or, for a bare-ensemble `sequence`, referenced
-    #: directly by it), keyed by name - independent copies, same provenance as `ensembles`.
+    #: Every PulseBlock referenced by `ensembles` (or, for a bare-ensemble `loaded_asset`,
+    #: referenced directly by it), keyed by name - independent copies, same provenance as
+    #: `ensembles`.
     blocks: Dict[str, 'PulseBlock'] = field(default_factory=dict)
+
+    @property
+    def loaded_sequence(self) -> Optional['PulseSequence']:
+        """`loaded_asset` when a PulseSequence is loaded, else None.
+
+        A view over the single `loaded_asset` slot rather than a field of its own, so this and
+        `loaded_ensemble` can never disagree with each other or with `loaded_asset`, and there is
+        no "at most one of them is set" invariant for anyone to break.
+
+        The tri-state getattr mirrors _resolve_asset_closure() in sequence_generator_logic.py:
+        None means "not a pulse asset at all", so an unrelated object reads as None from both
+        properties instead of raising AttributeError.
+        """
+        return self.loaded_asset if getattr(self.loaded_asset, 'is_sequence', None) is True else None
+
+    @property
+    def loaded_ensemble(self) -> Optional['PulseBlockEnsemble']:
+        """`loaded_asset` when a bare PulseBlockEnsemble is loaded, else None - see
+        `loaded_sequence` for why both are properties over one slot."""
+        return self.loaded_asset if getattr(self.loaded_asset, 'is_sequence', None) is False else None
 
     @property
     def elements(self) -> List['PulseBlockElement']:
@@ -141,24 +194,33 @@ class PulseObjects:
         return [element for block in self.blocks.values() for element in block.element_list]
 
     def to_dict(self):
-        """`sequence` is tagged with its own class name so from_dict() knows which class to
-        reconstruct.
+        """The loaded asset is written under 'loaded_sequence' or 'loaded_ensemble' - the key name
+        itself says which kind it is, so a saved file never reads 'sequence' while describing a
+        PulseBlockEnsemble. It still also carries a 'type' tag holding the class name: that is the
+        forward-compatible hook a third asset type would use, and it survives being read back
+        without the classes importable.
+
+        'ensembles' appears only when a PulseSequence is loaded. A bare ensemble resolves nothing
+        one level up, so for it the key is left out rather than written as an empty dict - an empty
+        'ensembles' next to an ensemble is exactly the reading that used to confuse people.
 
         The flattened `elements` view (see the property above) is deliberately NOT exported: every
         element already appears inside its block's 'element_list', so a second copy would only
         duplicate them. Use the `elements` property on a live instance if you want them flat.
         """
-        sequence_dict = None
-        if self.sequence is not None:
-            sequence_dict = {'type': type(self.sequence).__name__}
-            sequence_dict.update(self.sequence.get_dict_representation())
-        return {
-            'sequence': sequence_dict,
-            'ensembles': {name: ens.get_dict_representation() for name, ens in self.ensembles.items()},
-            'blocks': {name: blk.get_dict_representation() for name, blk in self.blocks.items()},
-        }
+        data = {}
+        if self.loaded_asset is not None:
+            asset_dict = {'type': type(self.loaded_asset).__name__}
+            asset_dict.update(self.loaded_asset.get_dict_representation())
+            data['loaded_sequence' if self.loaded_asset.is_sequence else 'loaded_ensemble'] = asset_dict
+        if self.loaded_sequence is not None:
+            data['ensembles'] = {
+                name: ens.get_dict_representation() for name, ens in self.ensembles.items()
+            }
+        data['blocks'] = {name: blk.get_dict_representation() for name, blk in self.blocks.items()}
+        return data
 
-    def to_metadata_dict(self):
+    def to_metadata_dict(self, omit_generation_method_parameters=False):
         """Trimmed variant of to_dict() for saved-measurement metadata: drops fields from each
         sequence/ensemble's 'sampling_information' that are either pure duplication
         ('ensemble_info' duplicates this same PulseObjects' `ensembles`; 'pulse_generator_settings'
@@ -168,6 +230,14 @@ class PulseObjects:
         rather than sequence structure. Structural fields (name, block_list/ensemble_list,
         generation_method_parameters, element definitions) are unaffected. One-way/display-only -
         no from_metadata_dict().
+
+        Parameters
+        ----------
+        omit_generation_method_parameters : bool
+            Optional, also drop 'generation_method_parameters' from the loaded asset's own entry,
+            for a header that already writes it out at its top level (only the signal file does -
+            see _get_signal_metadata()). Deliberately applies to the loaded asset alone: every
+            ensemble under 'ensembles' has its own, which is not duplicated anywhere.
         """
         def trim_sampling_information(sampling_info_dict):
             return {
@@ -179,11 +249,14 @@ class PulseObjects:
             }
 
         data = self.to_dict()
-        if data['sequence'] is not None:
-            data['sequence']['sampling_information'] = trim_sampling_information(
-                data['sequence']['sampling_information']
+        asset_dict = data.get('loaded_sequence') or data.get('loaded_ensemble')
+        if asset_dict is not None:
+            asset_dict['sampling_information'] = trim_sampling_information(
+                asset_dict['sampling_information']
             )
-        for ensemble_dict in data['ensembles'].values():
+            if omit_generation_method_parameters:
+                asset_dict.pop('generation_method_parameters', None)
+        for ensemble_dict in data.get('ensembles', {}).values():
             ensemble_dict['sampling_information'] = trim_sampling_information(
                 ensemble_dict['sampling_information']
             )
@@ -203,22 +276,39 @@ class PulseObjects:
             name: PulseBlockEnsemble.ensemble_from_dict(ensemble_dict)
             for name, ensemble_dict in (data.get('ensembles') or {}).items()
         }
-        sequence_dict = data.get('sequence')
-        sequence = None
+        sequence_dict = data.get('loaded_sequence')
+        ensemble_dict = data.get('loaded_ensemble')
+        if sequence_dict is None and ensemble_dict is None:
+            # Files written before the key split put both kinds under one 'sequence' key,
+            # distinguished only by the 'type' tag inside it - see to_dict().
+            legacy_dict = data.get('sequence')
+            if legacy_dict is not None:
+                if legacy_dict.get('type') == 'PulseSequence':
+                    sequence_dict = legacy_dict
+                elif legacy_dict.get('type') == 'PulseBlockEnsemble':
+                    ensemble_dict = legacy_dict
+        loaded_asset = None
         if sequence_dict is not None:
-            seq_type = sequence_dict.get('type')
-            if seq_type == 'PulseSequence':
-                sequence = PulseSequence.sequence_from_dict(sequence_dict)
-            elif seq_type == 'PulseBlockEnsemble':
-                sequence = PulseBlockEnsemble.ensemble_from_dict(sequence_dict)
-        return cls(sequence=sequence, ensembles=ensembles, blocks=blocks)
+            loaded_asset = PulseSequence.sequence_from_dict(sequence_dict)
+        elif ensemble_dict is not None:
+            loaded_asset = PulseBlockEnsemble.ensemble_from_dict(ensemble_dict)
+        return cls(loaded_asset=loaded_asset, ensembles=ensembles, blocks=blocks)
+
+    def __setstate__(self, state):
+        """Unpickles a '.pulsedmeasurement' snapshot written before `sequence` was renamed to
+        `loaded_asset`. Pickle restores instance state directly, bypassing from_dict()'s legacy
+        branch, so such a file would otherwise arrive with no `loaded_asset` at all."""
+        if 'sequence' in state and 'loaded_asset' not in state:
+            state = dict(state)
+            state['loaded_asset'] = state.pop('sequence')
+        self.__dict__.update(state)
 
 
 @dataclass
 class PulsedMeasurement:
     """Top-level container for everything that makes up a single pulsed measurement: its
-    settings, its acquired/evaluated data, and the pulse objects (sequence/ensembles/blocks) that
-    produced it. Built by PulsedMeasurementLogic.get_pulsed_measurement() / PulsedMasterLogic.
+    settings, its acquired/evaluated data, and the pulse objects (loaded asset/ensembles/blocks)
+    that produced it. Built by PulsedMeasurementLogic.get_pulsed_measurement() / PulsedMasterLogic.
     get_pulsed_measurement() as a frozen-in-time snapshot: `data` and `objects` are populated from
     independent copies, not live references, so a returned/stored PulsedMeasurement does not keep
     changing under the caller as the source measurement continues running or a same-named asset
@@ -235,11 +325,11 @@ class PulsedMeasurement:
     data: Optional[PulsedData] = None
     #: Source: PulsedMeasurementLogic.loaded_asset.copy() plus SequenceGeneratorLogic.
     #: resolve_asset_closure() - see PulseObjects. Always present (never None itself); "nothing
-    #: loaded" is represented by objects.sequence is None.
+    #: loaded" is represented by objects.loaded_asset is None.
     objects: PulseObjects = field(default_factory=PulseObjects)
 
     def to_dict(self):
-        """Serializes `settings`, `data`, and `objects` (sequence/ensembles/blocks)."""
+        """Serializes `settings`, `data`, and `objects` (loaded asset/ensembles/blocks)."""
         return {
             'settings': self.settings.to_dict(),
             'data': self.data.to_dict() if self.data is not None else None,

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 from dataclasses import dataclass, field
+from logging import getLogger
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from qudi.util.datafitting import FitContainer
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
     # imports several classes from this package), so importing these at runtime here would invert
     # that layering. Only needed for type hints below.
     from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockElement, PulseBlockEnsemble, PulseSequence
+
+_logger = getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -144,7 +147,7 @@ class PulseObjects:
 
     One slot holds the loaded asset (`loaded_asset`) whichever kind it is; `loaded_sequence` and
     `loaded_ensemble` are Optional views over it that read as None for the other kind. to_dict()
-    names the saved key after the kind, and shows `ensembles` only when they mean something.
+    flattens that back out into a fixed three-key shape - see its docstring.
     """
 
     #: The loaded top-level asset, whichever kind it is - independent copy
@@ -157,9 +160,10 @@ class PulseObjects:
     #: separate fields here.
     loaded_asset: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
     #: Every PulseBlockEnsemble `loaded_asset` references by name, keyed by name - independent
-    #: copies. Empty if `loaded_asset` is itself a bare PulseBlockEnsemble (or nothing is loaded):
-    #: there is nothing to resolve one level up in that case, which is why to_dict() leaves the key
-    #: out entirely rather than writing an empty dict.
+    #: copies. Empty *on the instance* if `loaded_asset` is itself a bare PulseBlockEnsemble (or
+    #: nothing is loaded): there is nothing to resolve one level up in that case. Note this differs
+    #: from the saved form, where to_dict() files a bare loaded ensemble into 'ensembles' so the
+    #: 'sequence' key can stay empty - see to_dict().
     ensembles: Dict[str, 'PulseBlockEnsemble'] = field(default_factory=dict)
     #: Every PulseBlock referenced by `ensembles` (or, for a bare-ensemble `loaded_asset`,
     #: referenced directly by it), keyed by name - independent copies, same provenance as
@@ -194,31 +198,42 @@ class PulseObjects:
         return [element for block in self.blocks.values() for element in block.element_list]
 
     def to_dict(self):
-        """The loaded asset is written under 'loaded_sequence' or 'loaded_ensemble' - the key name
-        itself says which kind it is, so a saved file never reads 'sequence' while describing a
-        PulseBlockEnsemble. It still also carries a 'type' tag holding the class name: that is the
-        forward-compatible hook a third asset type would use, and it survives being read back
-        without the classes importable.
+        """Always writes exactly three keys - 'sequence', 'ensembles', 'blocks' - whichever kind of
+        asset is loaded, so evaluation code reads one fixed shape and never has to test which keys
+        are present before it can start.
 
-        'ensembles' appears only when a PulseSequence is loaded. A bare ensemble resolves nothing
-        one level up, so for it the key is left out rather than written as an empty dict - an empty
-        'ensembles' next to an ensemble is exactly the reading that used to confuse people.
+        The kind is not encoded anywhere; it is *reconstructed* from the structure. A loaded
+        PulseSequence goes in 'sequence'. A loaded bare PulseBlockEnsemble goes into 'ensembles'
+        instead and 'sequence' stays empty, so:
+
+            if not data['sequence']:   # -> a PulseBlockEnsemble was loaded (or nothing was)
+
+        Test the whole 'sequence' value, never its 'ensemble_list': PulseSequence(name='x') has an
+        empty ensemble_list and is still a sequence, whereas a real sequence's representation always
+        carries at least its 'name' and so is never falsy.
+
+        This replaces an older layout that named the key after the kind ('loaded_sequence' /
+        'loaded_ensemble') and tagged the value with its class name. from_dict() still reads that
+        one, and the pre-split single-'sequence'-plus-'type'-tag one before it.
 
         The flattened `elements` view (see the property above) is deliberately NOT exported: every
         element already appears inside its block's 'element_list', so a second copy would only
         duplicate them. Use the `elements` property on a live instance if you want them flat.
         """
-        data = {}
-        if self.loaded_asset is not None:
-            asset_dict = {'type': type(self.loaded_asset).__name__}
-            asset_dict.update(self.loaded_asset.get_dict_representation())
-            data['loaded_sequence' if self.loaded_asset.is_sequence else 'loaded_ensemble'] = asset_dict
+        sequence = {}
+        ensembles = {name: ens.get_dict_representation() for name, ens in self.ensembles.items()}
         if self.loaded_sequence is not None:
-            data['ensembles'] = {
-                name: ens.get_dict_representation() for name, ens in self.ensembles.items()
-            }
-        data['blocks'] = {name: blk.get_dict_representation() for name, blk in self.blocks.items()}
-        return data
+            sequence = self.loaded_sequence.get_dict_representation()
+        elif self.loaded_ensemble is not None:
+            # A bare ensemble resolves nothing one level up, so `ensembles` is empty on the
+            # instance and filing the asset here costs nothing - and it is what lets 'sequence'
+            # stay empty as the kind marker.
+            ensembles[self.loaded_ensemble.name] = self.loaded_ensemble.get_dict_representation()
+        return {
+            'sequence': sequence,
+            'ensembles': ensembles,
+            'blocks': {name: blk.get_dict_representation() for name, blk in self.blocks.items()},
+        }
 
     def to_metadata_dict(self, omit_generation_method_parameters=False):
         """Trimmed variant of to_dict() for saved-measurement metadata: drops fields from each
@@ -237,7 +252,9 @@ class PulseObjects:
             Optional, also drop 'generation_method_parameters' from the loaded asset's own entry,
             for a header that already writes it out at its top level (only the signal file does -
             see _get_signal_metadata()). Deliberately applies to the loaded asset alone: every
-            ensemble under 'ensembles' has its own, which is not duplicated anywhere.
+            *other* ensemble under 'ensembles' has its own, which is not duplicated anywhere. Note
+            a loaded bare ensemble now lives under 'ensembles' too (see to_dict()), so the flag has
+            to follow it there rather than keying off a separate top-level entry.
         """
         def trim_sampling_information(sampling_info_dict):
             return {
@@ -249,17 +266,26 @@ class PulseObjects:
             }
 
         data = self.to_dict()
-        asset_dict = data.get('loaded_sequence') or data.get('loaded_ensemble')
-        if asset_dict is not None:
-            asset_dict['sampling_information'] = trim_sampling_information(
-                asset_dict['sampling_information']
+        # Which entry is the loaded asset: 'sequence' when non-empty, else the bare ensemble
+        # to_dict() filed under its own name. `None` when nothing is loaded.
+        loaded_ensemble_name = (
+            self.loaded_ensemble.name if self.loaded_sequence is None
+            and self.loaded_ensemble is not None else None
+        )
+
+        sequence_dict = data['sequence']
+        if sequence_dict:
+            sequence_dict['sampling_information'] = trim_sampling_information(
+                sequence_dict['sampling_information']
             )
             if omit_generation_method_parameters:
-                asset_dict.pop('generation_method_parameters', None)
-        for ensemble_dict in data.get('ensembles', {}).values():
+                sequence_dict.pop('generation_method_parameters', None)
+        for name, ensemble_dict in data['ensembles'].items():
             ensemble_dict['sampling_information'] = trim_sampling_information(
                 ensemble_dict['sampling_information']
             )
+            if omit_generation_method_parameters and name == loaded_ensemble_name:
+                ensemble_dict.pop('generation_method_parameters', None)
         return data
 
     @classmethod
@@ -276,22 +302,46 @@ class PulseObjects:
             name: PulseBlockEnsemble.ensemble_from_dict(ensemble_dict)
             for name, ensemble_dict in (data.get('ensembles') or {}).items()
         }
-        sequence_dict = data.get('loaded_sequence')
-        ensemble_dict = data.get('loaded_ensemble')
-        if sequence_dict is None and ensemble_dict is None:
-            # Files written before the key split put both kinds under one 'sequence' key,
-            # distinguished only by the 'type' tag inside it - see to_dict().
-            legacy_dict = data.get('sequence')
-            if legacy_dict is not None:
-                if legacy_dict.get('type') == 'PulseSequence':
-                    sequence_dict = legacy_dict
-                elif legacy_dict.get('type') == 'PulseBlockEnsemble':
-                    ensemble_dict = legacy_dict
+        # Three layouts are readable here, newest first:
+        #   1. current  - 'sequence' (no 'type' tag); a bare ensemble sits in 'ensembles'
+        #   2. split    - 'loaded_sequence' / 'loaded_ensemble', named after the kind
+        #   3. pre-split- one 'sequence' key holding either kind, told apart by a 'type' tag
+        # (1) and (3) share the key name, so the 'type' tag is what separates them: the current
+        # format never writes one.
+        sequence_dict = data.get('sequence') or None
+        ensemble_dict = None
+        take_loaded_ensemble_from_ensembles = False
+        if sequence_dict is not None and 'type' in sequence_dict:
+            if sequence_dict.get('type') == 'PulseBlockEnsemble':
+                sequence_dict, ensemble_dict = None, sequence_dict
+            elif sequence_dict.get('type') != 'PulseSequence':
+                sequence_dict = None
+        elif sequence_dict is None:
+            sequence_dict = data.get('loaded_sequence')
+            ensemble_dict = data.get('loaded_ensemble')
+            take_loaded_ensemble_from_ensembles = (
+                sequence_dict is None and ensemble_dict is None and bool(ensembles)
+            )
+
         loaded_asset = None
         if sequence_dict is not None:
             loaded_asset = PulseSequence.sequence_from_dict(sequence_dict)
         elif ensemble_dict is not None:
             loaded_asset = PulseBlockEnsemble.ensemble_from_dict(ensemble_dict)
+        elif take_loaded_ensemble_from_ensembles:
+            # Current format, ensemble case: to_dict() filed the loaded bare ensemble as the sole
+            # entry in 'ensembles'. Pop it back out, because on the instance `ensembles` holds only
+            # what the asset resolves one level up - empty for a bare ensemble.
+            if len(ensembles) == 1:
+                _, loaded_asset = ensembles.popitem()
+            else:
+                # Cannot come from to_dict(); with an empty 'sequence' and several candidates the
+                # loaded asset is genuinely ambiguous, so refuse to guess rather than pick one.
+                _logger.warning(
+                    'Cannot tell which of the %d ensembles was the loaded asset: no "sequence" '
+                    'entry and more than one candidate. Leaving loaded_asset unset.',
+                    len(ensembles),
+                )
         return cls(loaded_asset=loaded_asset, ensembles=ensembles, blocks=blocks)
 
     def __setstate__(self, state):

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
@@ -113,7 +113,8 @@ class PulseObjects:
     SequenceGeneratorLogic's saved-asset registries - untouched by this class). `ensembles`/
     `blocks` are read-only copies of just that subset, resolved via
     SequenceGeneratorLogic.resolve_asset_closure(), so a saved measurement's dict representation
-    shows every element/block/ensemble/sequence directly instead of only a name.
+    shows every block/ensemble/sequence definition directly instead of only a name (and with them
+    every element, nested inside its block's element_list).
 
     Frozen-in-time: mutating SequenceGeneratorLogic's live registries after a snapshot was taken
     never affects an already-built PulseObjects instance.
@@ -134,15 +135,19 @@ class PulseObjects:
 
     @property
     def elements(self) -> List['PulseBlockElement']:
-        """Every PulseBlockElement across every PulseBlock in `blocks`, flattened. NOT a stored
-        field - PulseBlockElement has no identity of its own, so computing this fresh on every
-        access (rather than caching it) means it can never drift out of sync with `blocks`."""
+        """Every PulseBlockElement across every PulseBlock in `blocks`, flattened. A convenience
+        view for callers wanting a flat list; not a stored field and not part of to_dict(), since
+        `blocks` is the single source of truth and already contains every element."""
         return [element for block in self.blocks.values() for element in block.element_list]
 
     def to_dict(self):
         """`sequence` is tagged with its own class name so from_dict() knows which class to
-        reconstruct. `elements` is exported for readability only - from_dict() does not accept it
-        back, since restoring `blocks` already fully determines it."""
+        reconstruct.
+
+        The flattened `elements` view (see the property above) is deliberately NOT exported: every
+        element already appears inside its block's 'element_list', so a second copy would only
+        duplicate them. Use the `elements` property on a live instance if you want them flat.
+        """
         sequence_dict = None
         if self.sequence is not None:
             sequence_dict = {'type': type(self.sequence).__name__}
@@ -151,7 +156,6 @@ class PulseObjects:
             'sequence': sequence_dict,
             'ensembles': {name: ens.get_dict_representation() for name, ens in self.ensembles.items()},
             'blocks': {name: blk.get_dict_representation() for name, blk in self.blocks.items()},
-            'elements': [elem.get_dict_representation() for elem in self.elements],
         }
 
     def to_metadata_dict(self):
@@ -235,7 +239,7 @@ class PulsedMeasurement:
     objects: PulseObjects = field(default_factory=PulseObjects)
 
     def to_dict(self):
-        """Serializes `settings`, `data`, and `objects` (sequence/ensembles/blocks/elements)."""
+        """Serializes `settings`, `data`, and `objects` (sequence/ensembles/blocks)."""
         return {
             'settings': self.settings.to_dict(),
             'data': self.data.to_dict() if self.data is not None else None,

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains the dataclass container used to store and manage all the
+settings, data and sequence for pulsed measurements.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Union
+
+from qudi.util.datafitting import FitContainer
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    PulsedMeasurementSettings,
+    PulsedMeasurementData,
+)
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SequenceGeneratorSettings
+
+if TYPE_CHECKING:
+    # Deferred: pulse_objects.py sits above pulsed_data/ in the dependency layering (it already
+    # imports several classes from this package), so importing PulseBlockEnsemble/PulseSequence
+    # at runtime here would invert that layering. Only needed for the `sequence` type hint below.
+    from qudi.logic.pulsed.pulse_objects import PulseBlockEnsemble, PulseSequence
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Bundles the two independently-persisted settings containers that together fully describe
+    a pulsed measurement: PulsedMeasurementLogic's own settings (microwave, fast counter,
+    readout, alternative signal processing, extraction/analysis parameters, timer interval) and
+    SequenceGeneratorLogic's settings (generation parameters, pulse generator hardware mirror,
+    upload speed benchmarks).
+
+    These stay two nested, independently-owned sub-objects rather than being flattened into one
+    - each is still owned, mutated and persisted by its own logic module's StatusVar
+    (PulsedMeasurementLogic._settings / SequenceGeneratorLogic._generator_settings). This
+    container only ever holds references to those, for the purpose of bundling a matched pair
+    together at the point a full pulsed measurement is captured (e.g.
+    PulsedMeasurementLogic.get_pulsed_measurement()/save_measurement_data(), which accept
+    generator_settings as a parameter handed down from PulsedMasterLogic - PulsedMeasurementLogic
+    has no Connector to SequenceGeneratorLogic and cannot fetch generator_settings on its own).
+    generator_settings is therefore Optional: it is None whenever a Settings/PulsedMeasurement is
+    built by code that only has access to PulsedMeasurementLogic.
+
+    No fields overlap between the two nested settings objects: PulsedMeasurementSettings covers
+    the *measurement/readout* side (external CW microwave source, fast counter, extraction/
+    analysis of already-acquired data) while SequenceGeneratorSettings covers the *pulse
+    generation* side (AWG channel/timing setup, pulse generator hardware mirror, upload speed
+    benchmarks). One close pair is worth flagging explicitly so it isn't mistaken for a
+    duplicate: PulsedMeasurementSettings.microwave_settings (power/frequency of the external CW
+    microwave source, applied when use_ext_microwave is enabled) versus
+    SequenceGeneratorSettings.generation_parameters.microwave_frequency/microwave_amplitude (the
+    frequency/amplitude value baked into a generated, AWG-played pulse waveform). These describe
+    two different microwave signal paths - external CW hardware vs. values encoded into a
+    sampled waveform - that are routinely calibrated to different values, so they are correctly
+    kept as separate fields rather than merged.
+    """
+
+    measurement_settings: PulsedMeasurementSettings
+    generator_settings: Optional[SequenceGeneratorSettings] = None
+
+    def to_dict(self):
+        return {
+            'measurement_settings': self.measurement_settings.to_dict(),
+            'generator_settings': (
+                self.generator_settings.to_dict() if self.generator_settings is not None else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        generator_data = data.get('generator_settings')
+        return cls(
+            measurement_settings=PulsedMeasurementSettings.from_dict(data['measurement_settings']),
+            generator_settings=(
+                SequenceGeneratorSettings.from_dict(generator_data) if generator_data is not None else None
+            ),
+        )
+
+
+@dataclass
+class PulsedData:
+    """Bundles this measurement's raw/laser/signal arrays with any fit results computed for it.
+
+    fit_result/fit_result_alt are lmfit.model.ModelResult objects (or None) - the output of
+    PulsedMeasurementLogic.do_fit(). Like `sequence` on PulsedMeasurement, these have only a
+    one-way, lossy export path: FitContainer.dict_result() (model name + parameter values/
+    stderr, already used in saved metadata today via _get_signal_metadata()) - there is no
+    reconstruction path anywhere in this codebase, and lmfit does not offer a simple one either,
+    so from_dict() cannot restore live ModelResult objects; round-tripping through to_dict()/
+    from_dict() loses them, same as `sequence` on PulsedMeasurement.
+
+    Not copied on construction: PulsedMeasurementLogic reassigns self._fit_result/
+    self._fit_result_alt wholesale on every new fit rather than mutating an existing ModelResult
+    in place, so holding a bare reference is already safe for a frozen snapshot's purposes -
+    unlike measurement_data, which is actively mutated in place while a measurement runs and
+    therefore does need PulsedMeasurementData.copy().
+    """
+
+    measurement_data: PulsedMeasurementData
+    fit_result: Optional[object] = None  # lmfit.model.ModelResult - see class docstring
+    fit_result_alt: Optional[object] = None  # lmfit.model.ModelResult - see class docstring
+
+    def to_dict(self):
+        """fit_result/fit_result_alt are exported one-way via FitContainer.dict_result() for
+        display/save purposes - from_dict() cannot restore them, see class docstring."""
+        return {
+            'measurement_data': self.measurement_data.to_dict(),
+            'fit_result': FitContainer.dict_result(self.fit_result) if self.fit_result is not None else None,
+            'fit_result_alt': (
+                FitContainer.dict_result(self.fit_result_alt) if self.fit_result_alt is not None else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        # fit_result/fit_result_alt intentionally not restored - see class docstring.
+        return cls(measurement_data=PulsedMeasurementData.from_dict(data['measurement_data']))
+
+
+@dataclass
+class PulsedMeasurement:
+    """Top-level container for everything that makes up a single pulsed measurement: its
+    settings, its acquired/evaluated data, and the pulse sequence/ensemble that produced it.
+    Built by PulsedMeasurementLogic.get_pulsed_measurement() / PulsedMasterLogic.
+    get_pulsed_measurement() as a frozen-in-time snapshot: `data` and `sequence` are populated
+    from independent copies (PulsedMeasurementData.copy() / PulseBlockEnsemble.copy() /
+    PulseSequence.copy()), not live references, so a returned/stored PulsedMeasurement does not
+    keep changing under the caller as the source measurement continues running or a same-named
+    asset gets reloaded/edited later.
+
+    `sequence` (and `data.fit_result`/`data.fit_result_alt` - see PulsedData) is intentionally
+    NOT fully included in to_dict()/from_dict(): PulseBlockEnsemble/PulseSequence are not
+    actually persisted via dict serialization anywhere in this codebase - the real persistence
+    path (SequenceGeneratorLogic._save_ensemble_to_file() et al.) pickles the live object
+    directly to a .block/.ensemble/.sequence file. get_dict_representation()/
+    ensemble_from_dict()/sequence_from_dict() do still exist on those classes but have no live
+    callers - their only caller is a fully commented-out block of abandoned StatusVar hooks in
+    sequence_generator_logic.py. If a whole PulsedMeasurement ever needs full serialization, it
+    should be pickled to match how the object it wraps is already persisted, rather than given a
+    bespoke dict-safe format this codebase already tried and dropped for this exact type.
+
+    Deliberately NOT frozen (unlike the settings dataclasses nested inside it): `data`/`sequence`
+    are ordinary mutable objects, matching PulsedData/PulseBlockEnsemble/PulseSequence themselves
+    - freezing this container wouldn't make them immutable, only misleadingly imply it.
+    """
+
+    settings: Settings
+    #: Source: PulsedMeasurementLogic.measurement_data.copy() plus the current fit results - see
+    #: PulsedData.
+    data: Optional[PulsedData] = None
+    #: Source: PulsedMeasurementLogic.loaded_asset.copy() (whichever PulseBlockEnsemble/
+    #: PulseSequence is currently loaded) - an independent copy, not a live reference. Also
+    #: carries that asset's own sampling_information/measurement_information/
+    #: generation_method_parameters - deliberately not duplicated as separate fields here.
+    sequence: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
+
+    def to_dict(self):
+        """Serializes `settings` and `data`. `sequence` is intentionally excluded - see class
+        docstring."""
+        return {
+            'settings': self.settings.to_dict(),
+            'data': self.data.to_dict() if self.data is not None else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        data_dict = data.get('data')
+        return cls(
+            settings=Settings.from_dict(data['settings']),
+            data=PulsedData.from_dict(data_dict) if data_dict is not None else None,
+        )

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement.py
@@ -19,8 +19,8 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from qudi.util.datafitting import FitContainer
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
@@ -31,42 +31,22 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import Sequence
 
 if TYPE_CHECKING:
     # Deferred: pulse_objects.py sits above pulsed_data/ in the dependency layering (it already
-    # imports several classes from this package), so importing PulseBlockEnsemble/PulseSequence
-    # at runtime here would invert that layering. Only needed for the `sequence` type hint below.
-    from qudi.logic.pulsed.pulse_objects import PulseBlockEnsemble, PulseSequence
+    # imports several classes from this package), so importing these at runtime here would invert
+    # that layering. Only needed for type hints below.
+    from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockElement, PulseBlockEnsemble, PulseSequence
 
 
 @dataclass(frozen=True)
 class Settings:
-    """Bundles the two independently-persisted settings containers that together fully describe
-    a pulsed measurement: PulsedMeasurementLogic's own settings (microwave, fast counter,
-    readout, alternative signal processing, extraction/analysis parameters, timer interval) and
-    SequenceGeneratorLogic's settings (generation parameters, pulse generator hardware mirror,
-    upload speed benchmarks).
+    """Bundles the two independently-persisted settings containers describing a pulsed
+    measurement: PulsedMeasurementLogic's own settings (microwave, fast counter, readout,
+    extraction/analysis) and SequenceGeneratorLogic's (generation parameters, pulse generator
+    hardware mirror).
 
-    These stay two nested, independently-owned sub-objects rather than being flattened into one
-    - each is still owned, mutated and persisted by its own logic module's StatusVar
-    (PulsedMeasurementLogic._settings / SequenceGeneratorLogic._generator_settings). This
-    container only ever holds references to those, for the purpose of bundling a matched pair
-    together at the point a full pulsed measurement is captured (e.g.
-    PulsedMeasurementLogic.get_pulsed_measurement()/save_measurement_data(), which accept
-    generator_settings as a parameter handed down from PulsedMasterLogic - PulsedMeasurementLogic
-    has no Connector to SequenceGeneratorLogic and cannot fetch generator_settings on its own).
-    generator_settings is therefore Optional: it is None whenever a Settings/PulsedMeasurement is
-    built by code that only has access to PulsedMeasurementLogic.
-
-    No fields overlap between the two nested settings objects: PulsedMeasurementSettings covers
-    the *measurement/readout* side (external CW microwave source, fast counter, extraction/
-    analysis of already-acquired data) while SequenceGeneratorSettings covers the *pulse
-    generation* side (AWG channel/timing setup, pulse generator hardware mirror, upload speed
-    benchmarks). One close pair is worth flagging explicitly so it isn't mistaken for a
-    duplicate: PulsedMeasurementSettings.microwave_settings (power/frequency of the external CW
-    microwave source, applied when use_ext_microwave is enabled) versus
-    SequenceGeneratorSettings.generation_parameters.microwave_frequency/microwave_amplitude (the
-    frequency/amplitude value baked into a generated, AWG-played pulse waveform). These describe
-    two different microwave signal paths - external CW hardware vs. values encoded into a
-    sampled waveform - that are routinely calibrated to different values, so they are correctly
-    kept as separate fields rather than merged.
+    Each stays owned/persisted by its own logic module's StatusVar - this only holds references,
+    bundled together when a measurement is captured. generator_settings is Optional since
+    PulsedMeasurementLogic has no Connector to SequenceGeneratorLogic and can't fetch it alone;
+    it's None whenever built by code with only PulsedMeasurementLogic access.
     """
 
     measurement_settings: PulsedMeasurementSettings
@@ -103,11 +83,6 @@ class PulsedData:
     so from_dict() cannot restore live ModelResult objects; round-tripping through to_dict()/
     from_dict() loses them, same as `sequence` on PulsedMeasurement.
 
-    Not copied on construction: PulsedMeasurementLogic reassigns self._fit_result/
-    self._fit_result_alt wholesale on every new fit rather than mutating an existing ModelResult
-    in place, so holding a bare reference is already safe for a frozen snapshot's purposes -
-    unlike measurement_data, which is actively mutated in place while a measurement runs and
-    therefore does need PulsedMeasurementData.copy().
     """
 
     measurement_data: PulsedMeasurementData
@@ -132,54 +107,147 @@ class PulsedData:
 
 
 @dataclass
+class PulseObjects:
+    """Bundles the currently loaded PulseSequence/PulseBlockEnsemble with independent copies of
+    every PulseBlockEnsemble/PulseBlock it references by name (real objects live in
+    SequenceGeneratorLogic's saved-asset registries - untouched by this class). `ensembles`/
+    `blocks` are read-only copies of just that subset, resolved via
+    SequenceGeneratorLogic.resolve_asset_closure(), so a saved measurement's dict representation
+    shows every element/block/ensemble/sequence directly instead of only a name.
+
+    Frozen-in-time: mutating SequenceGeneratorLogic's live registries after a snapshot was taken
+    never affects an already-built PulseObjects instance.
+    """
+
+    #: The loaded top-level asset - independent copy (PulseBlockEnsemble.copy()/
+    #: PulseSequence.copy()), or None if nothing is loaded. Also carries that asset's own
+    #: sampling_information/measurement_information/generation_method_parameters - deliberately
+    #: not duplicated as separate fields here.
+    sequence: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
+    #: Every PulseBlockEnsemble `sequence` references by name, keyed by name - independent copies.
+    #: Empty if `sequence` is itself a bare PulseBlockEnsemble (or nothing is loaded): there is
+    #: nothing to resolve one level up in that case.
+    ensembles: Dict[str, 'PulseBlockEnsemble'] = field(default_factory=dict)
+    #: Every PulseBlock referenced by `ensembles` (or, for a bare-ensemble `sequence`, referenced
+    #: directly by it), keyed by name - independent copies, same provenance as `ensembles`.
+    blocks: Dict[str, 'PulseBlock'] = field(default_factory=dict)
+
+    @property
+    def elements(self) -> List['PulseBlockElement']:
+        """Every PulseBlockElement across every PulseBlock in `blocks`, flattened. NOT a stored
+        field - PulseBlockElement has no identity of its own, so computing this fresh on every
+        access (rather than caching it) means it can never drift out of sync with `blocks`."""
+        return [element for block in self.blocks.values() for element in block.element_list]
+
+    def to_dict(self):
+        """`sequence` is tagged with its own class name so from_dict() knows which class to
+        reconstruct. `elements` is exported for readability only - from_dict() does not accept it
+        back, since restoring `blocks` already fully determines it."""
+        sequence_dict = None
+        if self.sequence is not None:
+            sequence_dict = {'type': type(self.sequence).__name__}
+            sequence_dict.update(self.sequence.get_dict_representation())
+        return {
+            'sequence': sequence_dict,
+            'ensembles': {name: ens.get_dict_representation() for name, ens in self.ensembles.items()},
+            'blocks': {name: blk.get_dict_representation() for name, blk in self.blocks.items()},
+            'elements': [elem.get_dict_representation() for elem in self.elements],
+        }
+
+    def to_metadata_dict(self):
+        """Trimmed variant of to_dict() for saved-measurement metadata: drops fields from each
+        sequence/ensemble's 'sampling_information' that are either pure duplication
+        ('ensemble_info' duplicates this same PulseObjects' `ensembles`; 'pulse_generator_settings'
+        is a single global snapshot shown once elsewhere already) or large per-sample arrays
+        (laser_rising_bins/falling_bins, elements_length_bins, and everything in
+        SamplingInformation._legacy_data) that would otherwise dominate the header with numbers
+        rather than sequence structure. Structural fields (name, block_list/ensemble_list,
+        generation_method_parameters, element definitions) are unaffected. One-way/display-only -
+        no from_metadata_dict().
+        """
+        def trim_sampling_information(sampling_info_dict):
+            return {
+                'waveforms': sampling_info_dict.get('waveforms', []),
+                'number_of_samples': sampling_info_dict.get('number_of_samples'),
+                'number_of_elements': sampling_info_dict.get('number_of_elements'),
+                'ideal_length': sampling_info_dict.get('ideal_length'),
+                'step_waveform_list': sampling_info_dict.get('step_waveform_list', []),
+            }
+
+        data = self.to_dict()
+        if data['sequence'] is not None:
+            data['sequence']['sampling_information'] = trim_sampling_information(
+                data['sequence']['sampling_information']
+            )
+        for ensemble_dict in data['ensembles'].values():
+            ensemble_dict['sampling_information'] = trim_sampling_information(
+                ensemble_dict['sampling_information']
+            )
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        # Local import: pulse_objects.py sits above pulsed_data/ in the dependency layering - a
+        # module-level import here would invert it.
+        from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
+
+        blocks = {
+            name: PulseBlock.block_from_dict(block_dict)
+            for name, block_dict in (data.get('blocks') or {}).items()
+        }
+        ensembles = {
+            name: PulseBlockEnsemble.ensemble_from_dict(ensemble_dict)
+            for name, ensemble_dict in (data.get('ensembles') or {}).items()
+        }
+        sequence_dict = data.get('sequence')
+        sequence = None
+        if sequence_dict is not None:
+            seq_type = sequence_dict.get('type')
+            if seq_type == 'PulseSequence':
+                sequence = PulseSequence.sequence_from_dict(sequence_dict)
+            elif seq_type == 'PulseBlockEnsemble':
+                sequence = PulseBlockEnsemble.ensemble_from_dict(sequence_dict)
+        return cls(sequence=sequence, ensembles=ensembles, blocks=blocks)
+
+
+@dataclass
 class PulsedMeasurement:
     """Top-level container for everything that makes up a single pulsed measurement: its
-    settings, its acquired/evaluated data, and the pulse sequence/ensemble that produced it.
-    Built by PulsedMeasurementLogic.get_pulsed_measurement() / PulsedMasterLogic.
-    get_pulsed_measurement() as a frozen-in-time snapshot: `data` and `sequence` are populated
-    from independent copies (PulsedMeasurementData.copy() / PulseBlockEnsemble.copy() /
-    PulseSequence.copy()), not live references, so a returned/stored PulsedMeasurement does not
-    keep changing under the caller as the source measurement continues running or a same-named
-    asset gets reloaded/edited later.
+    settings, its acquired/evaluated data, and the pulse objects (sequence/ensembles/blocks) that
+    produced it. Built by PulsedMeasurementLogic.get_pulsed_measurement() / PulsedMasterLogic.
+    get_pulsed_measurement() as a frozen-in-time snapshot: `data` and `objects` are populated from
+    independent copies, not live references, so a returned/stored PulsedMeasurement does not keep
+    changing under the caller as the source measurement continues running or a same-named asset
+    gets reloaded/edited later.
 
-    `sequence` (and `data.fit_result`/`data.fit_result_alt` - see PulsedData) is intentionally
-    NOT fully included in to_dict()/from_dict(): PulseBlockEnsemble/PulseSequence are not
-    actually persisted via dict serialization anywhere in this codebase - the real persistence
-    path (SequenceGeneratorLogic._save_ensemble_to_file() et al.) pickles the live object
-    directly to a .block/.ensemble/.sequence file. get_dict_representation()/
-    ensemble_from_dict()/sequence_from_dict() do still exist on those classes but have no live
-    callers - their only caller is a fully commented-out block of abandoned StatusVar hooks in
-    sequence_generator_logic.py. If a whole PulsedMeasurement ever needs full serialization, it
-    should be pickled to match how the object it wraps is already persisted, rather than given a
-    bespoke dict-safe format this codebase already tried and dropped for this exact type.
-
-    Deliberately NOT frozen (unlike the settings dataclasses nested inside it): `data`/`sequence`
-    are ordinary mutable objects, matching PulsedData/PulseBlockEnsemble/PulseSequence themselves
-    - freezing this container wouldn't make them immutable, only misleadingly imply it.
+    Deliberately NOT frozen (unlike the settings dataclasses nested inside it): `data`/`objects`
+    are ordinary mutable objects, matching PulsedData/PulseObjects themselves - freezing this
+    container wouldn't make them immutable, only misleadingly imply it.
     """
 
     settings: Settings
     #: Source: PulsedMeasurementLogic.measurement_data.copy() plus the current fit results - see
     #: PulsedData.
     data: Optional[PulsedData] = None
-    #: Source: PulsedMeasurementLogic.loaded_asset.copy() (whichever PulseBlockEnsemble/
-    #: PulseSequence is currently loaded) - an independent copy, not a live reference. Also
-    #: carries that asset's own sampling_information/measurement_information/
-    #: generation_method_parameters - deliberately not duplicated as separate fields here.
-    sequence: Optional[Union['PulseBlockEnsemble', 'PulseSequence']] = None
+    #: Source: PulsedMeasurementLogic.loaded_asset.copy() plus SequenceGeneratorLogic.
+    #: resolve_asset_closure() - see PulseObjects. Always present (never None itself); "nothing
+    #: loaded" is represented by objects.sequence is None.
+    objects: PulseObjects = field(default_factory=PulseObjects)
 
     def to_dict(self):
-        """Serializes `settings` and `data`. `sequence` is intentionally excluded - see class
-        docstring."""
+        """Serializes `settings`, `data`, and `objects` (sequence/ensembles/blocks/elements)."""
         return {
             'settings': self.settings.to_dict(),
             'data': self.data.to_dict() if self.data is not None else None,
+            'objects': self.objects.to_dict(),
         }
 
     @classmethod
     def from_dict(cls, data):
         data_dict = data.get('data')
+        objects_dict = data.get('objects')
         return cls(
             settings=Settings.from_dict(data['settings']),
             data=PulsedData.from_dict(data_dict) if data_dict is not None else None,
+            objects=PulseObjects.from_dict(objects_dict) if objects_dict is not None else PulseObjects(),
         )

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -233,42 +233,40 @@ class DataStashCache:
     def get_active(self):
         return self.cache.get(self.active_tag, None)
 
-@dataclass(frozen=True)
+@dataclass
 class AlternativeSignalSettings:
-    """Settings for alternative signal processing methods."""
-    alternative_data_type: Optional[str]
-    zeropad:int=0
-    psd: bool=False
-    window: str='none'
-    base_corr: bool=True
+    """Settings for the alternative (second) plot: which AltPlotAnalyzer method is selected, plus
+    every loaded method's parameter values.
+
+    `parameters` stays a plain dict (not fixed fields) because AltPlotAnalyzer discovers parameter
+    names dynamically from whichever AltPlotMethodBase subclasses are loaded - built-in ones plus
+    any lab-supplied ones via `alt_plot_import_path` - so the valid key set isn't known at
+    class-definition time.
+
+    Deliberately NOT frozen (unlike its sibling *Settings dataclasses): AltPlotAnalyzer holds this
+    exact instance and mutates it in place as its live state, the same pattern
+    PulseExtractor/PulseAnalyzer already use for ExtractionParameters/AnalysisParameters.
+    """
+    method: Optional[str] = None
+    parameters: dict = field(default_factory=dict)
+
     def to_dict(self) -> dict:
-        return {
-            'alternative_data_type': self.alternative_data_type,
-            'zeropad': self.zeropad,
-            'psd': self.psd,
-            'window': self.window,
-            'base_corr': self.base_corr,
-        }
+        return {'method': self.method, **self.parameters}
 
     @classmethod
     def from_dict(cls, data: dict):
-        return cls(
-            alternative_data_type=data.get('alternative_data_type', None),
-            zeropad=int(data.get('zeropad', 0)),
-            psd=_as_bool(data.get('psd', False)),
-            window=str(data.get('window', 'none')),
-            base_corr=_as_bool(data.get('base_corr', True)),
-        )
+        if not isinstance(data, dict):
+            return cls()
+        data = dict(data)
+        method = data.pop('method', None)
+        return cls(method=method, parameters=data)
 
     def update_from_dict(self, data: dict):
-        return replace(
-            self,
-            alternative_data_type=data.get('alternative_data_type', self.alternative_data_type),
-            zeropad=int(data.get('zeropad', self.zeropad)),
-            psd=_as_bool(data.get('psd', self.psd)),
-            window=str(data.get('window', self.window)),
-            base_corr=_as_bool(data.get('base_corr', self.base_corr)),
-        )
+        data = dict(data)
+        if 'method' in data:
+            self.method = data.pop('method')
+        self.parameters.update(data)
+        return self
 
 @dataclass
 class ExecutionState:
@@ -533,7 +531,6 @@ _DEFAULT_READOUT_SETTINGS = ReadoutSettings(
     units=('s', ''),
     labels=('Tau', 'Signal'),
 )
-_DEFAULT_ALTERNATE_SIGNAL_SETTINGS = AlternativeSignalSettings(alternative_data_type=None)
 
 
 @dataclass(frozen=True)
@@ -596,11 +593,7 @@ class PulsedMeasurementSettings:
                 if 'readout_settings' in data
                 else _DEFAULT_READOUT_SETTINGS
             ),
-            alternate_signal_settings=(
-                AlternativeSignalSettings.from_dict(data['alternate_signal_settings'])
-                if 'alternate_signal_settings' in data
-                else _DEFAULT_ALTERNATE_SIGNAL_SETTINGS
-            ),
+            alternate_signal_settings=AlternativeSignalSettings.from_dict(data.get('alternate_signal_settings')),
             extraction_parameters=ExtractionParameters.from_dict(data.get('extraction_parameters')),
             analysis_parameters=AnalysisParameters.from_dict(data.get('analysis_parameters')),
         )
@@ -669,7 +662,7 @@ class PulsedMeasurementSettings:
                 'labels': raw.get('_data_labels', ('Tau', 'Signal')),
             },
             'alternate_signal_settings': {
-                'alternative_data_type': raw.get('_alternative_data_type'),
+                'method': raw.get('_alternative_data_type'),
                 'zeropad': raw.get('zeropad', 0),
                 'psd': raw.get('psd', False),
                 'window': raw.get('window', 'none'),
@@ -697,13 +690,13 @@ class PulsedMeasurementSettings:
             value = data['readout_settings']
             readout_settings = value if isinstance(value, ReadoutSettings) else self.readout_settings.update_from_dict(value)
 
+        # alternate_signal_settings is a shared object too (AltPlotAnalyzer holds this exact
+        # instance, see its class docstring): mutate it in place, never replace the reference.
         alternate_signal_settings = self.alternate_signal_settings
         if 'alternate_signal_settings' in data:
             value = data['alternate_signal_settings']
-            alternate_signal_settings = (
-                value
-                if isinstance(value, AlternativeSignalSettings)
-                else self.alternate_signal_settings.update_from_dict(value)
+            alternate_signal_settings.update_from_dict(
+                value.to_dict() if isinstance(value, AlternativeSignalSettings) else value
             )
 
         # extraction_parameters/analysis_parameters are shared objects (see class docstring):

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -19,7 +19,7 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-from dataclasses import dataclass, replace, field
+from dataclasses import dataclass, replace, field, fields
 from typing import ClassVar, Optional
 import time
 import numpy as np
@@ -107,7 +107,7 @@ class MicrowaveSettings:
 
 
 @dataclass(frozen=True)
-class PulsedMeasurementSettings:
+class ReadoutSettings:
     """User-facing settings that define how a pulsed measurement is analyzed."""
 
     invoke_settings: bool
@@ -274,7 +274,6 @@ class ExecutionState:
     start_time: float = 0.0
     time_of_pause: float = 0.0
     elapsed_pause: float = 0.0
-    timer_interval_s: float = 5.0  # default 5 seconds
 
     @property
     def elapsed_time(self) -> float:
@@ -336,6 +335,72 @@ class MeasurementInformation:
 
     def __bool__(self):
         return self.is_valid
+
+    def __eq__(self, other):
+        """Custom equality: the auto-generated dataclass __eq__ would compare
+        controlled_variable with plain '==', which raises "truth value of an array is
+        ambiguous" once it holds a populated numpy array (the normal case)."""
+        if not isinstance(other, MeasurementInformation):
+            return NotImplemented
+        if not np.array_equal(self.controlled_variable, other.controlled_variable):
+            return False
+        return (
+            self.number_of_lasers,
+            self.laser_ignore_list,
+            self.alternating,
+            self.counting_length,
+            self.units,
+            self.labels,
+        ) == (
+            other.number_of_lasers,
+            other.laser_ignore_list,
+            other.alternating,
+            other.counting_length,
+            other.units,
+            other.labels,
+        )
+
+    def _field_names(self):
+        return {f.name for f in fields(self)}
+
+    def __contains__(self, key):
+        return key in self._field_names()
+
+    def __getitem__(self, key):
+        if key in self._field_names():
+            return getattr(self, key)
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        """Allows dict-item-assignment (e.g. block_ensemble.measurement_information['alternating']
+        = False), used throughout predefined_generate_methods/*.py, on this typed dataclass."""
+        if key not in self._field_names():
+            raise KeyError(
+                'MeasurementInformation has no field "{0}". Valid fields: {1}'.format(
+                    key, sorted(self._field_names())
+                )
+            )
+        setattr(self, key, value)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def update(self, other=(), **kwargs):
+        items = other.items() if hasattr(other, 'items') else other
+        for key, value in items:
+            self[key] = value
+        for key, value in kwargs.items():
+            self[key] = value
+
+    def copy(self):
+        return replace(
+            self,
+            laser_ignore_list=None if self.laser_ignore_list is None else list(self.laser_ignore_list),
+            controlled_variable=None if self.controlled_variable is None else self.controlled_variable.copy(),
+        )
 
     def to_dict(self) -> dict:
         if not self.is_valid:
@@ -434,4 +499,110 @@ class GenerationMethodParameters(dict):
     @classmethod
     def from_dict(cls, data):
         return cls(data) if isinstance(data, dict) else cls()
+
+
+@dataclass(frozen=True)
+class PulsedMeasurementSettings:
+    """Single settings container bundling everything PulsedMeasurementLogic persists as
+    user-configurable settings: external microwave, fast counter, readout (controlled
+    variable/units/labels/...), alternative signal processing, extraction/analysis parameters,
+    and the analysis-loop timer interval.
+
+    Note: extraction_parameters and analysis_parameters are SHARED objects, not independently
+    owned copies. PulseExtractor/PulseAnalyzer hold a reference to the exact same
+    ExtractionParameters/AnalysisParameters instance stored here and mutate it in place
+    (dict.__setitem__) as their real, live, authoritative state - see pulse_extractor.py/
+    pulse_analyzer.py. Because dataclasses.replace() leaves the object identity of any field it
+    doesn't touch untouched, swapping out some other field of this container (e.g. via
+    _apply_fast_counter_settings) never disturbs that shared reference. update_from_dict()
+    mirrors this: it mutates these two fields' dicts in place (dict.update()) rather than
+    replacing them with a freshly-constructed instance, precisely so PulseExtractor/
+    PulseAnalyzer's reference stays valid.
+
+    Note: sampling_information/measurement_information/generation_method_parameters are
+    intentionally NOT part of this container - they live on whichever PulseBlockEnsemble/
+    PulseSequence is currently loaded (owned/persisted by SequenceGeneratorLogic), and
+    PulsedMeasurementLogic exposes them as properties over a live `loaded_asset` reference
+    rather than an independently persisted copy - this is what actually eliminates the
+    save/load race that used to exist when that data was copied on every load instead.
+    """
+
+    microwave_settings: MicrowaveSettings
+    fast_counter_settings: FastCounterSettings
+    readout_settings: ReadoutSettings
+    alternate_signal_settings: AlternativeSignalSettings
+    extraction_parameters: ExtractionParameters
+    analysis_parameters: AnalysisParameters
+    timer_interval_s: float
+
+    def to_dict(self):
+        return {
+            'microwave_settings': self.microwave_settings.to_dict(),
+            'fast_counter_settings': self.fast_counter_settings.to_dict(),
+            'readout_settings': self.readout_settings.to_dict(),
+            'alternate_signal_settings': self.alternate_signal_settings.to_dict(),
+            'extraction_parameters': self.extraction_parameters.to_dict(),
+            'analysis_parameters': self.analysis_parameters.to_dict(),
+            'timer_interval_s': float(self.timer_interval_s),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            microwave_settings=MicrowaveSettings.from_dict(data['microwave_settings']),
+            fast_counter_settings=FastCounterSettings.from_dict(data['fast_counter_settings']),
+            readout_settings=ReadoutSettings.from_dict(data['readout_settings']),
+            alternate_signal_settings=AlternativeSignalSettings.from_dict(data['alternate_signal_settings']),
+            extraction_parameters=ExtractionParameters.from_dict(data['extraction_parameters']),
+            analysis_parameters=AnalysisParameters.from_dict(data['analysis_parameters']),
+            timer_interval_s=float(data['timer_interval_s']),
+        )
+
+    def update_from_dict(self, data):
+        microwave_settings = self.microwave_settings
+        if 'microwave_settings' in data:
+            value = data['microwave_settings']
+            microwave_settings = value if isinstance(value, MicrowaveSettings) else self.microwave_settings.update_from_dict(value)
+
+        fast_counter_settings = self.fast_counter_settings
+        if 'fast_counter_settings' in data:
+            value = data['fast_counter_settings']
+            fast_counter_settings = (
+                value if isinstance(value, FastCounterSettings) else self.fast_counter_settings.update_from_dict(value)
+            )
+
+        readout_settings = self.readout_settings
+        if 'readout_settings' in data:
+            value = data['readout_settings']
+            readout_settings = value if isinstance(value, ReadoutSettings) else self.readout_settings.update_from_dict(value)
+
+        alternate_signal_settings = self.alternate_signal_settings
+        if 'alternate_signal_settings' in data:
+            value = data['alternate_signal_settings']
+            alternate_signal_settings = (
+                value
+                if isinstance(value, AlternativeSignalSettings)
+                else self.alternate_signal_settings.update_from_dict(value)
+            )
+
+        # extraction_parameters/analysis_parameters are shared objects (see class docstring):
+        # mutate the existing dict in place, never replace the reference.
+        if 'extraction_parameters' in data:
+            value = data['extraction_parameters']
+            self.extraction_parameters.update(value if isinstance(value, dict) else ExtractionParameters.from_dict(value))
+
+        if 'analysis_parameters' in data:
+            value = data['analysis_parameters']
+            self.analysis_parameters.update(value if isinstance(value, dict) else AnalysisParameters.from_dict(value))
+
+        timer_interval_s = float(data.get('timer_interval_s', self.timer_interval_s))
+
+        return replace(
+            self,
+            microwave_settings=microwave_settings,
+            fast_counter_settings=fast_counter_settings,
+            readout_settings=readout_settings,
+            alternate_signal_settings=alternate_signal_settings,
+            timer_interval_s=timer_interval_s,
+        )
 

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -19,8 +19,9 @@ See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along with qudi.
 If not, see <https://www.gnu.org/licenses/>.
 """
-from dataclasses import dataclass, replace, field, fields
+from dataclasses import dataclass, replace, field, fields, asdict
 from typing import ClassVar, Optional
+import pprint
 import time
 import numpy as np
 
@@ -119,6 +120,9 @@ class ReadoutSettings:
     labels: tuple[str, str]
 
     def __post_init__(self):
+        # Copy first so freezing this array's writeable flag never affects a shared/live array
+        # some future caller might construct this with directly.
+        object.__setattr__(self, 'controlled_variable', self.controlled_variable.copy())
         self.controlled_variable.flags.writeable = False
 
     
@@ -434,16 +438,9 @@ class MeasurementInformation:
 
 
 class AnalysisParameters(dict):
-    """dict-based structured container for the persisted PulseAnalyzer settings: the keyword
-    argument values collected for all known analysis methods, plus the name of the currently
-    selected method under the 'method' key.
-
-    This stays a dict subclass (the same pattern as SequenceStep in pulse_objects.py) rather
-    than a plain dataclass because PulseAnalyzer reads and mutates it directly as an ordinary
-    dict (isinstance(..., dict) checks, "del container[param]", "for p in container" - see
-    pulse_analyzer.py). Subclassing dict keeps that code working unchanged while giving the
-    container a name, a docstring, and named read access via .method/.parameters.
-    """
+    """Persisted PulseAnalyzer settings: analysis method kwargs plus the selected method under
+    'method'. Stays a dict subclass (not a plain dataclass) because pulse_analyzer.py reads/
+    mutates it directly as an ordinary dict."""
 
     @property
     def method(self):
@@ -501,6 +498,23 @@ class GenerationMethodParameters(dict):
         return cls(data) if isinstance(data, dict) else cls()
 
 
+class MetadataDictRepresentation(dict):
+    """A dict whose repr() is pretty-printed (multi-line, indented) instead of the default
+    single-line dict repr.
+
+    qudi's DataStorage header writer (qudi.util.datastorage) renders every saved-file metadata
+    value via plain repr() and then prefixes each resulting physical line with the file's
+    comment marker. A plain dict's repr() never inserts line breaks no matter how deeply nested
+    it is, so a big settings dict ends up as one unreadable wall-of-text line. Wrapping such a
+    dict in this class instead makes repr() return pprint-formatted text - which does contain
+    real line breaks - so the existing line-by-line comment-prefixing already handles it, with
+    no changes needed to DataStorage itself.
+    """
+
+    def __repr__(self):
+        return pprint.pformat(dict(self), indent=2, sort_dicts=False, width=100)
+
+
 # Default sub-settings for PulsedMeasurementSettings.from_dict()'s per-field fallbacks (a saved
 # settings file predating a given field) and for pulsed_measurement_logic.py's
 # _default_measurement_settings() (a brand new settings object). Defined once, here, since
@@ -524,36 +538,19 @@ _DEFAULT_ALTERNATE_SIGNAL_SETTINGS = AlternativeSignalSettings(alternative_data_
 
 @dataclass(frozen=True)
 class PulsedMeasurementSettings:
-    """Single settings container bundling everything PulsedMeasurementLogic persists as
-    user-configurable settings: external microwave, fast counter, readout (controlled
-    variable/units/labels/...), alternative signal processing, extraction/analysis parameters,
-    the analysis-loop timer interval, and the available data-fit configurations.
+    """Settings PulsedMeasurementLogic persists: microwave, fast counter, readout, alternative
+    signal processing, extraction/analysis parameters.
 
-    Note: extraction_parameters and analysis_parameters are SHARED objects, not independently
-    owned copies. PulseExtractor/PulseAnalyzer hold a reference to the exact same
-    ExtractionParameters/AnalysisParameters instance stored here and mutate it in place
-    (dict.__setitem__) as their real, live, authoritative state - see pulse_extractor.py/
-    pulse_analyzer.py. Because dataclasses.replace() leaves the object identity of any field it
-    doesn't touch untouched, swapping out some other field of this container (e.g. via
-    _apply_fast_counter_settings) never disturbs that shared reference. update_from_dict()
-    mirrors this: it mutates these two fields' dicts in place (dict.update()) rather than
-    replacing them with a freshly-constructed instance, precisely so PulseExtractor/
-    PulseAnalyzer's reference stays valid.
+    extraction_parameters/analysis_parameters are SHARED, live objects - PulseExtractor/
+    PulseAnalyzer mutate them in place, so update_from_dict() mutates them in place too rather
+    than replacing the reference.
 
-    Note: fit_configs is NOT a shared object like the two fields above - it's a plain value
-    (a tuple of FitConfiguration.to_dict()-shaped dicts). PulsedMeasurementLogic's
-    FitConfigurationsModel (from qudi.util.datafitting, in the separately-installed qudi-core
-    package) keeps its own internal storage behind Qt's row-based model API, which this
-    dataclass cannot hold a live reference into - instead, PulsedMeasurementLogic listens for
-    FitConfigurationsModel.sigFitConfigurationsChanged and replaces this field wholesale via
-    _apply_fit_configs() whenever the model's contents change (e.g. from GUI edits).
+    timer_interval_s/fit_configs/pulser_benchmarks are deliberately NOT here - they're
+    operational bookkeeping, persisted as independent StatusVars on their owning logic module.
 
-    Note: sampling_information/measurement_information/generation_method_parameters are
-    intentionally NOT part of this container - they live on whichever PulseBlockEnsemble/
-    PulseSequence is currently loaded (owned/persisted by SequenceGeneratorLogic), and
-    PulsedMeasurementLogic exposes them as properties over a live `loaded_asset` reference
-    rather than an independently persisted copy - this is what actually eliminates the
-    save/load race that used to exist when that data was copied on every load instead.
+    sampling_information/measurement_information/generation_method_parameters live on the loaded
+    asset (SequenceGeneratorLogic) and are exposed as properties here, not copied - avoids a
+    save/load race that existed when this data was copied on every load.
     """
 
     microwave_settings: MicrowaveSettings
@@ -562,8 +559,6 @@ class PulsedMeasurementSettings:
     alternate_signal_settings: AlternativeSignalSettings
     extraction_parameters: ExtractionParameters
     analysis_parameters: AnalysisParameters
-    timer_interval_s: float
-    fit_configs: tuple
 
     def to_dict(self):
         return {
@@ -573,14 +568,12 @@ class PulsedMeasurementSettings:
             'alternate_signal_settings': self.alternate_signal_settings.to_dict(),
             'extraction_parameters': self.extraction_parameters.to_dict(),
             'analysis_parameters': self.analysis_parameters.to_dict(),
-            'timer_interval_s': float(self.timer_interval_s),
-            'fit_configs': tuple(self.fit_configs),
         }
 
     @classmethod
     def from_dict(cls, data):
         """Tolerant of a saved dict missing keys added after it was written (e.g. an older save
-        file that predates fit_configs being added to this class) - falls back to that field's
+        file that predates a field being added to this class) - falls back to that field's
         own default rather than raising KeyError. extraction_parameters/analysis_parameters
         don't need an explicit fallback here: ExtractionParameters.from_dict()/
         AnalysisParameters.from_dict() already return an empty container for non-dict input
@@ -610,13 +603,81 @@ class PulsedMeasurementSettings:
             ),
             extraction_parameters=ExtractionParameters.from_dict(data.get('extraction_parameters')),
             analysis_parameters=AnalysisParameters.from_dict(data.get('analysis_parameters')),
-            timer_interval_s=float(data.get('timer_interval_s', 5.0)),
-            # A missing key here means an older save file that predates fit_configs - it
-            # genuinely had zero fit configs of its own, so the correct fallback is an empty
-            # tuple, NOT qudi's shipped default fit configs (that fuller default belongs in
-            # _default_measurement_settings(), for a brand new settings object).
-            fit_configs=tuple(data.get('fit_configs', ())),
         )
+
+    #: Top-level status-file key names used by the ~20 individually-declared StatusVars that
+    #: existed on PulsedMeasurementLogic before this class was introduced (one file-level key
+    #: per StatusVar, instead of everything nested under a single '_settings' key). Used only to
+    #: detect a pre-refactor status file - see PulsedMeasurementLogic._migrate_legacy_settings_if_needed().
+    LEGACY_STATUS_VAR_KEYS = frozenset({
+        '_PulsedMeasurementLogic__microwave_power',
+        '_PulsedMeasurementLogic__microwave_freq',
+        '_PulsedMeasurementLogic__use_ext_microwave',
+        '_PulsedMeasurementLogic__fast_counter_record_length',
+        '_PulsedMeasurementLogic__fast_counter_binwidth',
+        '_PulsedMeasurementLogic__fast_counter_gates',
+        '_PulsedMeasurementLogic__timer_interval',
+        '_invoke_settings_from_sequence',
+        '_number_of_lasers',
+        '_controlled_variable',
+        '_alternating',
+        '_laser_ignore_list',
+        '_data_units',
+        '_data_labels',
+        'extraction_parameters',
+        'analysis_parameters',
+        'fit_configs',
+        '_alternative_data_type',
+        'zeropad',
+        'psd',
+        'window',
+        'base_corr',
+    })
+
+    @classmethod
+    def from_legacy_dict(cls, raw):
+        """Reconstruct settings from the pre-refactor flat, individually-StatusVar'd format
+        (key names below are the exact, name-mangled-where-applicable old StatusVar names).
+
+        is_gated stays at its default: the old format never persisted it (always a live hardware
+        query), and on_activate() re-syncs it from hardware right after this runs anyway.
+
+        '_PulsedMeasurementLogic__timer_interval'/'fit_configs' are still in
+        LEGACY_STATUS_VAR_KEYS (valid legacy-format signals) but deliberately not reconstructed
+        here - PulsedMeasurementLogic._migrate_legacy_settings_if_needed() migrates those two
+        directly into its own independent StatusVars instead.
+        """
+        return cls.from_dict({
+            'microwave_settings': {
+                'power': raw.get('_PulsedMeasurementLogic__microwave_power', -30.0),
+                'frequency': raw.get('_PulsedMeasurementLogic__microwave_freq', 2870e6),
+                'use_ext_microwave': raw.get('_PulsedMeasurementLogic__use_ext_microwave', False),
+            },
+            'fast_counter_settings': {
+                'bin_width': raw.get('_PulsedMeasurementLogic__fast_counter_binwidth', 1.0e-9),
+                'record_length': raw.get('_PulsedMeasurementLogic__fast_counter_record_length', 3.0e-6),
+                'number_of_gates': raw.get('_PulsedMeasurementLogic__fast_counter_gates', 0),
+                'is_gated': False,
+            },
+            'readout_settings': {
+                'invoke_settings': raw.get('_invoke_settings_from_sequence', False),
+                'controlled_variable': raw.get('_controlled_variable', list(range(50))),
+                'number_of_lasers': raw.get('_number_of_lasers', 50),
+                'laser_ignore_list': raw.get('_laser_ignore_list', []),
+                'alternating': raw.get('_alternating', False),
+                'units': raw.get('_data_units', ('s', '')),
+                'labels': raw.get('_data_labels', ('Tau', 'Signal')),
+            },
+            'alternate_signal_settings': {
+                'alternative_data_type': raw.get('_alternative_data_type'),
+                'zeropad': raw.get('zeropad', 0),
+                'psd': raw.get('psd', False),
+                'window': raw.get('window', 'none'),
+                'base_corr': raw.get('base_corr', True),
+            },
+            'extraction_parameters': raw.get('extraction_parameters'),
+            'analysis_parameters': raw.get('analysis_parameters'),
+        })
 
     def update_from_dict(self, data):
         microwave_settings = self.microwave_settings
@@ -655,16 +716,11 @@ class PulsedMeasurementSettings:
             value = data['analysis_parameters']
             self.analysis_parameters.update(value if isinstance(value, dict) else AnalysisParameters.from_dict(value))
 
-        timer_interval_s = float(data.get('timer_interval_s', self.timer_interval_s))
-        fit_configs = tuple(data.get('fit_configs', self.fit_configs))
-
         return replace(
             self,
             microwave_settings=microwave_settings,
             fast_counter_settings=fast_counter_settings,
             readout_settings=readout_settings,
             alternate_signal_settings=alternate_signal_settings,
-            timer_interval_s=timer_interval_s,
-            fit_configs=fit_configs,
         )
 

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -124,6 +124,10 @@ class ReadoutSettings:
         # some future caller might construct this with directly.
         object.__setattr__(self, 'controlled_variable', self.controlled_variable.copy())
         self.controlled_variable.flags.writeable = False
+        # Sorted here rather than only in update_from_dict() so the invariant holds for every
+        # construction path - from_dict(), replace(), and direct construction alike. sorted()
+        # also returns a new list, so a caller's live list can never alias our state.
+        object.__setattr__(self, 'laser_ignore_list', sorted(self.laser_ignore_list))
 
     
     def to_dict(self):

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 from dataclasses import dataclass, replace, field, fields, asdict
+from enum import Enum
 from typing import ClassVar, Optional
 import pprint
 import time
@@ -515,6 +516,70 @@ class MetadataDictRepresentation(dict):
 
     def __repr__(self):
         return pprint.pformat(dict(self), indent=2, sort_dicts=False, width=100)
+
+
+def to_plain_metadata(value):
+    """Recursively convert `value` into types whose repr() is valid Python needing no imports.
+
+    qudi.util.datastorage writes every saved-file metadata value with repr() and reads it back with
+    a bare eval() (metadata_to_str_dict()/str_dict_to_metadata()). A repr that NAMES A TOOL instead
+    of spelling the value out therefore raises NameError on the way back in, and
+    str_dict_to_metadata() silently keeps the raw string rather than raising - so the value looks
+    fine in the file but arrives as a str, and a caller doing
+    metadata['generation parameters']['rabi_period'] fails far away from the cause with
+    "string indices must be integers". Three such reprs actually occur here:
+
+        array([0., 1., ...])                                     numpy arrays
+        np.int64(5943750)                                        numpy scalars (numpy >= 2.0)
+        qudi.logic.pulsed.sampling_functions.PulseEnvelope(...)   PulseEnvelope, and the
+                                                                 PulseEnvelopeType enum inside it
+
+    str_dict_to_metadata() does try importing the missing name once, but that cannot rescue any of
+    them: there is no module called "np"; importing "qudi" binds only the top-level package, not the
+    sampling_functions submodule the repr addresses; and "array" resolves to the *stdlib* array
+    module, whose array() then rejects the argument. Converting here - at the save boundary, so only
+    the header text is affected - makes the file self-describing instead, which also means it no
+    longer depends on numpy's repr staying stable across versions.
+
+    Also fixes a silent data loss unrelated to parsing: numpy summarises the repr of any array
+    longer than np.get_printoptions()['threshold'] (1000 by default) as
+    "array([0., 1., 2., ..., 1497., 1498., 1499.])". A controlled variable with more than 1000
+    points is therefore written to the header with its middle values already gone - unrecoverably,
+    since the text itself no longer contains them. tolist() writes all of them.
+
+    NOTE the branch order: dict/list/tuple/set are tested BEFORE the to_dict() duck-type at the
+    bottom, because AnalysisParameters/ExtractionParameters/GenerationMethodParameters are dict
+    subclasses that also define to_dict() (see this module's docstrings, and convention 5 in
+    pulsed_data/README.md) - matching them as dicts keeps their contents recursed instead of
+    bouncing through a redundant round trip.
+    """
+    if isinstance(value, np.ndarray):
+        return to_plain_metadata(value.tolist())
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {to_plain_metadata(key): to_plain_metadata(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_plain_metadata(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(to_plain_metadata(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        # Sorted rather than left as a set so the header text for identical settings is identical
+        # every run (set repr order is arbitrary), and so the value stays literal-parseable - an
+        # empty set reprs as "set()", which is a call, not a literal.
+        items = [to_plain_metadata(item) for item in value]
+        try:
+            return sorted(items)
+        except TypeError:
+            return items
+    if isinstance(value, Enum):
+        return to_plain_metadata(value.value)
+    # Duck-typed rather than importing PulseEnvelope: this file sits below sampling_functions.py in
+    # the layering, and any future metadata value offering to_dict() should convert the same way.
+    to_dict = getattr(value, 'to_dict', None)
+    if callable(to_dict):
+        return to_plain_metadata(to_dict())
+    return value
 
 
 # Default sub-settings for PulsedMeasurementSettings.from_dict()'s per-field fallbacks (a saved

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -207,7 +207,7 @@ class PulsedMeasurementData:
 class DataStashCache:
     """Manages the memory for stashed/recalled raw data."""
     cache: dict = field(default_factory=dict)
-    active_tag: str | None = None
+    active_tag: Optional[str] = None
 
     def stash(self, tag: str, raw_data: np.ndarray, sweeps: int, time_elapsed: float):
         self.cache[tag] = {
@@ -232,7 +232,7 @@ class DataStashCache:
 @dataclass(frozen=True)
 class AlternativeSignalSettings:
     """Settings for alternative signal processing methods."""
-    alternative_data_type: str|None
+    alternative_data_type: Optional[str]
     zeropad:int=0
     psd: bool=False
     window: str='none'
@@ -501,12 +501,33 @@ class GenerationMethodParameters(dict):
         return cls(data) if isinstance(data, dict) else cls()
 
 
+# Default sub-settings for PulsedMeasurementSettings.from_dict()'s per-field fallbacks (a saved
+# settings file predating a given field) and for pulsed_measurement_logic.py's
+# _default_measurement_settings() (a brand new settings object). Defined once, here, since
+# pulsed_measurement_logic_data.py cannot import from pulsed_measurement_logic.py (that direction
+# would be circular) - this is the lower-level file, so it owns the shared literals instead.
+_DEFAULT_MICROWAVE_SETTINGS = MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False)
+_DEFAULT_FAST_COUNTER_SETTINGS = FastCounterSettings(
+    record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False
+)
+_DEFAULT_READOUT_SETTINGS = ReadoutSettings(
+    invoke_settings=False,
+    controlled_variable=np.array(list(range(50)), dtype=float),
+    number_of_lasers=50,
+    laser_ignore_list=list(),
+    alternating=False,
+    units=('s', ''),
+    labels=('Tau', 'Signal'),
+)
+_DEFAULT_ALTERNATE_SIGNAL_SETTINGS = AlternativeSignalSettings(alternative_data_type=None)
+
+
 @dataclass(frozen=True)
 class PulsedMeasurementSettings:
     """Single settings container bundling everything PulsedMeasurementLogic persists as
     user-configurable settings: external microwave, fast counter, readout (controlled
     variable/units/labels/...), alternative signal processing, extraction/analysis parameters,
-    and the analysis-loop timer interval.
+    the analysis-loop timer interval, and the available data-fit configurations.
 
     Note: extraction_parameters and analysis_parameters are SHARED objects, not independently
     owned copies. PulseExtractor/PulseAnalyzer hold a reference to the exact same
@@ -518,6 +539,14 @@ class PulsedMeasurementSettings:
     mirrors this: it mutates these two fields' dicts in place (dict.update()) rather than
     replacing them with a freshly-constructed instance, precisely so PulseExtractor/
     PulseAnalyzer's reference stays valid.
+
+    Note: fit_configs is NOT a shared object like the two fields above - it's a plain value
+    (a tuple of FitConfiguration.to_dict()-shaped dicts). PulsedMeasurementLogic's
+    FitConfigurationsModel (from qudi.util.datafitting, in the separately-installed qudi-core
+    package) keeps its own internal storage behind Qt's row-based model API, which this
+    dataclass cannot hold a live reference into - instead, PulsedMeasurementLogic listens for
+    FitConfigurationsModel.sigFitConfigurationsChanged and replaces this field wholesale via
+    _apply_fit_configs() whenever the model's contents change (e.g. from GUI edits).
 
     Note: sampling_information/measurement_information/generation_method_parameters are
     intentionally NOT part of this container - they live on whichever PulseBlockEnsemble/
@@ -534,6 +563,7 @@ class PulsedMeasurementSettings:
     extraction_parameters: ExtractionParameters
     analysis_parameters: AnalysisParameters
     timer_interval_s: float
+    fit_configs: tuple
 
     def to_dict(self):
         return {
@@ -544,18 +574,48 @@ class PulsedMeasurementSettings:
             'extraction_parameters': self.extraction_parameters.to_dict(),
             'analysis_parameters': self.analysis_parameters.to_dict(),
             'timer_interval_s': float(self.timer_interval_s),
+            'fit_configs': tuple(self.fit_configs),
         }
 
     @classmethod
     def from_dict(cls, data):
+        """Tolerant of a saved dict missing keys added after it was written (e.g. an older save
+        file that predates fit_configs being added to this class) - falls back to that field's
+        own default rather than raising KeyError. extraction_parameters/analysis_parameters
+        don't need an explicit fallback here: ExtractionParameters.from_dict()/
+        AnalysisParameters.from_dict() already return an empty container for non-dict input
+        (including None from a missing key), so data.get(...) with no second argument is
+        sufficient.
+        """
         return cls(
-            microwave_settings=MicrowaveSettings.from_dict(data['microwave_settings']),
-            fast_counter_settings=FastCounterSettings.from_dict(data['fast_counter_settings']),
-            readout_settings=ReadoutSettings.from_dict(data['readout_settings']),
-            alternate_signal_settings=AlternativeSignalSettings.from_dict(data['alternate_signal_settings']),
-            extraction_parameters=ExtractionParameters.from_dict(data['extraction_parameters']),
-            analysis_parameters=AnalysisParameters.from_dict(data['analysis_parameters']),
-            timer_interval_s=float(data['timer_interval_s']),
+            microwave_settings=(
+                MicrowaveSettings.from_dict(data['microwave_settings'])
+                if 'microwave_settings' in data
+                else _DEFAULT_MICROWAVE_SETTINGS
+            ),
+            fast_counter_settings=(
+                FastCounterSettings.from_dict(data['fast_counter_settings'])
+                if 'fast_counter_settings' in data
+                else _DEFAULT_FAST_COUNTER_SETTINGS
+            ),
+            readout_settings=(
+                ReadoutSettings.from_dict(data['readout_settings'])
+                if 'readout_settings' in data
+                else _DEFAULT_READOUT_SETTINGS
+            ),
+            alternate_signal_settings=(
+                AlternativeSignalSettings.from_dict(data['alternate_signal_settings'])
+                if 'alternate_signal_settings' in data
+                else _DEFAULT_ALTERNATE_SIGNAL_SETTINGS
+            ),
+            extraction_parameters=ExtractionParameters.from_dict(data.get('extraction_parameters')),
+            analysis_parameters=AnalysisParameters.from_dict(data.get('analysis_parameters')),
+            timer_interval_s=float(data.get('timer_interval_s', 5.0)),
+            # A missing key here means an older save file that predates fit_configs - it
+            # genuinely had zero fit configs of its own, so the correct fallback is an empty
+            # tuple, NOT qudi's shipped default fit configs (that fuller default belongs in
+            # _default_measurement_settings(), for a brand new settings object).
+            fit_configs=tuple(data.get('fit_configs', ())),
         )
 
     def update_from_dict(self, data):
@@ -596,6 +656,7 @@ class PulsedMeasurementSettings:
             self.analysis_parameters.update(value if isinstance(value, dict) else AnalysisParameters.from_dict(value))
 
         timer_interval_s = float(data.get('timer_interval_s', self.timer_interval_s))
+        fit_configs = tuple(data.get('fit_configs', self.fit_configs))
 
         return replace(
             self,
@@ -604,5 +665,6 @@ class PulsedMeasurementSettings:
             readout_settings=readout_settings,
             alternate_signal_settings=alternate_signal_settings,
             timer_interval_s=timer_interval_s,
+            fit_configs=fit_configs,
         )
 

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -3,6 +3,10 @@ import time
 import numpy as np
 
 
+##############################################################################
+#   The following dataclasses are for the PulsedMeasurementLogic class and   #
+# are used to store and manage the settings and data for pulsed measurements #                                                
+##############################################################################
 def _as_bool(value):
     """Converts a value to a boolean. If the value is a string, 
     it checks for common truthy values.
@@ -182,7 +186,7 @@ class PulsedMeasurementData:
 class DataStashCache:
     """Manages the memory for stashed/recalled raw data."""
     cache: dict = field(default_factory=dict)
-    active_tag: str = None
+    active_tag: str | None = None
 
     def stash(self, tag: str, raw_data: np.ndarray, sweeps: int, time_elapsed: float):
         self.cache[tag] = {
@@ -200,6 +204,9 @@ class DataStashCache:
 
     def clear_active(self):
         self.active_tag = None
+
+    def get_active(self):
+        return self.cache.get(self.active_tag, None)
 
 @dataclass(frozen=True)
 class AlternativeSignalSettings:
@@ -221,7 +228,7 @@ class AlternativeSignalSettings:
     @classmethod
     def from_dict(cls, data: dict):
         return cls(
-            alternative_data_type=str(data.get('alternative_data_type', 'None')),
+            alternative_data_type=data.get('alternative_data_type', None),
             zeropad=int(data.get('zeropad', 0)),
             psd=_as_bool(data.get('psd', False)),
             window=str(data.get('window', 'none')),
@@ -231,7 +238,7 @@ class AlternativeSignalSettings:
     def update_from_dict(self, data: dict):
         return replace(
             self,
-            alternative_data_type=str(data.get('alternative_data_type', self.alternative_data_type)),
+            alternative_data_type=data.get('alternative_data_type', self.alternative_data_type),
             zeropad=int(data.get('zeropad', self.zeropad)),
             psd=_as_bool(data.get('psd', self.psd)),
             window=str(data.get('window', self.window)),
@@ -246,15 +253,11 @@ class ExecutionState:
     start_time: float = 0.0
     time_of_pause: float = 0.0
     elapsed_pause: float = 0.0
-    timer_interval_s: float = 5.0  # e.g., default 5 seconds
+    timer_interval_s: float = 5.0  # default 5 seconds
 
     @property
     def elapsed_time(self) -> float:
         return self.get_live_elapsed_time()
-
-    @property
-    def elapsed_sweeps(self) -> int:
-        return 0
 
     def start(self):
         """Called when a new measurement begins."""
@@ -290,35 +293,3 @@ class FitDefinition:
     estimator: str = 'default'
     custom_parameters: dict | None = None
 
-@dataclass(frozen=True)
-class AnalysisSettings:
-    """Serializable analysis parameters for the pulse analyzer."""
-
-    parameters: dict = field(default_factory=dict)
-
-    def to_dict(self) -> dict:
-        return dict(self.parameters)
-
-    @classmethod
-    def from_dict(cls, data: dict | None = None):
-        return cls(parameters=dict(data or {}))
-
-    def update_from_dict(self, data: dict | None = None):
-        return replace(self, parameters={**self.parameters, **dict(data or {})})
-
-
-@dataclass(frozen=True)
-class ExtractionSettings:
-    """Serializable extraction parameters for the pulse extractor."""
-
-    parameters: dict = field(default_factory=dict)
-
-    def to_dict(self) -> dict:
-        return dict(self.parameters)
-
-    @classmethod
-    def from_dict(cls, data: dict | None = None):
-        return cls(parameters=dict(data or {}))
-
-    def update_from_dict(self, data: dict | None = None):
-        return replace(self, parameters={**self.parameters, **dict(data or {})})

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -1,0 +1,324 @@
+from dataclasses import dataclass, replace, field
+import time
+import numpy as np
+
+
+def _as_bool(value):
+    """Converts a value to a boolean. If the value is a string, 
+    it checks for common truthy values.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+#done
+@dataclass(frozen=True)
+class FastCounterSettings:
+    """Settings used to configure and describe the fast counter."""
+
+    bin_width: float
+    record_length: float
+    number_of_gates: int
+    is_gated: bool
+
+    def to_dict(self):
+        return {
+            'bin_width': self.bin_width,
+            'record_length': self.record_length,
+            'number_of_gates': self.number_of_gates,
+            'is_gated': self.is_gated,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            bin_width=float(data['bin_width']),
+            record_length=float(data['record_length']),
+            number_of_gates=int(data['number_of_gates']),
+            is_gated=_as_bool(data['is_gated']),
+        )
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            bin_width=float(data.get('bin_width', self.bin_width)),
+            record_length=float(data.get('record_length', self.record_length)),
+            number_of_gates=int(data.get('number_of_gates', self.number_of_gates)),
+            is_gated=_as_bool(data.get('is_gated', self.is_gated)),
+        )
+
+
+#Done
+@dataclass(frozen=True)
+class MicrowaveSettings:
+    """External microwave settings used during a pulsed measurement."""
+
+    power: float
+    frequency: float
+    use_ext_microwave: bool
+
+    def to_dict(self):
+        return {
+            'power': self.power,
+            'frequency': self.frequency,
+            'use_ext_microwave': self.use_ext_microwave,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            power=float(data['power']),
+            frequency=float(data['frequency']),
+            use_ext_microwave=_as_bool(data['use_ext_microwave']),
+        )
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            power=float(data.get('power', self.power)),
+            frequency=float(data.get('frequency', self.frequency)),
+            use_ext_microwave=_as_bool(data.get('use_ext_microwave', self.use_ext_microwave)),
+        )
+
+
+@dataclass(frozen=True)
+class PulsedMeasurementSettings:
+    """User-facing settings that define how a pulsed measurement is analyzed."""
+
+    invoke_settings: bool
+    controlled_variable: np.ndarray
+    number_of_lasers: int
+    laser_ignore_list: list[int]
+    alternating: bool
+    units: tuple[str, str]
+    labels: tuple[str, str]
+
+    def __post_init__(self):
+        self.controlled_variable.flags.writeable = False
+
+    
+    def to_dict(self):
+        return {
+            'invoke_settings': self.invoke_settings,
+            'controlled_variable': self.controlled_variable.copy(),
+            'number_of_lasers': self.number_of_lasers,
+            'laser_ignore_list': self.laser_ignore_list.copy(),
+            'alternating': self.alternating,
+            'units': self.units,
+            'labels': self.labels,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            invoke_settings=_as_bool(data['invoke_settings']),
+            controlled_variable=np.array(data['controlled_variable'], dtype=float),
+            number_of_lasers=int(data['number_of_lasers']),
+            laser_ignore_list=sorted(data['laser_ignore_list']),
+            alternating=_as_bool(data['alternating']),
+            units=tuple(data['units']),
+            labels=tuple(data['labels']),
+        )
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            invoke_settings=_as_bool(data.get('invoke_settings', self.invoke_settings)),
+            controlled_variable=np.array(data.get('controlled_variable', self.controlled_variable), dtype=float),
+            number_of_lasers=int(data.get('number_of_lasers', self.number_of_lasers)),
+            laser_ignore_list=sorted(data.get('laser_ignore_list', self.laser_ignore_list)),
+            alternating=_as_bool(data.get('alternating', self.alternating)),
+            units=tuple(data.get('units', self.units)),
+            labels=tuple(data.get('labels', self.labels)),
+        )
+
+
+@dataclass
+class PulsedMeasurementData:
+    """Arrays and timing information that make up the current pulsed measurement."""
+
+    raw_data: np.ndarray
+    laser_data: np.ndarray
+    signal_data: np.ndarray
+    signal_alt_data: np.ndarray
+    measurement_error: np.ndarray
+    elapsed_time: float =0.0
+    elapsed_sweeps: int=0
+
+    def copy(self):
+        return type(self)(
+            raw_data=self.raw_data.copy(),
+            laser_data=self.laser_data.copy(),
+            signal_data=self.signal_data.copy(),
+            signal_alt_data=self.signal_alt_data.copy(),
+            measurement_error=self.measurement_error.copy(),
+            elapsed_time=float(self.elapsed_time),
+            elapsed_sweeps=int(self.elapsed_sweeps),
+        )
+
+    def to_dict(self):
+        return {
+            'raw_data': self.raw_data.copy(),
+            'laser_data': self.laser_data.copy(),
+            'signal_data': self.signal_data.copy(),
+            'signal_alt_data': self.signal_alt_data.copy(),
+            'measurement_error': self.measurement_error.copy(),
+            'elapsed_time': self.elapsed_time,
+            'elapsed_sweeps': self.elapsed_sweeps,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            raw_data=np.array(data['raw_data']),
+            laser_data=np.array(data['laser_data']),
+            signal_data=np.array(data['signal_data'], dtype=float),
+            signal_alt_data=np.array(data['signal_alt_data'], dtype=float),
+            measurement_error=np.array(data['measurement_error'], dtype=float),
+            elapsed_time=float(data['elapsed_time']),
+            elapsed_sweeps=int(data['elapsed_sweeps']),
+        )
+@dataclass
+class DataStashCache:
+    """Manages the memory for stashed/recalled raw data."""
+    cache: dict = field(default_factory=dict)
+    active_tag: str = None
+
+    def stash(self, tag: str, raw_data: np.ndarray, sweeps: int, time_elapsed: float):
+        self.cache[tag] = {
+            'data': raw_data.copy(),
+            'elapsed_sweeps': sweeps,
+            'elapsed_time': time_elapsed
+        }
+
+    def recall(self, tag: str):
+        if tag in self.cache:
+            self.active_tag = tag
+            return self.cache[tag]
+        self.active_tag = None
+        return None
+
+    def clear_active(self):
+        self.active_tag = None
+
+@dataclass(frozen=True)
+class AlternativeSignalSettings:
+    """Settings for alternative signal processing methods."""
+    alternative_data_type: str|None
+    zeropad:int=0
+    psd: bool=False
+    window: str='none'
+    base_corr: bool=True
+    def to_dict(self) -> dict:
+        return {
+            'alternative_data_type': self.alternative_data_type,
+            'zeropad': self.zeropad,
+            'psd': self.psd,
+            'window': self.window,
+            'base_corr': self.base_corr,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(
+            alternative_data_type=str(data.get('alternative_data_type', 'None')),
+            zeropad=int(data.get('zeropad', 0)),
+            psd=_as_bool(data.get('psd', False)),
+            window=str(data.get('window', 'none')),
+            base_corr=_as_bool(data.get('base_corr', True)),
+        )
+
+    def update_from_dict(self, data: dict):
+        return replace(
+            self,
+            alternative_data_type=str(data.get('alternative_data_type', self.alternative_data_type)),
+            zeropad=int(data.get('zeropad', self.zeropad)),
+            psd=_as_bool(data.get('psd', self.psd)),
+            window=str(data.get('window', self.window)),
+            base_corr=_as_bool(data.get('base_corr', self.base_corr)),
+        )
+
+@dataclass
+class ExecutionState:
+    """Manages the live running state, pausing, and timing of the measurement loop."""
+
+    is_paused: bool = False
+    start_time: float = 0.0
+    time_of_pause: float = 0.0
+    elapsed_pause: float = 0.0
+    timer_interval_s: float = 5.0  # e.g., default 5 seconds
+
+    @property
+    def elapsed_time(self) -> float:
+        return self.get_live_elapsed_time()
+
+    @property
+    def elapsed_sweeps(self) -> int:
+        return 0
+
+    def start(self):
+        """Called when a new measurement begins."""
+        self.is_paused = False
+        self.start_time = time.time()
+        self.time_of_pause = 0.0
+        self.elapsed_pause = 0.0
+
+    def pause(self):
+        """Called when the user hits pause."""
+        if not self.is_paused:
+            self.is_paused = True
+            self.time_of_pause = time.time()
+
+    def unpause(self):
+        """Called when the user resumes."""
+        if self.is_paused:
+            self.is_paused = False
+            # Push the start time forward so the pause duration isn't counted
+            self.start_time += (time.time() - self.time_of_pause)
+            
+    def get_live_elapsed_time(self) -> float:
+        """Calculates the true running time, ignoring pauses."""
+        if self.is_paused:
+            return self.time_of_pause - self.start_time
+        return time.time() - self.start_time
+    
+@dataclass(frozen=True)
+class FitDefinition:
+    """Definition for default fit configurations"""
+    name: str
+    model: str
+    estimator: str = 'default'
+    custom_parameters: dict | None = None
+
+@dataclass(frozen=True)
+class AnalysisSettings:
+    """Serializable analysis parameters for the pulse analyzer."""
+
+    parameters: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return dict(self.parameters)
+
+    @classmethod
+    def from_dict(cls, data: dict | None = None):
+        return cls(parameters=dict(data or {}))
+
+    def update_from_dict(self, data: dict | None = None):
+        return replace(self, parameters={**self.parameters, **dict(data or {})})
+
+
+@dataclass(frozen=True)
+class ExtractionSettings:
+    """Serializable extraction parameters for the pulse extractor."""
+
+    parameters: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return dict(self.parameters)
+
+    @classmethod
+    def from_dict(cls, data: dict | None = None):
+        return cls(parameters=dict(data or {}))
+
+    def update_from_dict(self, data: dict | None = None):
+        return replace(self, parameters={**self.parameters, **dict(data or {})})

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -22,7 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 from dataclasses import dataclass, replace, field, fields, asdict
 from enum import Enum
 from typing import ClassVar, Optional
-import pprint
+import math
 import time
 import numpy as np
 
@@ -501,23 +501,6 @@ class GenerationMethodParameters(dict):
         return cls(data) if isinstance(data, dict) else cls()
 
 
-class MetadataDictRepresentation(dict):
-    """A dict whose repr() is pretty-printed (multi-line, indented) instead of the default
-    single-line dict repr.
-
-    qudi's DataStorage header writer (qudi.util.datastorage) renders every saved-file metadata
-    value via plain repr() and then prefixes each resulting physical line with the file's
-    comment marker. A plain dict's repr() never inserts line breaks no matter how deeply nested
-    it is, so a big settings dict ends up as one unreadable wall-of-text line. Wrapping such a
-    dict in this class instead makes repr() return pprint-formatted text - which does contain
-    real line breaks - so the existing line-by-line comment-prefixing already handles it, with
-    no changes needed to DataStorage itself.
-    """
-
-    def __repr__(self):
-        return pprint.pformat(dict(self), indent=2, sort_dicts=False, width=100)
-
-
 def to_plain_metadata(value):
     """Recursively convert `value` into types whose repr() is valid Python needing no imports.
 
@@ -527,19 +510,31 @@ def to_plain_metadata(value):
     str_dict_to_metadata() silently keeps the raw string rather than raising - so the value looks
     fine in the file but arrives as a str, and a caller doing
     metadata['generation parameters']['rabi_period'] fails far away from the cause with
-    "string indices must be integers". Three such reprs actually occur here:
+    "string indices must be integers". Four such reprs actually occur here:
 
         array([0., 1., ...])                                     numpy arrays
         np.int64(5943750)                                        numpy scalars (numpy >= 2.0)
         qudi.logic.pulsed.sampling_functions.PulseEnvelope(...)   PulseEnvelope, and the
                                                                  PulseEnvelopeType enum inside it
+        nan / inf / -inf                                         non-finite floats
 
     str_dict_to_metadata() does try importing the missing name once, but that cannot rescue any of
     them: there is no module called "np"; importing "qudi" binds only the top-level package, not the
-    sampling_functions submodule the repr addresses; and "array" resolves to the *stdlib* array
-    module, whose array() then rejects the argument. Converting here - at the save boundary, so only
-    the header text is affected - makes the file self-describing instead, which also means it no
-    longer depends on numpy's repr staying stable across versions.
+    sampling_functions submodule the repr addresses; "array" resolves to the *stdlib* array module,
+    whose array() then rejects the argument; and there is no module called "nan" either. Converting
+    here - at the save boundary, so only the header text is affected - makes the file
+    self-describing instead, which also means it no longer depends on numpy's repr staying stable
+    across versions.
+
+    The non-finite floats are the one case that changes the value's TYPE (float -> str), and that is
+    unavoidable rather than a preference: Python has no literal for nan or inf, so no value that is
+    still a float can repr as something eval() resolves. They are written as 'nan'/'inf'/'-inf' and
+    a reader recovers the number with float(v). Writing None instead would have collapsed the three
+    cases together; a float subclass with a constructor-shaped __repr__ was rejected as not worth a
+    class. This matters more than it looks: PulseGeneratorSettings.upload_speed is nan until the
+    pulse generator has been benchmarked (PulserBenchmarks.estimate_combined_speed()), so before
+    this branch existed EVERY saved file on a fresh install had its whole 'pulsed measurement
+    settings' block come back as an unparsed str - one leaf poisons the entire key.
 
     Also fixes a silent data loss unrelated to parsing: numpy summarises the repr of any array
     longer than np.get_printoptions()['threshold'] (1000 by default) as
@@ -556,7 +551,12 @@ def to_plain_metadata(value):
     if isinstance(value, np.ndarray):
         return to_plain_metadata(value.tolist())
     if isinstance(value, np.generic):
-        return value.item()
+        # Recursed rather than returned directly (like the ndarray branch above) so a numpy nan/inf
+        # reaches the non-finite branch below instead of leaving here as a raw Python float.
+        return to_plain_metadata(value.item())
+    if isinstance(value, float) and not math.isfinite(value):
+        # 'nan' / 'inf' / '-inf' - see the fourth row of the table in this docstring.
+        return repr(value)
     if isinstance(value, dict):
         return {to_plain_metadata(key): to_plain_metadata(item) for key, item in value.items()}
     if isinstance(value, list):

--- a/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/pulsed_measurement_logic_data.py
@@ -1,21 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains the dataclasses used by PulsedMeasurementLogic to store and manage its
+settings and data for pulsed measurements.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
 from dataclasses import dataclass, replace, field
+from typing import ClassVar, Optional
 import time
 import numpy as np
 
 
 ##############################################################################
 #   The following dataclasses are for the PulsedMeasurementLogic class and   #
-# are used to store and manage the settings and data for pulsed measurements #                                                
+# are used to store and manage the settings and data for pulsed measurements #
 ##############################################################################
 def _as_bool(value):
-    """Converts a value to a boolean. If the value is a string, 
+    """Converts a value to a boolean. If the value is a string,
     it checks for common truthy values.
     """
     if isinstance(value, str):
         return value.strip().lower() in {'1', 'true', 'yes', 'on'}
     return bool(value)
 
-#done
+
 @dataclass(frozen=True)
 class FastCounterSettings:
     """Settings used to configure and describe the fast counter."""
@@ -52,7 +74,6 @@ class FastCounterSettings:
         )
 
 
-#Done
 @dataclass(frozen=True)
 class MicrowaveSettings:
     """External microwave settings used during a pulsed measurement."""
@@ -284,12 +305,133 @@ class ExecutionState:
         if self.is_paused:
             return self.time_of_pause - self.start_time
         return time.time() - self.start_time
-    
-@dataclass(frozen=True)
-class FitDefinition:
-    """Definition for default fit configurations"""
-    name: str
-    model: str
-    estimator: str = 'default'
-    custom_parameters: dict | None = None
+
+
+@dataclass
+class MeasurementInformation:
+    """Metadata about the currently loaded pulse block ensemble/sequence (number of laser
+    pulses, controlled variable array, etc.), used to auto-populate PulsedMeasurementSettings
+    when 'invoke_settings' is enabled.
+
+    All fields default to None ("not yet available"). Use is_valid (or plain bool(...), which
+    mirrors it) to check whether enough information is present to invoke measurement settings -
+    this replaces the previous "check 5 required keys are present in a plain dict" convention.
+    """
+    number_of_lasers: Optional[int] = None
+    controlled_variable: Optional[np.ndarray] = None
+    laser_ignore_list: Optional[list] = None
+    alternating: Optional[bool] = None
+    counting_length: Optional[float] = None
+    units: Optional[tuple] = None
+    labels: Optional[tuple] = None
+
+    _MANDATORY_FIELDS: ClassVar[tuple] = (
+        'number_of_lasers', 'controlled_variable', 'laser_ignore_list', 'alternating', 'counting_length'
+    )
+
+    @property
+    def is_valid(self) -> bool:
+        """True only if every field required to invoke measurement settings is present."""
+        return all(getattr(self, name) is not None for name in self._MANDATORY_FIELDS)
+
+    def __bool__(self):
+        return self.is_valid
+
+    def to_dict(self) -> dict:
+        if not self.is_valid:
+            return {}
+        data = {
+            'number_of_lasers': self.number_of_lasers,
+            'controlled_variable': self.controlled_variable,
+            'laser_ignore_list': self.laser_ignore_list,
+            'alternating': self.alternating,
+            'counting_length': self.counting_length,
+        }
+        if self.units is not None:
+            data['units'] = self.units
+        if self.labels is not None:
+            data['labels'] = self.labels
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        if not isinstance(data, dict) or not all(data.get(key) is not None for key in cls._MANDATORY_FIELDS):
+            return cls()
+        return cls(
+            number_of_lasers=int(data['number_of_lasers']),
+            controlled_variable=data['controlled_variable'],
+            laser_ignore_list=list(data['laser_ignore_list']),
+            alternating=bool(data['alternating']),
+            counting_length=float(data['counting_length']),
+            units=tuple(data['units']) if data.get('units') is not None else None,
+            labels=tuple(data['labels']) if data.get('labels') is not None else None,
+        )
+
+
+class AnalysisParameters(dict):
+    """dict-based structured container for the persisted PulseAnalyzer settings: the keyword
+    argument values collected for all known analysis methods, plus the name of the currently
+    selected method under the 'method' key.
+
+    This stays a dict subclass (the same pattern as SequenceStep in pulse_objects.py) rather
+    than a plain dataclass because PulseAnalyzer reads and mutates it directly as an ordinary
+    dict (isinstance(..., dict) checks, "del container[param]", "for p in container" - see
+    pulse_analyzer.py). Subclassing dict keeps that code working unchanged while giving the
+    container a name, a docstring, and named read access via .method/.parameters.
+    """
+
+    @property
+    def method(self):
+        """Name of the currently selected analysis method, or None if not set."""
+        return self.get('method')
+
+    @property
+    def parameters(self) -> dict:
+        """All method keyword-argument parameters, excluding the 'method' key itself."""
+        return {key: value for key, value in self.items() if key != 'method'}
+
+    def to_dict(self) -> dict:
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data) if isinstance(data, dict) else cls()
+
+
+class ExtractionParameters(dict):
+    """Same purpose as AnalysisParameters, but for the persisted PulseExtractor settings - see
+    pulse_extractor.py."""
+
+    @property
+    def method(self):
+        return self.get('method')
+
+    @property
+    def parameters(self) -> dict:
+        return {key: value for key, value in self.items() if key != 'method'}
+
+    def to_dict(self) -> dict:
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data) if isinstance(data, dict) else cls()
+
+
+class GenerationMethodParameters(dict):
+    """dict-based structured container for the keyword arguments used to (re-)generate the
+    currently loaded PulseBlockEnsemble/PulseSequence via a predefined generator method.
+
+    Kept as a dict subclass for the same reason as AnalysisParameters/ExtractionParameters:
+    PulseBlockEnsemble/PulseSequence (pulse_objects.py) already store this as a plain dict on
+    their own 'generation_method_parameters' attribute, and the parameter names vary freely
+    depending on which predefined generator method produced the ensemble/sequence.
+    """
+
+    def to_dict(self) -> dict:
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data) if isinstance(data, dict) else cls()
 

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -22,7 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 from dataclasses import dataclass, replace, field, fields
 from enum import Enum
 from logging import getLogger
-from typing import Optional, get_type_hints
+from typing import ClassVar, Optional, get_type_hints
 import numpy as np
 
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
@@ -645,9 +645,14 @@ class PulserBenchmarks:
 
 @dataclass(frozen=True)
 class EnsembleAnalysisResult:
-    """Result of analyzing a single PulseBlockEnsemble: sample/element counts, channel
-    transition timings and the generation parameters used, as returned by
-    SequenceGeneratorLogic.analyze_block_ensemble()."""
+    """Result of analyzing a single PulseBlockEnsemble: sample/element counts and channel
+    transition timings, as returned by SequenceGeneratorLogic.analyze_block_ensemble().
+
+    Deliberately carries no generation_parameters: those live only on
+    SequenceGeneratorSettings. This class used to hold a snapshot of them that nothing read,
+    and _dataclass_to_dict() dumps every field of it straight into SamplingInformation - which
+    is how a second, silently diverging copy ended up pickled into every saved asset. See
+    SamplingInformation below."""
 
     number_of_samples: int
     number_of_elements: int
@@ -657,7 +662,6 @@ class EnsembleAnalysisResult:
     analog_channels: set
     digital_channels: set
     channel_set: set
-    generation_parameters: GenerationParameters
     ideal_length: float
     laser_rising_bins: np.ndarray
     laser_falling_bins: np.ndarray
@@ -667,12 +671,12 @@ class EnsembleAnalysisResult:
 class SequenceAnalysisResult:
     """Result of analyzing a PulseSequence: the same information as
     EnsembleAnalysisResult, aggregated over the whole sequence plus broken down per step, as
-    returned by SequenceGeneratorLogic.analyze_sequence()."""
+    returned by SequenceGeneratorLogic.analyze_sequence(). Carries no generation_parameters, for
+    the reason given on EnsembleAnalysisResult."""
 
     digital_channels: set
     analog_channels: set
     channel_set: set
-    generation_parameters: GenerationParameters
     digital_rising_bins: dict
     digital_falling_bins: dict
     number_of_steps: int
@@ -722,6 +726,9 @@ class SamplingInformation:
     # - these two used to only arrive here implicitly, via that dump landing in _legacy_data
     # (since they weren't declared fields), rather than because they were designed to live here.
     # Read by pulse_extraction_methods/basic_extraction_methods.py's ungated_gated_conv_deriv().
+    # Declaring a field is one of the two ways to answer that accidental-arrival problem; the
+    # other is to refuse the key outright - see _REJECTED_KEYS below, which is what
+    # 'generation_parameters' got, since unlike these it had no reader at all.
     laser_rising_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
     laser_falling_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
 
@@ -731,6 +738,17 @@ class SamplingInformation:
 
     # Legacy fields catch-all (optional, to ensure no data is lost)
     _legacy_data: dict = field(default_factory=dict)
+
+    #: Keys refused by __setitem__/from_dict instead of being absorbed into _legacy_data.
+    #: 'generation_parameters' is here because those belong to SequenceGeneratorSettings and
+    #: nowhere else. It used to arrive by accident: analyze_block_ensemble()/analyze_sequence()
+    #: returned it as one field among many, and _dataclass_to_dict() dumps every field of that
+    #: result through from_dict() below - so an undeclared key landed in _legacy_data, got pickled
+    #: into every .ensemble/.sequence, and then diverged from the live settings the moment anyone
+    #: edited a generation parameter (nothing re-samples on that change, and the sequence sampling
+    #: cache does not key on it). Nothing ever read it back except one save-time fallback, now
+    #: gone. Refusing it here also strips it from assets pickled before that change, on load.
+    _REJECTED_KEYS: ClassVar[frozenset] = frozenset({'generation_parameters'})
 
     def __bool__(self):
         """
@@ -753,6 +771,8 @@ class SamplingInformation:
         raise KeyError(key)
 
     def __setitem__(self, key, value):
+        if key in self._REJECTED_KEYS:
+            return
         if key in self._field_names():
             setattr(self, key, value)
         else:
@@ -814,10 +834,14 @@ class SamplingInformation:
         # unrecognized keys on top.
         known_field_names = {f.name for f in fields(cls) if f.name != '_legacy_data'}
         init_kwargs = {}
-        legacy_kwargs = dict(data.get('_legacy_data') or {})
+        legacy_kwargs = {
+            key: value
+            for key, value in (data.get('_legacy_data') or {}).items()
+            if key not in cls._REJECTED_KEYS
+        }
 
         for key, value in data.items():
-            if key == '_legacy_data':
+            if key == '_legacy_data' or key in cls._REJECTED_KEYS:
                 continue
             elif key in known_field_names:
                 init_kwargs[key] = value

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -33,11 +33,31 @@ from qudi.util.benchmark import BenchmarkTool
 # merges with CoreGenerationParameters into the public GenerationParameters class. The base lives
 # over there so that file never has to import back from this one - a cycle would make the merge
 # silently skip extensions depending on which module happened to be imported first.
-from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import (
-    BaseGenerationParameters,
-    as_bool as _as_bool,
-)
-import qudi.logic.pulsed.pulsed_data.generation_parameter_extensions as _generation_parameter_extensions  # noqa: F401
+#
+# Wrapped so a mutable field default in a lab's contributor explains itself. @dataclass raises
+# that one while the module below is still being imported - long before _build_generation_parameters()
+# could inspect anything - so this import is the only place able to add context to it.
+try:
+    from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import (
+        BaseGenerationParameters,
+        as_bool as _as_bool,
+    )
+    import qudi.logic.pulsed.pulsed_data.generation_parameter_extensions as _generation_parameter_extensions  # noqa: F401
+except ValueError as err:
+    if 'mutable default' not in str(err):
+        raise
+    raise ValueError(
+        f'{err}\n\n'
+        'A generation parameter declared in generation_parameter_extensions.py has a mutable '
+        'default. One default object would be shared by every instance of the class, so Python '
+        'refuses the declaration. Give that field a factory instead:\n'
+        '    envelope: PulseEnvelope = field(\n'
+        '        default_factory=lambda: PulseEnvelope(PulseEnvelopeType.rectangle)\n'
+        '    )\n'
+        'PulseEnvelope needs this despite being a supported parameter type - it is a plain '
+        '@dataclass holding a parameters dict, so it counts as mutable. The same applies to a '
+        'dict, a list, a numpy array, or an instance of any class defining __eq__.'
+    ) from err
 
 _logger = getLogger(__name__)
 

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains the dataclasses used by SequenceGeneratorLogic to store and manage the
+settings for pulse/sequence object generation and the connected pulse generator hardware.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
 from dataclasses import dataclass, replace, field, fields
 from typing import Optional
 import numpy as np
@@ -363,12 +384,14 @@ class PulserBenchmarks:
         if ignore:
             return True
         return not np.isnan(self.estimate_combined_speed())
-    
-#The following class is for storing the results of the ensemble analysis 
-#performed by the SequenceGeneratorLogic class.
+
 
 @dataclass(frozen=True)
 class EnsembleAnalysisResult:
+    """Result of analyzing a single PulseBlockEnsemble: sample/element counts, channel
+    transition timings and the generation parameters used, as returned by
+    SequenceGeneratorLogic.analyze_block_ensemble()."""
+
     number_of_samples: int
     number_of_elements: int
     elements_length_bins: np.ndarray
@@ -382,8 +405,13 @@ class EnsembleAnalysisResult:
     laser_rising_bins: np.ndarray
     laser_falling_bins: np.ndarray
 
+
 @dataclass(frozen=True)
 class SequenceAnalysisResult:
+    """Result of analyzing a PulseSequence: the same information as
+    EnsembleAnalysisResult, aggregated over the whole sequence plus broken down per step, as
+    returned by SequenceGeneratorLogic.analyze_sequence()."""
+
     digital_channels: set
     analog_channels: set
     channel_set: set
@@ -404,20 +432,38 @@ class SequenceAnalysisResult:
     laser_falling_bins: np.ndarray
 
 
+# Note: SamplingInformation is the only class in this file that is also used by
+# pulsed_measurement_logic (imported directly from there). It stores the results of the
+# ensemble/sequence analysis performed by SequenceGeneratorLogic as well as the results of the
+# sampling performed by PulsedMeasurementLogic.
 @dataclass
 class SamplingInformation:
-    """Stores sampling metadata and waveform references for generated ensembles and sequences."""
+    """Stores sampling metadata and waveform references for generated ensembles and sequences.
+
+    Note: pulse_generator_settings is typed as Optional[dict], NOT PulseGeneratorSettings,
+    even though it conceptually is a pulse generator settings snapshot. It is always populated
+    from SequenceGeneratorLogic.pulse_generator_settings, which itself returns
+    PulseGeneratorSettings.to_dict() (a plain dict) rather than the dataclass instance - see
+    sequence_generator_logic.py's sample_pulse_sequence/from_dict call sites. Two call sites
+    depend on this being a plain dict: the sampling-cache comparison in
+    SequenceGeneratorLogic.sample_pulse_sequence (dict equality) and
+    pulse_extraction_methods/basic_extraction_methods.py (dict subscript access,
+    e.g. sampling_information['pulse_generator_settings']['sample_rate']). Reconstructing a real
+    PulseGeneratorSettings instance here would require updating both of those call sites plus
+    defensively handling older pickled sessions whose pulse_generator_settings dict may not match
+    the current schema - left as a plain dict to avoid that risk.
+    """
     waveforms: list = field(default_factory=list)
-    pulse_generator_settings: Optional[PulseGeneratorSettings] = None
+    pulse_generator_settings: Optional[dict] = None
     number_of_samples: int = 0
     number_of_elements: int = 0
     elements_length_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
     ideal_length: float = 0.0
-    
+
     # Sequence-specific fields
     step_waveform_list: list = field(default_factory=list)
     ensemble_info: dict = field(default_factory=dict)
-    
+
     # Legacy fields catch-all (optional, to ensure no data is lost)
     _legacy_data: dict = field(default_factory=dict)
 
@@ -473,16 +519,59 @@ class SamplingInformation:
         """Safely parses a legacy dictionary into the dataclass."""
         if not data:
             return cls()
-            
-        # Extract known fields
-        known_field_names = {f.name for f in fields(cls)}
+
+        # Extract known fields, excluding '_legacy_data' itself: a round-tripped YAML dump (via
+        # the generic dataclass_representer registered for this class) includes '_legacy_data' as
+        # a top-level key alongside the real fields, since it iterates over ALL dataclass fields.
+        # Treating it as a "known field" here would make it end up in both init_kwargs and the
+        # explicit _legacy_data= kwarg below, raising "got multiple values for keyword argument
+        # '_legacy_data'". Instead, seed legacy_kwargs from it (if present) and merge in any other
+        # unrecognized keys on top.
+        known_field_names = {f.name for f in fields(cls) if f.name != '_legacy_data'}
         init_kwargs = {}
-        legacy_kwargs = {}
-        
+        legacy_kwargs = dict(data.get('_legacy_data') or {})
+
         for key, value in data.items():
-            if key in known_field_names:
+            if key == '_legacy_data':
+                continue
+            elif key in known_field_names:
                 init_kwargs[key] = value
             else:
                 legacy_kwargs[key] = value
-                
+
         return cls(**init_kwargs, _legacy_data=legacy_kwargs)
+
+
+@dataclass(frozen=True)
+class LoadedAsset:
+    """Name and type ('PulseBlockEnsemble', 'PulseSequence', or '' if nothing/unknown is
+    currently loaded) of the waveform/sequence currently loaded on the pulse generator hardware.
+
+    Supports iteration/indexing so existing tuple-style call sites (*loaded_asset,
+    loaded_asset[0], loaded_asset[1]) keep working unchanged - the same backward-compatibility
+    pattern already used by AssetInfo above.
+    """
+
+    name: str
+    asset_type: str
+
+    @property
+    def as_tuple(self):
+        return (self.name, self.asset_type)
+
+    def __iter__(self):
+        return iter(self.as_tuple)
+
+    def __len__(self):
+        return len(self.as_tuple)
+
+    def __getitem__(self, index):
+        return self.as_tuple[index]
+
+    def __bool__(self):
+        """True only if both a name and a recognized asset type are set."""
+        return bool(self.name) and bool(self.asset_type)
+
+    @classmethod
+    def empty(cls):
+        return cls(name='', asset_type='')

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -26,6 +26,14 @@ import numpy as np
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
 from qudi.util.benchmark import BenchmarkTool
 
+# Imported for its side effect as much as for the name: importing this module defines every
+# lab-declared BaseGenerationParameters subclass, which _build_generation_parameters() below then
+# merges with CoreGenerationParameters into the public GenerationParameters class. The base lives
+# over there so that file never has to import back from this one - a cycle would make the merge
+# silently skip extensions depending on which module happened to be imported first.
+from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import BaseGenerationParameters
+import qudi.logic.pulsed.pulsed_data.generation_parameter_extensions as _generation_parameter_extensions  # noqa: F401
+
 
 ##############################################################################
 #  The following dataclasses are for the SequenceGeneratorLogic class and    #
@@ -40,88 +48,165 @@ def _as_bool(value):
         return value.strip().lower() in {'1', 'true', 'yes', 'on'}
     return bool(value)
 
-
 @dataclass(frozen=True)
-class GenerationParameters:
+class CoreGenerationParameters(BaseGenerationParameters):
     """Global parameters describing the channel usage and common parameters used during
-    pulsed object generation for predefined methods."""
+    pulsed object generation for predefined methods.
 
-    laser_channel: str
-    sync_channel: str
-    gate_channel: str
-    microwave_channel: str
-    microwave_frequency: float
-    microwave_amplitude: float
-    rabi_period: float
-    laser_length: float
-    laser_delay: float
-    wait_time: float
-    analog_trigger_voltage: float
-    optimal_control_assets_path: str
-    pulse_envelope: PulseEnvelope
-    pulse_envelope_order: int
+    The built-in contributor to `GenerationParameters`. Note this class is NOT the type the rest
+    of the toolchain annotates against - that is the merged `GenerationParameters` built at the
+    bottom of this module, which includes these fields plus every lab extension's.
+    """
 
-    def to_dict(self):
-        return {
-            'laser_channel': self.laser_channel,
-            'sync_channel': self.sync_channel,
-            'gate_channel': self.gate_channel,
-            'microwave_channel': self.microwave_channel,
-            'microwave_frequency': self.microwave_frequency,
-            'microwave_amplitude': self.microwave_amplitude,
-            'rabi_period': self.rabi_period,
-            'laser_length': self.laser_length,
-            'laser_delay': self.laser_delay,
-            'wait_time': self.wait_time,
-            'analog_trigger_voltage': self.analog_trigger_voltage,
-            'optimal_control_assets_path': self.optimal_control_assets_path,
-            'pulse_envelope': self.pulse_envelope,
-            'pulse_envelope_order': self.pulse_envelope_order,
-        }
+    laser_channel: str = 'd_ch1'
+    sync_channel: str = ''
+    gate_channel: str = ''
+    microwave_channel: str = 'a_ch1'
+    microwave_frequency: float = 2.87e9
+    microwave_amplitude: float = 0.0
+    rabi_period: float = 100e-9
+    laser_length: float = 3e-6
+    laser_delay: float = 500e-9
+    wait_time: float = 1e-6
+    analog_trigger_voltage: float = 0.0
+    optimal_control_assets_path: str = 'C:\\Software\\qudi_data\\optimal_control_assets'
+    pulse_envelope: PulseEnvelope = field(
+        default_factory=lambda: PulseEnvelope(PulseEnvelopeType.rectangle)
+    )
+    pulse_envelope_order: int = 1
 
     @staticmethod
     def _as_pulse_envelope(value):
         return value if isinstance(value, PulseEnvelope) else PulseEnvelope.from_dict(value)
 
     @classmethod
-    def from_dict(cls, data):
-        return cls(
-            laser_channel=str(data['laser_channel']),
-            sync_channel=str(data['sync_channel']),
-            gate_channel=str(data['gate_channel']),
-            microwave_channel=str(data['microwave_channel']),
-            microwave_frequency=float(data['microwave_frequency']),
-            microwave_amplitude=float(data['microwave_amplitude']),
-            rabi_period=float(data['rabi_period']),
-            laser_length=float(data['laser_length']),
-            laser_delay=float(data['laser_delay']),
-            wait_time=float(data['wait_time']),
-            analog_trigger_voltage=float(data['analog_trigger_voltage']),
-            optimal_control_assets_path=str(data['optimal_control_assets_path']),
-            pulse_envelope=cls._as_pulse_envelope(data['pulse_envelope']),
-            pulse_envelope_order=int(data['pulse_envelope_order']),
-        )
-
-    def update_from_dict(self, data):
-        return replace(
-            self,
-            laser_channel=str(data.get('laser_channel', self.laser_channel)),
-            sync_channel=str(data.get('sync_channel', self.sync_channel)),
-            gate_channel=str(data.get('gate_channel', self.gate_channel)),
-            microwave_channel=str(data.get('microwave_channel', self.microwave_channel)),
-            microwave_frequency=float(data.get('microwave_frequency', self.microwave_frequency)),
-            microwave_amplitude=float(data.get('microwave_amplitude', self.microwave_amplitude)),
-            rabi_period=float(data.get('rabi_period', self.rabi_period)),
-            laser_length=float(data.get('laser_length', self.laser_length)),
-            laser_delay=float(data.get('laser_delay', self.laser_delay)),
-            wait_time=float(data.get('wait_time', self.wait_time)),
-            analog_trigger_voltage=float(data.get('analog_trigger_voltage', self.analog_trigger_voltage)),
-            optimal_control_assets_path=str(
-                data.get('optimal_control_assets_path', self.optimal_control_assets_path)
+    def _coerce_fields(cls, data, current=None):
+        pick = cls._pick
+        return {
+            'laser_channel': str(pick(data, current, 'laser_channel', 'd_ch1')),
+            'sync_channel': str(pick(data, current, 'sync_channel', '')),
+            'gate_channel': str(pick(data, current, 'gate_channel', '')),
+            'microwave_channel': str(pick(data, current, 'microwave_channel', 'a_ch1')),
+            'microwave_frequency': float(pick(data, current, 'microwave_frequency', 2.87e9)),
+            'microwave_amplitude': float(pick(data, current, 'microwave_amplitude', 0.0)),
+            'rabi_period': float(pick(data, current, 'rabi_period', 100e-9)),
+            'laser_length': float(pick(data, current, 'laser_length', 3e-6)),
+            'laser_delay': float(pick(data, current, 'laser_delay', 500e-9)),
+            'wait_time': float(pick(data, current, 'wait_time', 1e-6)),
+            'analog_trigger_voltage': float(pick(data, current, 'analog_trigger_voltage', 0.0)),
+            'optimal_control_assets_path': str(
+                pick(data, current, 'optimal_control_assets_path',
+                     'C:\\Software\\qudi_data\\optimal_control_assets')
             ),
-            pulse_envelope=self._as_pulse_envelope(data.get('pulse_envelope', self.pulse_envelope)),
-            pulse_envelope_order=int(data.get('pulse_envelope_order', self.pulse_envelope_order)),
-        )
+            'pulse_envelope': cls._as_pulse_envelope(
+                pick(data, current, 'pulse_envelope', PulseEnvelope(PulseEnvelopeType.rectangle))
+            ),
+            'pulse_envelope_order': int(pick(data, current, 'pulse_envelope_order', 1)),
+        }
+
+
+def _generation_parameters_to_dict(self):
+    """Flat dict of every parameter, contributors in order (core first, then extensions by name).
+
+    Order matters beyond aesthetics: the GUI builds the Predefined Methods tab's global-parameter
+    widget grid by iterating these items (pulsed_maingui._create_pm_global_params), so relying on
+    dataclasses.fields() here would put extension fields ahead of the built-in ones - field order
+    on a merged dataclass is reverse-MRO.
+    """
+    result = {}
+    for contributor in self._CONTRIBUTORS:
+        for name in contributor._own_field_names():
+            result[name] = getattr(self, name)
+    return result
+
+
+def _generation_parameters_from_dict(cls, data):
+    """Build from a saved dict, falling back to defaults for anything absent.
+
+    Tolerant by design: a status file written before a parameter existed (or by an install without
+    a given extension) must still load. The pre-refactor version indexed `data['...']` directly, so
+    one missing key raised KeyError inside the StatusVar constructor and silently reset *every*
+    generation parameter to its default. Unknown keys are ignored rather than rejected, so removing
+    an extension does not make its old status file unloadable.
+    """
+    kwargs = {}
+    for contributor in cls._CONTRIBUTORS:
+        kwargs.update(contributor._coerce_fields(data, None))
+    return cls(**kwargs)
+
+
+def _generation_parameters_update_from_dict(self, data):
+    """Return a new instance with the parameters named in `data` applied on top of this one."""
+    kwargs = {}
+    for contributor in self._CONTRIBUTORS:
+        kwargs.update(contributor._coerce_fields(data, self))
+    return type(self)(**kwargs)
+
+
+def _build_generation_parameters(extensions=None):
+    """Merge CoreGenerationParameters with every lab extension into one frozen dataclass.
+
+    Runs once at module import - long before qudi-core restores status variables
+    (LogicBase.__activation_callback does _load_status_variables() then on_activate()), which is
+    exactly why the extensions must be declared at import time rather than discovered from a
+    ConfigOption path during activation.
+
+    The result is bound to the module-level name `GenerationParameters`, matching the class's own
+    __name__/__qualname__, so pickle can resolve it. That matters: a GenerationParameters instance
+    is pickled into every saved .ensemble/.sequence via SamplingInformation (see
+    sequence_generator_logic.sample_pulse_block_ensemble).
+
+    Parameters
+    ----------
+    extensions : iterable of BaseGenerationParameters subclasses, optional
+        Contributors to merge alongside CoreGenerationParameters. Defaults to discovering every
+        declared subclass, which is what production uses; tests pass an explicit list so a
+        throwaway contributor cannot leak into a later build (__subclasses__() only drops entries
+        once the class object is garbage collected, and the merged class keeps its bases alive).
+    """
+    if extensions is None:
+        extensions = [
+            cls for cls in BaseGenerationParameters.__subclasses__() if cls is not CoreGenerationParameters
+        ]
+    extensions = sorted(extensions, key=lambda cls: cls.__name__)
+    # Core first so it wins any tie and reads first in tracebacks; extensions in a deterministic
+    # (name-sorted) order so the merged schema does not depend on import order.
+    contributors = (CoreGenerationParameters, *extensions)
+
+    # Reject duplicate field names. The method/sampling-function registries elsewhere in the
+    # pulsed toolchain resolve collisions by silent last-wins, which is survivable there (you see
+    # the wrong pulse shape) but not for a settings value - it would silently change a measurement
+    # parameter with no other signal.
+    seen = {}
+    for contributor in contributors:
+        for name in contributor._own_field_names():
+            if name in seen:
+                raise TypeError(
+                    f'Duplicate generation parameter "{name}" declared by both '
+                    f'{seen[name].__name__} and {contributor.__name__}. Rename one of them - '
+                    f'generation parameter names must be unique across all contributors.'
+                )
+            seen[name] = contributor
+
+    merged = dataclass(frozen=True)(type('GenerationParameters', contributors, {}))
+    merged._CONTRIBUTORS = contributors
+    # Attached here rather than to the module-level GenerationParameters, so every class this
+    # builder produces carries them - including the ones built in tests.
+    merged.to_dict = _generation_parameters_to_dict
+    merged.from_dict = classmethod(_generation_parameters_from_dict)
+    merged.update_from_dict = _generation_parameters_update_from_dict
+    merged.__doc__ = """Global parameters describing the channel usage and common parameters used
+    during pulsed object generation for predefined methods.
+
+    Built at import time by merging CoreGenerationParameters (the built-in settings) with every
+    BaseGenerationParameters subclass declared in generation_parameter_extensions.py, so a lab's
+    own parameters are indistinguishable from the built-in ones at every call site. See
+    _build_generation_parameters() and the extensions module's docstring.
+    """
+    return merged
+
+
+GenerationParameters = _build_generation_parameters()
 
 
 @dataclass(frozen=True)
@@ -632,22 +717,12 @@ class LoadedAsset:
 # _default_generator_settings() (a brand new settings object). Defined once, here, since this
 # file can't import back from sequence_generator_logic.py (that direction would be circular) -
 # this is the lower-level file, so it owns the shared literals instead.
-_DEFAULT_GENERATION_PARAMETERS = GenerationParameters(
-    laser_channel='d_ch1',
-    sync_channel='',
-    gate_channel='',
-    microwave_channel='a_ch1',
-    microwave_frequency=2.87e9,
-    microwave_amplitude=0.0,
-    rabi_period=100e-9,
-    laser_length=3e-6,
-    laser_delay=500e-9,
-    wait_time=1e-6,
-    analog_trigger_voltage=0.0,
-    optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
-    pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
-    pulse_envelope_order=1,
-)
+#
+# Every field now carries its default on the dataclass itself (required: a merged dataclass cannot
+# have a no-default field following a defaulted one), so this is just a zero-argument construction
+# rather than the explicit field-by-field literal it used to be. Extensions supply their own
+# defaults the same way, so this stays correct however many are declared.
+_DEFAULT_GENERATION_PARAMETERS = GenerationParameters()
 _DEFAULT_PULSE_GENERATOR_SETTINGS = PulseGeneratorSettings(
     activation_config=ActivationConfig(name='', channels=set()),
     sample_rate=0.0,

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -20,7 +20,9 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 from dataclasses import dataclass, replace, field, fields
-from typing import Optional
+from enum import Enum
+from logging import getLogger
+from typing import Optional, get_type_hints
 import numpy as np
 
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
@@ -31,8 +33,19 @@ from qudi.util.benchmark import BenchmarkTool
 # merges with CoreGenerationParameters into the public GenerationParameters class. The base lives
 # over there so that file never has to import back from this one - a cycle would make the merge
 # silently skip extensions depending on which module happened to be imported first.
-from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import BaseGenerationParameters
+from qudi.logic.pulsed.pulsed_data.generation_parameter_extensions import (
+    BaseGenerationParameters,
+    as_bool as _as_bool,
+)
 import qudi.logic.pulsed.pulsed_data.generation_parameter_extensions as _generation_parameter_extensions  # noqa: F401
+
+_logger = getLogger(__name__)
+
+#: Field types pulsed_maingui._create_pm_global_params() can build a widget for. A generation
+#: parameter outside this set still works from a script, but never appears on the Predefined
+#: Methods tab - _build_generation_parameters() warns about one at import rather than leaving it to
+#: surface as a GUI error at activation.
+_GUI_RENDERABLE_TYPES = (str, int, float, bool, Enum, PulseEnvelope)
 
 
 ##############################################################################
@@ -40,14 +53,6 @@ import qudi.logic.pulsed.pulsed_data.generation_parameter_extensions as _generat
 #   are used to store and manage the settings for pulse/sequence object      #
 #              generation and the connected pulse generator hardware         #
 ##############################################################################
-def _as_bool(value):
-    """Converts a value to a boolean. If the value is a string,
-    it checks for common truthy values.
-    """
-    if isinstance(value, str):
-        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
-    return bool(value)
-
 @dataclass(frozen=True)
 class CoreGenerationParameters(BaseGenerationParameters):
     """Global parameters describing the channel usage and common parameters used during
@@ -81,6 +86,10 @@ class CoreGenerationParameters(BaseGenerationParameters):
 
     @classmethod
     def _coerce_fields(cls, data, current=None):
+        """Kept explicit, unlike a lab extension, which inherits the type-driven version in
+        BaseGenerationParameters. These are the built-in settings: spelling out every conversion and
+        default in one reviewable block is worth the duplication here, and it pins the behaviour the
+        automatic path is expected to reproduce."""
         pick = cls._pick
         return {
             'laser_channel': str(pick(data, current, 'laser_channel', 'd_ch1')),
@@ -143,6 +152,55 @@ def _generation_parameters_update_from_dict(self, data):
     return type(self)(**kwargs)
 
 
+def _check_is_dataclass(contributor):
+    """Raise if a contributor was declared without the @dataclass decorator.
+
+    `dataclasses.is_dataclass()` cannot be used: it reports True for an undecorated subclass,
+    because `__dataclass_fields__` is inherited from BaseGenerationParameters. Only the decorator
+    writes that attribute into the class's own __dict__.
+
+    Parameters
+    ----------
+    contributor : type
+        A BaseGenerationParameters subclass about to be merged.
+
+    Raises
+    ------
+    TypeError
+        If `contributor` itself was never processed by @dataclass.
+    """
+    if '__dataclass_fields__' not in contributor.__dict__:
+        raise TypeError(
+            f'{contributor.__name__} is missing the @dataclass(frozen=True) decorator. Without it '
+            f'its annotations never become fields, so it would contribute nothing to '
+            f'GenerationParameters and its parameters would silently not exist.'
+        )
+
+
+def _warn_about_unrenderable_types(contributor):
+    """Log a warning for each field whose type the Predefined Methods tab cannot build a widget for.
+
+    Parameters
+    ----------
+    contributor : type
+        A BaseGenerationParameters subclass about to be merged.
+    """
+    try:
+        hints = get_type_hints(contributor)
+    except (NameError, TypeError):
+        return
+    for name in contributor._own_field_names():
+        declared_type = hints.get(name)
+        if isinstance(declared_type, type) and not issubclass(declared_type, _GUI_RENDERABLE_TYPES):
+            _logger.warning(
+                'Generation parameter "%s" declared by %s has type %s, which the Predefined '
+                'Methods tab cannot build a widget for - it will be usable from scripts but will '
+                'not appear in the GUI. Supported types are str, int, float, bool, Enum and '
+                'PulseEnvelope.',
+                name, contributor.__name__, declared_type.__name__
+            )
+
+
 def _build_generation_parameters(extensions=None):
     """Merge CoreGenerationParameters with every lab extension into one frozen dataclass.
 
@@ -179,6 +237,8 @@ def _build_generation_parameters(extensions=None):
     # parameter with no other signal.
     seen = {}
     for contributor in contributors:
+        _check_is_dataclass(contributor)
+        _warn_about_unrenderable_types(contributor)
         for name in contributor._own_field_names():
             if name in seen:
                 raise TypeError(

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -1,0 +1,488 @@
+from dataclasses import dataclass, replace, field, fields
+from typing import Optional
+import numpy as np
+
+from qudi.logic.pulsed.sampling_functions import PulseEnvelope
+from qudi.util.benchmark import BenchmarkTool
+
+
+##############################################################################
+#  The following dataclasses are for the SequenceGeneratorLogic class and    #
+#   are used to store and manage the settings for pulse/sequence object      #
+#              generation and the connected pulse generator hardware         #
+##############################################################################
+def _as_bool(value):
+    """Converts a value to a boolean. If the value is a string,
+    it checks for common truthy values.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+@dataclass(frozen=True)
+class GenerationParameters:
+    """Global parameters describing the channel usage and common parameters used during
+    pulsed object generation for predefined methods."""
+
+    laser_channel: str
+    sync_channel: str
+    gate_channel: str
+    microwave_channel: str
+    microwave_frequency: float
+    microwave_amplitude: float
+    rabi_period: float
+    laser_length: float
+    laser_delay: float
+    wait_time: float
+    analog_trigger_voltage: float
+    optimal_control_assets_path: str
+    pulse_envelope: PulseEnvelope
+    pulse_envelope_order: int
+
+    def to_dict(self):
+        return {
+            'laser_channel': self.laser_channel,
+            'sync_channel': self.sync_channel,
+            'gate_channel': self.gate_channel,
+            'microwave_channel': self.microwave_channel,
+            'microwave_frequency': self.microwave_frequency,
+            'microwave_amplitude': self.microwave_amplitude,
+            'rabi_period': self.rabi_period,
+            'laser_length': self.laser_length,
+            'laser_delay': self.laser_delay,
+            'wait_time': self.wait_time,
+            'analog_trigger_voltage': self.analog_trigger_voltage,
+            'optimal_control_assets_path': self.optimal_control_assets_path,
+            'pulse_envelope': self.pulse_envelope,
+            'pulse_envelope_order': self.pulse_envelope_order,
+        }
+
+    @staticmethod
+    def _as_pulse_envelope(value):
+        return value if isinstance(value, PulseEnvelope) else PulseEnvelope.from_dict(value)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            laser_channel=str(data['laser_channel']),
+            sync_channel=str(data['sync_channel']),
+            gate_channel=str(data['gate_channel']),
+            microwave_channel=str(data['microwave_channel']),
+            microwave_frequency=float(data['microwave_frequency']),
+            microwave_amplitude=float(data['microwave_amplitude']),
+            rabi_period=float(data['rabi_period']),
+            laser_length=float(data['laser_length']),
+            laser_delay=float(data['laser_delay']),
+            wait_time=float(data['wait_time']),
+            analog_trigger_voltage=float(data['analog_trigger_voltage']),
+            optimal_control_assets_path=str(data['optimal_control_assets_path']),
+            pulse_envelope=cls._as_pulse_envelope(data['pulse_envelope']),
+            pulse_envelope_order=int(data['pulse_envelope_order']),
+        )
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            laser_channel=str(data.get('laser_channel', self.laser_channel)),
+            sync_channel=str(data.get('sync_channel', self.sync_channel)),
+            gate_channel=str(data.get('gate_channel', self.gate_channel)),
+            microwave_channel=str(data.get('microwave_channel', self.microwave_channel)),
+            microwave_frequency=float(data.get('microwave_frequency', self.microwave_frequency)),
+            microwave_amplitude=float(data.get('microwave_amplitude', self.microwave_amplitude)),
+            rabi_period=float(data.get('rabi_period', self.rabi_period)),
+            laser_length=float(data.get('laser_length', self.laser_length)),
+            laser_delay=float(data.get('laser_delay', self.laser_delay)),
+            wait_time=float(data.get('wait_time', self.wait_time)),
+            analog_trigger_voltage=float(data.get('analog_trigger_voltage', self.analog_trigger_voltage)),
+            optimal_control_assets_path=str(
+                data.get('optimal_control_assets_path', self.optimal_control_assets_path)
+            ),
+            pulse_envelope=self._as_pulse_envelope(data.get('pulse_envelope', self.pulse_envelope)),
+            pulse_envelope_order=int(data.get('pulse_envelope_order', self.pulse_envelope_order)),
+        )
+
+
+@dataclass(frozen=True)
+class ActivationConfig:
+    """The activation config name and the set of pulse generator channels it activates."""
+
+    name: str
+    channels: set
+
+    @property
+    def as_tuple(self):
+        return (self.name, set(self.channels))
+
+    def to_dict(self):
+        return {'name': self.name, 'channels': set(self.channels)}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(name=str(data['name']), channels=set(data['channels']))
+
+    @classmethod
+    def from_tuple(cls, name, channels):
+        return cls(name=str(name), channels=set(channels))
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            name=str(data.get('name', self.name)),
+            channels=set(data.get('channels', self.channels)),
+        )
+
+
+@dataclass(frozen=True)
+class AnalogLevels:
+    """Pulse generator analog channel levels (pp-amplitude and offset), keyed by channel
+    descriptor."""
+
+    amplitude: dict
+    offset: dict
+
+    @property
+    def as_tuple(self):
+        return (self.amplitude, self.offset)
+
+    def to_dict(self):
+        return {'amplitude': dict(self.amplitude), 'offset': dict(self.offset)}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(amplitude=dict(data['amplitude']), offset=dict(data['offset']))
+
+    @classmethod
+    def from_tuple(cls, levels):
+        amplitude, offset = levels
+        return cls(amplitude=dict(amplitude), offset=dict(offset))
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            amplitude=dict(data.get('amplitude', self.amplitude)),
+            offset=dict(data.get('offset', self.offset)),
+        )
+
+
+@dataclass(frozen=True)
+class DigitalLevels:
+    """Pulse generator digital channel levels (low/high voltage), keyed by channel descriptor."""
+
+    low: dict
+    high: dict
+
+    @property
+    def as_tuple(self):
+        return (self.low, self.high)
+
+    def to_dict(self):
+        return {'low': dict(self.low), 'high': dict(self.high)}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(low=dict(data['low']), high=dict(data['high']))
+
+    @classmethod
+    def from_tuple(cls, levels):
+        low, high = levels
+        return cls(low=dict(low), high=dict(high))
+
+    def update_from_dict(self, data):
+        return replace(
+            self,
+            low=dict(data.get('low', self.low)),
+            high=dict(data.get('high', self.high)),
+        )
+
+
+@dataclass(frozen=True)
+class PulseGeneratorSettings:
+    """Current pulse generator hardware settings, mirrored locally by SequenceGeneratorLogic to
+    avoid repeated slow hardware reads."""
+
+    activation_config: ActivationConfig
+    sample_rate: float
+    analog_levels: AnalogLevels
+    digital_levels: DigitalLevels
+    interleave: bool
+    flags: set
+    upload_speed: float
+
+    def to_dict(self):
+        return {
+            'activation_config': self.activation_config.as_tuple,
+            'sample_rate': float(self.sample_rate),
+            'analog_levels': self.analog_levels.as_tuple,
+            'digital_levels': self.digital_levels.as_tuple,
+            'interleave': bool(self.interleave),
+            'flags': set(self.flags),
+            'upload_speed': float(self.upload_speed),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            activation_config=ActivationConfig.from_tuple(*data['activation_config']),
+            sample_rate=float(data['sample_rate']),
+            analog_levels=AnalogLevels.from_tuple(data['analog_levels']),
+            digital_levels=DigitalLevels.from_tuple(data['digital_levels']),
+            interleave=_as_bool(data['interleave']),
+            flags=set(data['flags']),
+            upload_speed=float(data['upload_speed']),
+        )
+
+    def update_from_dict(self, data):
+        activation_config = self.activation_config
+        if 'activation_config' in data:
+            value = data['activation_config']
+            activation_config = value if isinstance(value, ActivationConfig) else ActivationConfig.from_tuple(*value)
+
+        analog_levels = self.analog_levels
+        if 'analog_levels' in data:
+            value = data['analog_levels']
+            analog_levels = value if isinstance(value, AnalogLevels) else AnalogLevels.from_tuple(value)
+
+        digital_levels = self.digital_levels
+        if 'digital_levels' in data:
+            value = data['digital_levels']
+            digital_levels = value if isinstance(value, DigitalLevels) else DigitalLevels.from_tuple(value)
+
+        return replace(
+            self,
+            activation_config=activation_config,
+            sample_rate=float(data.get('sample_rate', self.sample_rate)),
+            analog_levels=analog_levels,
+            digital_levels=digital_levels,
+            interleave=_as_bool(data.get('interleave', self.interleave)),
+            flags=set(data.get('flags', self.flags)),
+            upload_speed=float(data.get('upload_speed', self.upload_speed)),
+        )
+
+
+@dataclass(frozen=True)
+class AssetInfo:
+    """Length and laser-pulse-count summary for a sampled PulseBlockEnsemble or PulseSequence."""
+
+    length_s: float
+    length_bins: int
+    number_of_lasers: int
+
+    @property
+    def as_tuple(self):
+        return (self.length_s, self.length_bins, self.number_of_lasers)
+
+    def __iter__(self):
+        return iter(self.as_tuple)
+
+    def __len__(self):
+        return len(self.as_tuple)
+
+    def to_dict(self):
+        return {
+            'length_s': self.length_s,
+            'length_bins': self.length_bins,
+            'number_of_lasers': self.number_of_lasers,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            length_s=float(data['length_s']),
+            length_bins=int(data['length_bins']),
+            number_of_lasers=int(data['number_of_lasers']),
+        )
+
+    @classmethod
+    def from_tuple(cls, values):
+        length_s, length_bins, number_of_lasers = values
+        return cls(length_s=float(length_s), length_bins=int(length_bins), number_of_lasers=int(number_of_lasers))
+
+
+@dataclass
+class SequenceSamplingState:
+    """Tracks the bookkeeping needed while sampling a PulseSequence step-by-step.
+
+    One instance is created per sampling run and discarded once the run finishes
+    (successfully or not) - it is not persisted.
+    """
+
+    in_progress: bool = False
+    offset_bin: int = 0
+    written_waveforms: set = field(default_factory=set)
+    generated_ensembles: dict = field(default_factory=dict)
+    step_results: list = field(default_factory=list)
+
+    def start(self):
+        """Called when a new PulseSequence sampling run begins."""
+        self.in_progress = True
+        self.offset_bin = 0
+        self.written_waveforms = set()
+        self.generated_ensembles = dict()
+        self.step_results = list()
+
+    def finish(self):
+        """Called when the PulseSequence sampling run ends, successfully or not."""
+        self.in_progress = False
+
+    def record_ensemble(self, name_tag, ensemble_info, waveforms):
+        """Store the sampling result for one sequence step's PulseBlockEnsemble."""
+        ensemble_info = dict(ensemble_info)
+        ensemble_info['waveforms'] = waveforms
+        self.generated_ensembles[name_tag] = ensemble_info
+        self.written_waveforms.update(waveforms)
+
+    def record_step(self, name_tag, seq_step):
+        """Append the waveform names produced for one PulseSequence step."""
+        waveforms = tuple(self.generated_ensembles[name_tag]['waveforms'])
+        self.step_results.append((waveforms, seq_step))
+
+
+@dataclass
+class PulserBenchmarks:
+    """Bundles the write/load BenchmarkTool instances used to estimate pulser upload speed."""
+
+    write: BenchmarkTool = field(default_factory=BenchmarkTool)
+    load: BenchmarkTool = field(default_factory=BenchmarkTool)
+
+    def reset(self):
+        self.write.reset()
+        self.load.reset()
+
+    def estimate_combined_speed(self):
+        """Combined write+load speed estimate in Sa/s, or NaN if there isn't enough data yet."""
+        if not (self.write.sanity or self.load.sanity):
+            return np.nan
+        speed_combined = 1 / (
+            1 / self.write.estimate_speed(check_sanity=False) + 1 / self.load.estimate_speed(check_sanity=False)
+        )
+        return speed_combined if speed_combined >= 0 else np.nan
+
+    def has_valid_estimate(self, ignore=False):
+        """Whether a sane combined speed estimate is available, or True if checks are ignored."""
+        if ignore:
+            return True
+        return not np.isnan(self.estimate_combined_speed())
+    
+#The following class is for storing the results of the ensemble analysis 
+#performed by the SequenceGeneratorLogic class.
+
+@dataclass(frozen=True)
+class EnsembleAnalysisResult:
+    number_of_samples: int
+    number_of_elements: int
+    elements_length_bins: np.ndarray
+    digital_rising_bins: dict
+    digital_falling_bins: dict
+    analog_channels: set
+    digital_channels: set
+    channel_set: set
+    generation_parameters: GenerationParameters
+    ideal_length: float
+    laser_rising_bins: np.ndarray
+    laser_falling_bins: np.ndarray
+
+@dataclass(frozen=True)
+class SequenceAnalysisResult:
+    digital_channels: set
+    analog_channels: set
+    channel_set: set
+    generation_parameters: GenerationParameters
+    digital_rising_bins: dict
+    digital_falling_bins: dict
+    number_of_steps: int
+    number_of_samples: int
+    number_of_samples_per_step: np.ndarray
+    number_of_ensembles: int
+    ensemble_names: set
+    number_of_elements: int
+    number_of_elements_per_step: np.ndarray
+    elements_length_bins_per_step: list
+    ideal_length_per_step: np.ndarray
+    ideal_length: float
+    laser_rising_bins: np.ndarray
+    laser_falling_bins: np.ndarray
+
+
+@dataclass
+class SamplingInformation:
+    """Stores sampling metadata and waveform references for generated ensembles and sequences."""
+    waveforms: list = field(default_factory=list)
+    pulse_generator_settings: Optional[PulseGeneratorSettings] = None
+    number_of_samples: int = 0
+    number_of_elements: int = 0
+    elements_length_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
+    ideal_length: float = 0.0
+    
+    # Sequence-specific fields
+    step_waveform_list: list = field(default_factory=list)
+    ensemble_info: dict = field(default_factory=dict)
+    
+    # Legacy fields catch-all (optional, to ensure no data is lost)
+    _legacy_data: dict = field(default_factory=dict)
+
+    def __bool__(self):
+        """
+        Crucial for Qudi logic. Returns True only if the object has actually been sampled
+        (indicated by the presence of stored waveforms).
+        """
+        return bool(self.waveforms)
+
+    def _field_names(self):
+        return {f.name for f in fields(self) if f.name != '_legacy_data'}
+
+    def __contains__(self, key):
+        return key in self._field_names() or key in self._legacy_data
+
+    def __getitem__(self, key):
+        if key in self._field_names():
+            return getattr(self, key)
+        if key in self._legacy_data:
+            return self._legacy_data[key]
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        if key in self._field_names():
+            setattr(self, key, value)
+        else:
+            self._legacy_data[key] = value
+
+    def __delitem__(self, key):
+        if key in self._field_names():
+            raise KeyError('Cannot delete required field "{0}" from SamplingInformation.'.format(key))
+        del self._legacy_data[key]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def update(self, other=(), **kwargs):
+        items = other.items() if hasattr(other, 'items') else other
+        for key, value in items:
+            self[key] = value
+        for key, value in kwargs.items():
+            self[key] = value
+
+    def copy(self):
+        return replace(self, _legacy_data=dict(self._legacy_data))
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Safely parses a legacy dictionary into the dataclass."""
+        if not data:
+            return cls()
+            
+        # Extract known fields
+        known_field_names = {f.name for f in fields(cls)}
+        init_kwargs = {}
+        legacy_kwargs = {}
+        
+        for key, value in data.items():
+            if key in known_field_names:
+                init_kwargs[key] = value
+            else:
+                legacy_kwargs[key] = value
+                
+        return cls(**init_kwargs, _legacy_data=legacy_kwargs)

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -307,6 +307,9 @@ class AssetInfo:
     def __len__(self):
         return len(self.as_tuple)
 
+    def __getitem__(self, index):
+        return self.as_tuple[index]
+
     def to_dict(self):
         return {
             'length_s': self.length_s,
@@ -539,7 +542,20 @@ class SamplingInformation:
             self[key] = value
 
     def copy(self):
-        return replace(self, _legacy_data=dict(self._legacy_data))
+        """Independent copy: mutating any mutable field on the copy never affects the original."""
+        return replace(
+            self,
+            waveforms=list(self.waveforms),
+            pulse_generator_settings=(
+                None if self.pulse_generator_settings is None else dict(self.pulse_generator_settings)
+            ),
+            elements_length_bins=self.elements_length_bins.copy(),
+            laser_rising_bins=self.laser_rising_bins.copy(),
+            laser_falling_bins=self.laser_falling_bins.copy(),
+            step_waveform_list=list(self.step_waveform_list),
+            ensemble_info=dict(self.ensemble_info),
+            _legacy_data=dict(self._legacy_data),
+        )
 
     def to_dict(self) -> dict:
         """Inverse of from_dict(): flattens the known dataclass fields plus any legacy/unknown
@@ -647,27 +663,21 @@ _DEFAULT_PULSE_GENERATOR_SETTINGS = PulseGeneratorSettings(
 class SequenceGeneratorSettings:
     """Single settings container bundling everything SequenceGeneratorLogic persists as
     user-configurable settings: the generation parameters (laser/microwave channels, timings,
-    ...), the pulse generator hardware settings (activation config, sample rate, levels, ...),
-    and the write/load speed benchmarks.
+    ...) and the pulse generator hardware settings (activation config, sample rate, levels, ...).
 
-    Note: pulser_benchmarks is a SHARED object, not an independently owned copy.
-    SequenceGeneratorLogic mutates the BenchmarkTool instances held here directly (via
-    add_benchmark()/reset()) as their real, live, authoritative state - there are no more
-    class-level singleton BenchmarkTool instances or bound-method StatusVar hooks; this
-    container's own to_dict()/from_dict() is the only persistence path. Because
-    dataclasses.replace() leaves the object identity of any field it doesn't touch alone,
-    swapping out some other field of this container never disturbs this reference.
+    Note: pulser_benchmarks is intentionally NOT part of this container - it's runtime telemetry
+    (hardware upload/download speed statistics), not a measurement-defining setting, and is
+    persisted as its own independent, per-instance StatusVar directly on SequenceGeneratorLogic
+    instead (see `pulser_benchmarks` there).
     """
 
     generation_parameters: GenerationParameters
     pulse_generator_settings: PulseGeneratorSettings
-    pulser_benchmarks: PulserBenchmarks
 
     def to_dict(self):
         return {
             'generation_parameters': self.generation_parameters.to_dict(),
             'pulse_generator_settings': self.pulse_generator_settings.to_dict(),
-            'pulser_benchmarks': self.pulser_benchmarks.to_dict(),
         }
 
     @classmethod
@@ -685,11 +695,40 @@ class SequenceGeneratorSettings:
                 if 'pulse_generator_settings' in data
                 else _DEFAULT_PULSE_GENERATOR_SETTINGS
             ),
-            pulser_benchmarks=(
-                PulserBenchmarks.from_dict(data['pulser_benchmarks'])
-                if 'pulser_benchmarks' in data
-                else PulserBenchmarks()
+        )
+
+    #: Top-level status-file key names used by the 3 individually-declared StatusVars that
+    #: existed on SequenceGeneratorLogic before this class was introduced (one file-level key
+    #: per StatusVar, instead of everything nested under a single '_generator_settings' key).
+    #: Used only to detect a pre-refactor status file - see
+    #: SequenceGeneratorLogic._migrate_legacy_settings_if_needed().
+    LEGACY_STATUS_VAR_KEYS = frozenset({
+        '_generation_parameters',
+        '_benchmark_write_state',
+        '_benchmark_load_state',
+    })
+
+    @classmethod
+    def from_legacy_dict(cls, raw):
+        """Reconstruct settings from the pre-refactor format, where '_generation_parameters' was
+        its own StatusVar holding the same flat dict shape GenerationParameters.from_dict() expects.
+
+        pulse_generator_settings is deliberately not migrated - the old format never persisted it
+        either, and on_activate() always re-derives it fresh from hardware regardless.
+
+        '_benchmark_write_state'/'_benchmark_load_state' stay in LEGACY_STATUS_VAR_KEYS (valid
+        legacy-format signals) but aren't reconstructed here - pulser_benchmarks is no longer a
+        field of this class (see the class docstring); SequenceGeneratorLogic.
+        _migrate_legacy_settings_if_needed() migrates it directly into its own StatusVar instead.
+        """
+        generation_parameters = raw.get('_generation_parameters')
+        return cls(
+            generation_parameters=(
+                GenerationParameters.from_dict(generation_parameters)
+                if isinstance(generation_parameters, dict)
+                else _DEFAULT_GENERATION_PARAMETERS
             ),
+            pulse_generator_settings=_DEFAULT_PULSE_GENERATOR_SETTINGS,
         )
 
     def update_from_dict(self, data):
@@ -708,15 +747,6 @@ class SequenceGeneratorSettings:
                 if isinstance(value, PulseGeneratorSettings)
                 else self.pulse_generator_settings.update_from_dict(value)
             )
-
-        # pulser_benchmarks is a shared object (see class docstring): mutate the existing
-        # BenchmarkTool instances in place, never replace the reference.
-        if 'pulser_benchmarks' in data:
-            value = data['pulser_benchmarks']
-            write_data = value.write.save() if isinstance(value, PulserBenchmarks) else value['write']
-            load_data = value.load.save() if isinstance(value, PulserBenchmarks) else value['load']
-            self.pulser_benchmarks.write.load_from_dict(saved_dict=write_data)
-            self.pulser_benchmarks.load.load_from_dict(saved_dict=load_data)
 
         return replace(
             self,

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, replace, field, fields
 from typing import Optional
 import numpy as np
 
-from qudi.logic.pulsed.sampling_functions import PulseEnvelope
+from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
 from qudi.util.benchmark import BenchmarkTool
 
 
@@ -478,6 +478,14 @@ class SamplingInformation:
     number_of_elements: int = 0
     elements_length_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
     ideal_length: float = 0.0
+    # Populated from the EnsembleAnalysisResult/SequenceAnalysisResult computed at sampling time
+    # (sequence_generator_logic.py: info_dict = _dataclass_to_dict(ensemble_info)/
+    # _dataclass_to_dict(self.analyze_sequence(sequence)), which dumps every field of that result
+    # - these two used to only arrive here implicitly, via that dump landing in _legacy_data
+    # (since they weren't declared fields), rather than because they were designed to live here.
+    # Read by pulse_extraction_methods/basic_extraction_methods.py's ungated_gated_conv_deriv().
+    laser_rising_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
+    laser_falling_bins: np.ndarray = field(default_factory=lambda: np.empty(0, dtype='int64'))
 
     # Sequence-specific fields
     step_waveform_list: list = field(default_factory=list)
@@ -603,6 +611,38 @@ class LoadedAsset:
         return cls(name='', asset_type='')
 
 
+# Default sub-settings for SequenceGeneratorSettings.from_dict()'s per-field fallbacks (a saved
+# settings file predating a given field) and for sequence_generator_logic.py's
+# _default_generator_settings() (a brand new settings object). Defined once, here, since this
+# file can't import back from sequence_generator_logic.py (that direction would be circular) -
+# this is the lower-level file, so it owns the shared literals instead.
+_DEFAULT_GENERATION_PARAMETERS = GenerationParameters(
+    laser_channel='d_ch1',
+    sync_channel='',
+    gate_channel='',
+    microwave_channel='a_ch1',
+    microwave_frequency=2.87e9,
+    microwave_amplitude=0.0,
+    rabi_period=100e-9,
+    laser_length=3e-6,
+    laser_delay=500e-9,
+    wait_time=1e-6,
+    analog_trigger_voltage=0.0,
+    optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
+    pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
+    pulse_envelope_order=1,
+)
+_DEFAULT_PULSE_GENERATOR_SETTINGS = PulseGeneratorSettings(
+    activation_config=ActivationConfig(name='', channels=set()),
+    sample_rate=0.0,
+    analog_levels=AnalogLevels(amplitude=dict(), offset=dict()),
+    digital_levels=DigitalLevels(low=dict(), high=dict()),
+    interleave=False,
+    flags=set(),
+    upload_speed=np.nan,
+)
+
+
 @dataclass(frozen=True)
 class SequenceGeneratorSettings:
     """Single settings container bundling everything SequenceGeneratorLogic persists as
@@ -632,10 +672,24 @@ class SequenceGeneratorSettings:
 
     @classmethod
     def from_dict(cls, data):
+        """Tolerant of a saved dict missing keys added after it was written - falls back to
+        that field's own default rather than raising KeyError."""
         return cls(
-            generation_parameters=GenerationParameters.from_dict(data['generation_parameters']),
-            pulse_generator_settings=PulseGeneratorSettings.from_dict(data['pulse_generator_settings']),
-            pulser_benchmarks=PulserBenchmarks.from_dict(data['pulser_benchmarks']),
+            generation_parameters=(
+                GenerationParameters.from_dict(data['generation_parameters'])
+                if 'generation_parameters' in data
+                else _DEFAULT_GENERATION_PARAMETERS
+            ),
+            pulse_generator_settings=(
+                PulseGeneratorSettings.from_dict(data['pulse_generator_settings'])
+                if 'pulse_generator_settings' in data
+                else _DEFAULT_PULSE_GENERATOR_SETTINGS
+            ),
+            pulser_benchmarks=(
+                PulserBenchmarks.from_dict(data['pulser_benchmarks'])
+                if 'pulser_benchmarks' in data
+                else PulserBenchmarks()
+            ),
         )
 
     def update_from_dict(self, data):

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -164,7 +164,7 @@ class AnalogLevels:
 
     @property
     def as_tuple(self):
-        return (self.amplitude, self.offset)
+        return (dict(self.amplitude), dict(self.offset))
 
     def to_dict(self):
         return {'amplitude': dict(self.amplitude), 'offset': dict(self.offset)}
@@ -195,7 +195,7 @@ class DigitalLevels:
 
     @property
     def as_tuple(self):
-        return (self.low, self.high)
+        return (dict(self.low), dict(self.high))
 
     def to_dict(self):
         return {'low': dict(self.low), 'high': dict(self.high)}
@@ -229,6 +229,14 @@ class PulseGeneratorSettings:
     interleave: bool
     flags: set
     upload_speed: float
+
+    @property
+    def analog_channels(self):
+        return {chnl for chnl in self.activation_config.channels if chnl.startswith('a_ch')}
+
+    @property
+    def digital_channels(self):
+        return {chnl for chnl in self.activation_config.channels if chnl.startswith('d_ch')}
 
     def to_dict(self):
         return {
@@ -385,6 +393,17 @@ class PulserBenchmarks:
             return True
         return not np.isnan(self.estimate_combined_speed())
 
+    def to_dict(self):
+        return {'write': self.write.save(), 'load': self.load.save()}
+
+    @classmethod
+    def from_dict(cls, data):
+        write = BenchmarkTool()
+        write.load_from_dict(saved_dict=data['write'])
+        load = BenchmarkTool()
+        load.load_from_dict(saved_dict=data['load'])
+        return cls(write=write, load=load)
+
 
 @dataclass(frozen=True)
 class EnsembleAnalysisResult:
@@ -514,6 +533,13 @@ class SamplingInformation:
     def copy(self):
         return replace(self, _legacy_data=dict(self._legacy_data))
 
+    def to_dict(self) -> dict:
+        """Inverse of from_dict(): flattens the known dataclass fields plus any legacy/unknown
+        keys back into a plain dict."""
+        data = {name: getattr(self, name) for name in self._field_names()}
+        data.update(self._legacy_data)
+        return data
+
     @classmethod
     def from_dict(cls, data: dict):
         """Safely parses a legacy dictionary into the dataclass."""
@@ -575,3 +601,71 @@ class LoadedAsset:
     @classmethod
     def empty(cls):
         return cls(name='', asset_type='')
+
+
+@dataclass(frozen=True)
+class SequenceGeneratorSettings:
+    """Single settings container bundling everything SequenceGeneratorLogic persists as
+    user-configurable settings: the generation parameters (laser/microwave channels, timings,
+    ...), the pulse generator hardware settings (activation config, sample rate, levels, ...),
+    and the write/load speed benchmarks.
+
+    Note: pulser_benchmarks is a SHARED object, not an independently owned copy.
+    SequenceGeneratorLogic mutates the BenchmarkTool instances held here directly (via
+    add_benchmark()/reset()) as their real, live, authoritative state - there are no more
+    class-level singleton BenchmarkTool instances or bound-method StatusVar hooks; this
+    container's own to_dict()/from_dict() is the only persistence path. Because
+    dataclasses.replace() leaves the object identity of any field it doesn't touch alone,
+    swapping out some other field of this container never disturbs this reference.
+    """
+
+    generation_parameters: GenerationParameters
+    pulse_generator_settings: PulseGeneratorSettings
+    pulser_benchmarks: PulserBenchmarks
+
+    def to_dict(self):
+        return {
+            'generation_parameters': self.generation_parameters.to_dict(),
+            'pulse_generator_settings': self.pulse_generator_settings.to_dict(),
+            'pulser_benchmarks': self.pulser_benchmarks.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            generation_parameters=GenerationParameters.from_dict(data['generation_parameters']),
+            pulse_generator_settings=PulseGeneratorSettings.from_dict(data['pulse_generator_settings']),
+            pulser_benchmarks=PulserBenchmarks.from_dict(data['pulser_benchmarks']),
+        )
+
+    def update_from_dict(self, data):
+        generation_parameters = self.generation_parameters
+        if 'generation_parameters' in data:
+            value = data['generation_parameters']
+            generation_parameters = (
+                value if isinstance(value, GenerationParameters) else self.generation_parameters.update_from_dict(value)
+            )
+
+        pulse_generator_settings = self.pulse_generator_settings
+        if 'pulse_generator_settings' in data:
+            value = data['pulse_generator_settings']
+            pulse_generator_settings = (
+                value
+                if isinstance(value, PulseGeneratorSettings)
+                else self.pulse_generator_settings.update_from_dict(value)
+            )
+
+        # pulser_benchmarks is a shared object (see class docstring): mutate the existing
+        # BenchmarkTool instances in place, never replace the reference.
+        if 'pulser_benchmarks' in data:
+            value = data['pulser_benchmarks']
+            write_data = value.write.save() if isinstance(value, PulserBenchmarks) else value['write']
+            load_data = value.load.save() if isinstance(value, PulserBenchmarks) else value['load']
+            self.pulser_benchmarks.write.load_from_dict(saved_dict=write_data)
+            self.pulser_benchmarks.load.load_from_dict(saved_dict=load_data)
+
+        return replace(
+            self,
+            generation_parameters=generation_parameters,
+            pulse_generator_settings=pulse_generator_settings,
+        )

--- a/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
+++ b/src/qudi/logic/pulsed/pulsed_data/sequence_generator_logic_data.py
@@ -124,8 +124,11 @@ def _generation_parameters_to_dict(self):
     """
     result = {}
     for contributor in self._CONTRIBUTORS:
+        defaults = contributor()
         for name in contributor._own_field_names():
-            result[name] = getattr(self, name)
+            # Default fallback: an instance unpickled from a saved .ensemble predates the current
+            # contributor set, so it can be missing a field the schema now has.
+            result[name] = getattr(self, name, getattr(defaults, name))
     return result
 
 
@@ -204,10 +207,15 @@ def _warn_about_unrenderable_types(contributor):
 def _build_generation_parameters(extensions=None):
     """Merge CoreGenerationParameters with every lab extension into one frozen dataclass.
 
-    Runs once at module import - long before qudi-core restores status variables
-    (LogicBase.__activation_callback does _load_status_variables() then on_activate()), which is
-    exactly why the extensions must be declared at import time rather than discovered from a
-    ConfigOption path during activation.
+    Runs at module import to establish the built-in schema, and again from
+    rebuild_generation_parameters() during SequenceGeneratorLogic.on_activate() once the predefined
+    generator modules have been imported and can be asked what they declare.
+
+    The import-time build happens before qudi-core restores status variables
+    (LogicBase.__activation_callback does _load_status_variables() then on_activate()), so a
+    parameter that only joins on the second pass has already been dropped from the restored
+    settings - SequenceGeneratorLogic._merge_generator_declared_parameters() re-reads those values
+    off the status file rather than letting them reset.
 
     The result is bound to the module-level name `GenerationParameters`, matching the class's own
     __name__/__qualname__, so pickle can resolve it. That matters: a GenerationParameters instance
@@ -239,7 +247,17 @@ def _build_generation_parameters(extensions=None):
     for contributor in contributors:
         _check_is_dataclass(contributor)
         _warn_about_unrenderable_types(contributor)
-        for name in contributor._own_field_names():
+        own_names = contributor._own_field_names()
+        if not own_names:
+            # A contributor that declares nothing is always a fault, never an intention. Caught
+            # here because the symptom otherwise surfaces far away: an empty parameter grid and a
+            # status file with no generation parameters in it, with nothing raised in between.
+            raise TypeError(
+                f'{contributor.__name__} contributes no generation parameters. Every contributor '
+                f'must declare at least one field, so either it declares none or _own_field_names() '
+                f'failed to see them.'
+            )
+        for name in own_names:
             if name in seen:
                 raise TypeError(
                     f'Duplicate generation parameter "{name}" declared by both '
@@ -267,6 +285,58 @@ def _build_generation_parameters(extensions=None):
 
 
 GenerationParameters = _build_generation_parameters()
+
+#: What generation_parameter_extensions.py declared, captured before any rebuild can widen the
+#: schema. [0] is CoreGenerationParameters, which _build_generation_parameters() re-adds itself.
+_DECLARED_EXTENSIONS = tuple(GenerationParameters._CONTRIBUTORS[1:])
+
+
+def generation_parameters_class():
+    """The GenerationParameters class currently in effect.
+
+    Always call this instead of holding a `from ... import GenerationParameters` binding:
+    rebuild_generation_parameters() rebinds the module global, and an imported name would keep
+    pointing at the superseded class.
+    """
+    return GenerationParameters
+
+
+def rebuild_generation_parameters(extensions):
+    """Rebuild GenerationParameters as the extensions file plus `extensions`, rebinding the globals.
+
+    Lets contributors declared by predefined generator classes join the schema, which the
+    import-time build cannot see - those modules are imported during module activation, long after
+    this one.
+
+    Always rebuilt from `_DECLARED_EXTENSIONS` rather than from whatever the last call produced, so
+    repeated calls are idempotent. Module re-activation re-imports the generator modules and hands
+    over freshly created contributor classes; accumulating them would collide with the equivalent
+    classes from the previous activation on every field name.
+
+    A contributor the merge rejects is logged and the current class kept, so a faulty lab
+    declaration costs its own parameters rather than the whole toolchain.
+
+    Parameters
+    ----------
+    extensions : iterable of BaseGenerationParameters subclasses
+
+    Returns
+    -------
+    type
+        The class now in effect - the rebuilt one, or the existing one if the merge failed.
+    """
+    global GenerationParameters, _DEFAULT_GENERATION_PARAMETERS
+    merged = list(_DECLARED_EXTENSIONS)
+    merged.extend(cls for cls in extensions if cls not in merged)
+    try:
+        rebuilt = _build_generation_parameters(merged)
+    except TypeError:
+        _logger.exception('Cannot merge the declared generation parameter contributors. Keeping '
+                          'the current generation parameters:')
+        return GenerationParameters
+    GenerationParameters = rebuilt
+    _DEFAULT_GENERATION_PARAMETERS = rebuilt()
+    return rebuilt
 
 
 @dataclass(frozen=True)
@@ -821,7 +891,7 @@ class SequenceGeneratorSettings:
         that field's own default rather than raising KeyError."""
         return cls(
             generation_parameters=(
-                GenerationParameters.from_dict(data['generation_parameters'])
+                generation_parameters_class().from_dict(data['generation_parameters'])
                 if 'generation_parameters' in data
                 else _DEFAULT_GENERATION_PARAMETERS
             ),
@@ -859,7 +929,7 @@ class SequenceGeneratorSettings:
         generation_parameters = raw.get('_generation_parameters')
         return cls(
             generation_parameters=(
-                GenerationParameters.from_dict(generation_parameters)
+                generation_parameters_class().from_dict(generation_parameters)
                 if isinstance(generation_parameters, dict)
                 else _DEFAULT_GENERATION_PARAMETERS
             ),
@@ -871,7 +941,9 @@ class SequenceGeneratorSettings:
         if 'generation_parameters' in data:
             value = data['generation_parameters']
             generation_parameters = (
-                value if isinstance(value, GenerationParameters) else self.generation_parameters.update_from_dict(value)
+                value
+                if isinstance(value, generation_parameters_class())
+                else self.generation_parameters.update_from_dict(value)
             )
 
         pulse_generator_settings = self.pulse_generator_settings

--- a/src/qudi/logic/pulsed/pulsed_data/settings_coercion.py
+++ b/src/qudi/logic/pulsed/pulsed_data/settings_coercion.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains the shared normalization helper used by the settings setters of
+PulsedMeasurementLogic, PulsedMasterLogic and SequenceGeneratorLogic.
+
+Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-iqo-modules/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from dataclasses import fields, is_dataclass, replace
+
+__all__ = ['SettingsTypeError', 'coerce_settings', 'as_settings_dict']
+
+
+class SettingsTypeError(TypeError):
+    """Raised when a caller hands a settings setter something it cannot interpret.
+
+    """
+
+
+def coerce_settings(value, kwargs, current, cls):
+    """Normalize a settings argument into an instance of `cls`.
+
+    `cls` is the one concrete settings dataclass the call site accepts (e.g. FastCounterSettings),
+    not a generic "is this a class" check - anything that is not an instance of that type (or a
+    subclass of it), a dict, or None is rejected.
+
+    A dict means a *partial patch* relative to `current`; a `cls` instance means a *full
+    replacement*. Neither `value` nor `kwargs` is mutated.
+
+    Parameters
+    ----------
+    value : cls or dict or None
+        The settings argument as passed by the caller.
+    kwargs : dict
+        The setter's keyword arguments. Take precedence over conflicting names in `value`.
+    current : cls
+        The settings currently in effect, used as the base a partial patch is applied to.
+    cls : type
+        The settings dataclass to normalize to.
+
+    Returns
+    -------
+    cls
+        The new settings instance to apply. Never the same object as `current` unless `value`
+        happens to be `current` itself.
+
+    Raises
+    ------
+    SettingsTypeError
+        `value` is neither a `cls`, a dict, nor None.
+    TypeError
+        `cls`/`current` are inconsistent, or `kwargs` names a field `cls` does not have - both
+        are bugs in the calling module rather than bad user input.
+    """
+    if not (isinstance(cls, type) and is_dataclass(cls)):
+        raise TypeError(f'coerce_settings: cls must be a dataclass type, got {cls!r}')
+    if not isinstance(current, cls):
+        raise TypeError(f'coerce_settings: current must be a {cls.__name__}, got '
+                        f'{type(current).__name__}')
+
+    # Check for the dataclass before the dict: AnalysisParameters/ExtractionParameters/
+    # GenerationMethodParameters are dict subclasses, so isinstance(x, dict) is True for them.
+    if isinstance(value, cls):
+        if not kwargs:
+            return value
+        unknown = set(kwargs) - {f.name for f in fields(cls)}
+        if unknown:
+            raise TypeError(f'Unknown {cls.__name__} field(s): {sorted(unknown)}')
+        return replace(value, **kwargs)
+    if isinstance(value, dict):
+        return current.update_from_dict({**value, **kwargs} if kwargs else value)
+    if value is None:
+        return current.update_from_dict(kwargs)
+    raise SettingsTypeError(f'Expected {cls.__name__}, dict or None, got {type(value).__name__}')
+
+
+def as_settings_dict(value, kwargs, cls=None):
+    """Normalize a settings argument into a plain dict.
+
+    The counterpart of coerce_settings() for the relay layer, where the value has to end up as a
+    dict regardless: a QtCore.Signal(dict) cannot carry a dataclass across a thread boundary, so
+    PulsedMasterLogic must flatten before emitting. Unlike coerce_settings() this does not need
+    the current settings, since it produces a (possibly partial) dict rather than a complete
+    settings object.
+
+    Parameters
+    ----------
+    value : cls or dict or None
+        The settings argument as passed by the caller.
+    kwargs : dict
+        The setter's keyword arguments. Take precedence over conflicting names in `value`.
+    cls : type, optional
+        Settings dataclass to accept in addition to dict/None. If None, only dict/None are valid.
+
+    Returns
+    -------
+    dict
+        A new dict; neither `value` nor `kwargs` is mutated.
+
+    Raises
+    ------
+    SettingsTypeError
+        `value` is neither a `cls`, a dict, nor None.
+    """
+    if cls is not None and isinstance(value, cls):
+        return {**value.to_dict(), **kwargs}
+    if isinstance(value, dict):
+        return {**value, **kwargs}
+    if value is None:
+        return dict(kwargs)
+    expected = f'{cls.__name__}, dict or None' if cls is not None else 'dict or None'
+    raise SettingsTypeError(f'Expected {expected}, got {type(value).__name__}')

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -596,11 +596,27 @@ class PulsedMasterLogic(LogicBase):
     def benchmark_completed(self):
         self.status_dict.benchmark_busy = False
 
+    def get_pulsed_measurement(self):
+        """Full settings+data+sequence snapshot of the current measurement, combining both
+        sub-modules' state - for scripting/notebook use (see this module's own docstring, which
+        already names that as a design goal). PulsedMasterLogic is the only module with
+        Connectors to both PulsedMeasurementLogic and SequenceGeneratorLogic, so it is the only
+        place that can build the combined object.
+
+        @return PulsedMeasurement: snapshot built from independent copies (see
+            PulsedMeasurementLogic.get_pulsed_measurement()) - safe to hold onto, will not change
+            as the measurement continues running or assets get reloaded/edited later.
+        """
+        return self.pulsedmeasurementlogic().get_pulsed_measurement(
+            generator_settings=self.sequencegeneratorlogic().generator_settings
+        )
+
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
                               with_error=True, save_laser_pulses=True, save_pulsed_measurement=True,
                               save_figure=None):
         """ Prepare data to be saved and create a proper plot of the data.
-        This is just handed over to the measurement logic.
+        Combines the current SequenceGeneratorLogic settings with the measurement logic's own
+        settings/data before handing off, since only this module has Connectors to both.
 
         @param str tag: a name tag which will be included in the filename if file_path is None
         @param str file_path: optional, custom full file path including file extension to use.
@@ -630,7 +646,12 @@ class PulsedMasterLogic(LogicBase):
             save_laser_pulses=save_laser_pulses,
             save_pulsed_measurement=save_pulsed_measurement,
             save_figure=save_figure,
-            notes=notes
+            notes=notes,
+            # PulsedMasterLogic is the only module with Connectors to both PulsedMeasurementLogic
+            # and SequenceGeneratorLogic, so it is the one place that can hand the sequence
+            # generator's settings down to be included in the saved measurement metadata (see
+            # PulsedMeasurementLogic.get_pulsed_measurement()/_get_signal_metadata()).
+            generator_settings=self.sequencegeneratorlogic().generator_settings,
         )
 
     #######################################################################

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -1136,13 +1136,22 @@ class PulsedMasterLogic(LogicBase):
         return
 
     @QtCore.Slot(object, bool)
-    def predefined_sequence_generated(self, asset_name, is_sequence):
+    def predefined_sequence_generated(self, asset_name, produced_sequence):
+        """
+        Parameters
+        ----------
+        asset_name : str or None
+            Name of the generated asset, or None if generation failed.
+        produced_sequence : bool
+            Whether the generate method returned any PulseSequence. Not to be confused with
+            PulseSequence.is_sequence, which asks whether a given *object* is a sequence.
+        """
         self.status_dict.predefined_generation_busy = False
         if asset_name is None:
             self.status_dict.sampload_busy = False
-        self.sigPredefinedSequenceGenerated.emit(asset_name, is_sequence)
+        self.sigPredefinedSequenceGenerated.emit(asset_name, produced_sequence)
         if self.status_dict.sampload_busy:
-            if is_sequence:
+            if produced_sequence:
                 self.sample_sequence(asset_name, True)
             else:
                 self.sample_ensemble(asset_name, True)

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -27,11 +27,6 @@ from qudi.core.connector import Connector
 from qudi.core.module import LogicBase
 from qudi.logic.pulsed.pulsed_measurement_logic import PulsedMeasurementLogic
 from qudi.logic.pulsed.sequence_generator_logic import SequenceGeneratorLogic
-from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
-    MeasurementInformation,
-    GenerationMethodParameters,
-)
-from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 from qudi.logic.pulsed.pulsed_data.pulsed_master_logic_data import PulsedMasterStatus, FitContainers
 
 
@@ -617,6 +612,16 @@ class PulsedMasterLogic(LogicBase):
         @param bool save_figure: select whether a thumbnail plot should be saved
         @param str notes: optional, string that is included in the metadata "as-is" without a field
         """
+        still_busy = (self.status_dict.loading_busy
+                      or self.status_dict.sampload_busy
+                      or self.status_dict.sampling_ensemble_busy
+                      or self.status_dict.sampling_sequence_busy)
+        if still_busy:
+            self.log.error('Can not save measurement data while a load/sample operation is still '
+                           'in progress. The currently loaded asset\'s settings have not fully '
+                           'propagated yet - saving now would save stale data from the previously '
+                           'loaded asset. Wait for loading/sampling to finish and try again.')
+            return
         return self.pulsedmeasurementlogic().save_measurement_data(
             tag=tag,
             file_path=file_path,
@@ -822,14 +827,7 @@ class PulsedMasterLogic(LogicBase):
         else:
             object_instance = None
 
-        if object_instance is None:
-            self.pulsedmeasurementlogic().sampling_information = SamplingInformation()
-            self.pulsedmeasurementlogic().measurement_information = MeasurementInformation()
-            self.pulsedmeasurementlogic().generation_method_parameters = GenerationMethodParameters()
-        else:
-            self.pulsedmeasurementlogic().sampling_information = object_instance.sampling_information
-            self.pulsedmeasurementlogic().measurement_information = object_instance.measurement_information
-            self.pulsedmeasurementlogic().generation_method_parameters = object_instance.generation_method_parameters
+        self.pulsedmeasurementlogic().loaded_asset = object_instance
         return
 
     @QtCore.Slot(object)

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -28,6 +28,16 @@ from qudi.core.module import LogicBase
 from qudi.logic.pulsed.pulsed_measurement_logic import PulsedMeasurementLogic
 from qudi.logic.pulsed.sequence_generator_logic import SequenceGeneratorLogic
 from qudi.logic.pulsed.pulsed_data.pulsed_master_logic_data import PulsedMasterStatus, FitContainers
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    FastCounterSettings,
+    MicrowaveSettings,
+    ReadoutSettings,
+)
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
+    GenerationParameters,
+    PulseGeneratorSettings,
+)
+from qudi.logic.pulsed.pulsed_data.settings_coercion import SettingsTypeError, as_settings_dict
 
 
 class PulsedMasterLogic(LogicBase):
@@ -254,8 +264,6 @@ class PulsedMasterLogic(LogicBase):
 
     def on_deactivate(self):
         """
-
-        @return:
         """
         # Disconnect all signals
         # Disconnect signals controlling PulsedMeasurementLogic
@@ -414,91 +422,119 @@ class PulsedMasterLogic(LogicBase):
     #######################################################################
     ###             Pulsed measurement methods                          ###
     #######################################################################
-    @QtCore.Slot(dict)
-    def set_measurement_settings(self, settings_dict=None, **kwargs):
-        """
+    def _relay_settings(self, signal, settings, kwargs, name, dataclass_type=None):
+        """Normalize a settings argument to a plain dict and emit it on `signal`.
 
-        @param settings_dict:
-        @param kwargs:
+        A QtCore.Signal(dict) cannot carry a dataclass across the queued cross-thread connection
+        to the target logic module, so a dataclass argument has to be flattened here rather than
+        passed through. A caller mistake is logged rather than raised: these are queued slots,
+        where an escaping exception cannot reach the emitter and may take the whole application
+        down mid-measurement.
+
+        Returns
+        -------
+        dict or None
+            The dict that was emitted, or None if the argument could not be interpreted.
         """
-        if isinstance(settings_dict, dict):
-            self.sigMeasurementSettingsChanged.emit(settings_dict)
-        else:
-            self.sigMeasurementSettingsChanged.emit(kwargs)
+        try:
+            settings_dict = as_settings_dict(settings, kwargs, dataclass_type)
+        except SettingsTypeError as err:
+            self.log.error(f'Unable to change {name}. {err}')
+            return None
+        signal.emit(settings_dict)
+        return settings_dict
+
+    @QtCore.Slot(dict)
+    def set_measurement_settings(self, settings=None, **kwargs):
+        """
+        Parameters
+        ----------
+        settings : ReadoutSettings or dict or None
+        kwargs
+        """
+        self._relay_settings(self.sigMeasurementSettingsChanged, settings, kwargs,
+                             'measurement settings', ReadoutSettings)
         return
 
     @QtCore.Slot(dict)
-    def set_fast_counter_settings(self, settings_dict=None, **kwargs):
+    def set_fast_counter_settings(self, settings=None, **kwargs):
         """
-
-        @param settings_dict:
-        @param kwargs:
+        Parameters
+        ----------
+        settings : FastCounterSettings or dict or None
+        kwargs
         """
-        if isinstance(settings_dict, dict):
-            self.sigFastCounterSettingsChanged.emit(settings_dict)
-        else:
-            self.sigFastCounterSettingsChanged.emit(kwargs)
+        self._relay_settings(self.sigFastCounterSettingsChanged, settings, kwargs,
+                             'fast counter settings', FastCounterSettings)
         return
 
     @QtCore.Slot(dict)
-    def set_ext_microwave_settings(self, settings_dict=None, **kwargs):
+    def set_ext_microwave_settings(self, settings=None, **kwargs):
         """
-
-        @param settings_dict:
-        @param kwargs:
+        Parameters
+        ----------
+        settings : MicrowaveSettings or dict or None
+        kwargs
         """
-        if isinstance(settings_dict, dict):
-            self.sigExtMicrowaveSettingsChanged.emit(settings_dict)
-        else:
-            self.sigExtMicrowaveSettingsChanged.emit(kwargs)
+        self._relay_settings(self.sigExtMicrowaveSettingsChanged, settings, kwargs,
+                             'external microwave settings', MicrowaveSettings)
         return
 
     @QtCore.Slot(dict)
-    def set_analysis_settings(self, settings_dict=None, **kwargs):
+    def set_analysis_settings(self, settings=None, **kwargs):
         """
-
-        @param settings_dict:
-        @param kwargs:
+        Parameters
+        ----------
+        settings : dict or None
+        kwargs
         """
-        if isinstance(settings_dict, dict):
-            self.sigAnalysisSettingsChanged.emit(settings_dict)
-        else:
-            self.sigAnalysisSettingsChanged.emit(kwargs)
+        # No dataclass counterpart: AnalysisParameters is a dict subclass because the parameter
+        # names are discovered at runtime from whichever analysis method is selected.
+        self._relay_settings(self.sigAnalysisSettingsChanged, settings, kwargs,
+                             'analysis settings')
         return
 
     @QtCore.Slot(dict)
-    def set_extraction_settings(self, settings_dict=None, **kwargs):
+    def set_extraction_settings(self, settings=None, **kwargs):
         """
-
-        @param settings_dict:
-        @param kwargs:
+        Parameters
+        ----------
+        settings : dict or None
+        kwargs
         """
-        if isinstance(settings_dict, dict):
-            self.sigExtractionSettingsChanged.emit(settings_dict)
-        else:
-            self.sigExtractionSettingsChanged.emit(kwargs)
+        # No dataclass counterpart - see set_analysis_settings above.
+        self._relay_settings(self.sigExtractionSettingsChanged, settings, kwargs,
+                             'extraction settings')
         return
 
     @QtCore.Slot(int)
     @QtCore.Slot(float)
     def set_timer_interval(self, interval):
         """
-
-        @param int|float interval: The timer interval to set in seconds.
+        Parameters
+        ----------
+        interval : int or float
+            The timer interval to set in seconds.
         """
-        if isinstance(interval, (int, float)):
-            self.sigTimerIntervalChanged.emit(interval)
+        if not isinstance(interval, (int, float)) or isinstance(interval, bool):
+            self.log.error(f'Unable to change timer interval. Expected int or float, got '
+                           f'{type(interval).__name__}.')
+            return
+        self.sigTimerIntervalChanged.emit(interval)
         return
 
     @QtCore.Slot(str)
     def set_alternative_data_type(self, alt_data_type):
         """
-
-        @param alt_data_type:
-        @return:
+        Parameters
+        ----------
+        alt_data_type
         """
-        if isinstance(alt_data_type, str):
-            self.sigAlternativeDataTypeChanged.emit(alt_data_type)
+        if not isinstance(alt_data_type, str):
+            self.log.error(f'Unable to change alternative data type. Expected str, got '
+                           f'{type(alt_data_type).__name__}.')
+            return
+        self.sigAlternativeDataTypeChanged.emit(alt_data_type)
         return
 
     @QtCore.Slot()
@@ -511,8 +547,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool)
     def toggle_ext_microwave(self, switch_on):
         """
-
-        @param switch_on:
+        Parameters
+        ----------
+        switch_on
         """
         if isinstance(switch_on, bool):
             self.sigToggleExtMicrowave.emit(switch_on)
@@ -521,8 +558,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool)
     def ext_microwave_running_updated(self, is_running):
         """
-
-        @param is_running:
+        Parameters
+        ----------
+        is_running
         """
         if isinstance(is_running, bool):
             self.status_dict.microwave_running = is_running
@@ -532,8 +570,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool)
     def toggle_pulse_generator(self, switch_on):
         """
-
-        @param switch_on:
+        Parameters
+        ----------
+        switch_on
         """
         if isinstance(switch_on, bool):
             self.sigTogglePulser.emit(switch_on)
@@ -542,8 +581,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool)
     def pulser_running_updated(self, is_running):
         """
-
-        @param is_running:
+        Parameters
+        ----------
+        is_running
         """
         if isinstance(is_running, bool):
             self.status_dict.pulser_running = is_running
@@ -554,9 +594,10 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool, str)
     def toggle_pulsed_measurement(self, start, stash_raw_data_tag=''):
         """
-
-        @param bool start:
-        @param str stash_raw_data_tag:
+        Parameters
+        ----------
+        start : bool
+        stash_raw_data_tag : str
         """
         if isinstance(start, bool) and isinstance(stash_raw_data_tag, str):
             self.sigToggleMeasurement.emit(start, stash_raw_data_tag)
@@ -565,8 +606,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool)
     def toggle_pulsed_measurement_pause(self, pause):
         """
-
-        @param pause:
+        Parameters
+        ----------
+        pause
         """
         if isinstance(pause, bool):
             self.sigToggleMeasurementPause.emit(pause)
@@ -575,9 +617,10 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(bool, bool)
     def measurement_status_updated(self, is_running, is_paused):
         """
-
-        @param is_running:
-        @param is_paused:
+        Parameters
+        ----------
+        is_running
+        is_paused
         """
         if isinstance(is_running, bool) and isinstance(is_paused, bool):
             self.status_dict.measurement_running = is_running
@@ -588,9 +631,10 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str, bool)
     def do_fit(self, fit_function, use_alternative_data=False):
         """
-
-        @param str fit_function:
-        @param bool use_alternative_data:
+        Parameters
+        ----------
+        fit_function : str
+        use_alternative_data : bool
         """
         if isinstance(fit_function, str) and isinstance(use_alternative_data, bool):
             self.status_dict.fitting_busy = True
@@ -600,8 +644,6 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str, object, bool)
     def fit_updated(self, fit_name, fit_result, use_alternative_data):
         """
-
-        @return:
         """
         self.status_dict.fitting_busy = False
         self.sigFitUpdated.emit(fit_name, fit_result, use_alternative_data)
@@ -619,7 +661,10 @@ class PulsedMasterLogic(LogicBase):
         place that can build the combined object - including resolving the loaded asset's
         ensemble/block closure, which requires SequenceGeneratorLogic's saved-asset registries.
 
-        @return PulsedMeasurement: snapshot built from independent copies (see
+        Returns
+        -------
+        PulsedMeasurement
+            Snapshot built from independent copies (see
             PulsedMeasurementLogic.get_pulsed_measurement()) - safe to hold onto, will not change
             as the measurement continues running or assets get reloaded/edited later.
         """
@@ -639,16 +684,27 @@ class PulsedMasterLogic(LogicBase):
         Combines the current SequenceGeneratorLogic settings with the measurement logic's own
         settings/data before handing off, since only this module has Connectors to both.
 
-        @param str tag: a name tag which will be included in the filename if file_path is None
-        @param str file_path: optional, custom full file path including file extension to use.
-                              If given, tag is ignored.
-        @param type storage_cls: optional, the explicit data storage class to use
-        @param bool with_error: select whether errors should be saved/plotted
-        @param bool save_laser_pulses: select whether extracted lasers should be saved
-        @param bool save_pulsed_measurement: select whether final measurement should be saved
-        @param bool save_figure: select whether a thumbnail plot should be saved
-        @param str notes: optional, string that is included in the metadata "as-is" without a field
-        @param bool save_measurement_snapshot: optional, additionally pickle the complete
+        Parameters
+        ----------
+        tag : str
+            A name tag which will be included in the filename if file_path is None.
+        file_path : str
+            Optional, custom full file path including file extension to use.
+            If given, tag is ignored.
+        storage_cls : type
+            Optional, the explicit data storage class to use.
+        with_error : bool
+            Select whether errors should be plotted.
+        save_laser_pulses : bool
+            Select whether extracted lasers should be saved.
+        save_pulsed_measurement : bool
+            Select whether final measurement should be saved.
+        save_figure : bool
+            Select whether a thumbnail plot should be saved.
+        notes : str
+            Optional, string that is included in the metadata "as-is" without a field.
+        save_measurement_snapshot : bool
+            Optional, additionally pickle the complete
             PulsedMeasurement snapshot (settings + data + the loaded sequence/ensemble) to a
             single '.pulsedmeasurement' file - see PulsedMeasurementLogic.save_measurement_data().
         """
@@ -870,10 +926,10 @@ class PulsedMasterLogic(LogicBase):
 
     def loaded_asset_updated(self, asset_name, asset_type):
         """
-
-        @param asset_name:
-        @param asset_type:
-        @return:
+        Parameters
+        ----------
+        asset_name
+        asset_type
         """
         self.status_dict.sampload_busy = False
         self.status_dict.loading_busy = False
@@ -902,9 +958,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(object)
     def save_pulse_block(self, block_instance):
         """
-
-        @param block_instance:
-        @return:
+        Parameters
+        ----------
+        block_instance
         """
         self.sigSavePulseBlock.emit(block_instance)
         return
@@ -912,10 +968,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(object)
     def save_block_ensemble(self, ensemble_instance):
         """
-
-
-        @param ensemble_instance:
-        @return:
+        Parameters
+        ----------
+        ensemble_instance
         """
         self.sigSaveBlockEnsemble.emit(ensemble_instance)
         return
@@ -923,9 +978,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(object)
     def save_sequence(self, sequence_instance):
         """
-
-        @param sequence_instance:
-        @return:
+        Parameters
+        ----------
+        sequence_instance
         """
         self.sigSaveSequence.emit(sequence_instance)
         return
@@ -933,9 +988,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str)
     def delete_pulse_block(self, block_name):
         """
-
-        @param block_name:
-        @return:
+        Parameters
+        ----------
+        block_name
         """
         self.sigDeletePulseBlock.emit(block_name)
         return
@@ -953,9 +1008,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str)
     def delete_block_ensemble(self, ensemble_name):
         """
-
-        @param ensemble_name:
-        @return:
+        Parameters
+        ----------
+        ensemble_name
         """
         if (self.status_dict.pulser_running and self.loaded_asset.name == ensemble_name
                 and self.loaded_asset.asset_type == 'PulseBlockEnsemble'):
@@ -983,9 +1038,9 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str)
     def delete_sequence(self, sequence_name):
         """
-
-        @param sequence_name:
-        @return:
+        Parameters
+        ----------
+        sequence_name
         """
         if (self.status_dict.pulser_running and self.loaded_asset.name == sequence_name
                 and self.loaded_asset.asset_type == 'PulseSequence'):
@@ -1020,40 +1075,40 @@ class PulsedMasterLogic(LogicBase):
         self.sigGeneratorSettingsChanged.emit({})
 
     @QtCore.Slot(dict)
-    def set_pulse_generator_settings(self, settings_dict=None, **kwargs):
+    def set_pulse_generator_settings(self, settings=None, **kwargs):
         """
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accept a PulseGeneratorSettings instance or a settings dictionary as positional
+        argument, or keyword arguments. If both are present both are being used by updating the
+        settings_dict with kwargs. The keyword arguments take precedence over the items in
+        settings_dict if there are conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings : PulseGeneratorSettings or dict or None
+        kwargs
         """
-        if not isinstance(settings_dict, dict):
-            settings_dict = kwargs
-        else:
-            settings_dict.update(kwargs)
-        self.sigGeneratorSettingsChanged.emit(settings_dict)
+        self._relay_settings(self.sigGeneratorSettingsChanged, settings, kwargs,
+                             'pulse generator settings', PulseGeneratorSettings)
         return
 
     @QtCore.Slot(dict)
-    def set_generation_parameters(self, settings_dict=None, **kwargs):
+    def set_generation_parameters(self, settings=None, **kwargs):
         """
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accept a GenerationParameters instance or a settings dictionary as positional
+        argument, or keyword arguments. If both are present both are being used by updating the
+        settings_dict with kwargs. The keyword arguments take precedence over the items in
+        settings_dict if there are conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings : GenerationParameters or dict or None
+        kwargs
         """
-        if not isinstance(settings_dict, dict):
-            settings_dict = kwargs
-        else:
-            settings_dict.update(kwargs)
+        try:
+            settings_dict = as_settings_dict(settings, kwargs, GenerationParameters)
+        except SettingsTypeError as err:
+            self.log.error(f'Unable to change generation parameters. {err}')
+            return
 
         # Force empty gate channel if fast counter is not gated
         if 'gate_channel' in settings_dict and not self.fast_counter_settings.get('is_gated'):
@@ -1066,11 +1121,11 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str, dict, bool)
     def generate_predefined_sequence(self, generator_method_name, kwarg_dict=None, sample_and_load=False):
         """
-
-        @param generator_method_name:
-        @param kwarg_dict:
-        @param sample_and_load:
-        @return:
+        Parameters
+        ----------
+        generator_method_name
+        kwarg_dict
+        sample_and_load
         """
         if not isinstance(kwarg_dict, dict):
             kwarg_dict = dict()
@@ -1101,8 +1156,15 @@ class PulsedMasterLogic(LogicBase):
         Will return information like length in seconds and bins (with currently set sampling rate)
         as well as number of laser pulses (with currently selected laser/gate channel)
 
-        @param PulseBlockEnsemble ensemble: The PulseBlockEnsemble instance to analyze
-        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
+        Parameters
+        ----------
+        ensemble : PulseBlockEnsemble
+            The PulseBlockEnsemble instance to analyze.
+
+        Returns
+        -------
+        (float, int, int)
+            Length in seconds, length in bins, number of laser/gate pulses.
         """
         return self.sequencegeneratorlogic().get_ensemble_info(ensemble=ensemble)
 
@@ -1112,8 +1174,15 @@ class PulsedMasterLogic(LogicBase):
         seconds and bins (with currently set sampling rate), number of laser pulses (with currently
         selected laser/gate channel)
 
-        @param PulseSequence sequence: The PulseSequence instance to analyze
-        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
+        Parameters
+        ----------
+        sequence : PulseSequence
+            The PulseSequence instance to analyze.
+
+        Returns
+        -------
+        (float, int, int)
+            Length in seconds, length in bins, number of laser/gate pulses.
         """
         return self.sequencegeneratorlogic().get_sequence_info(sequence=sequence)
 
@@ -1132,19 +1201,26 @@ class PulsedMasterLogic(LogicBase):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param ensemble: A PulseBlockEnsemble object (see logic.pulse_objects.py)
-        @return: number_of_samples (int): The total number of samples in a Waveform provided the
-                                              current sample_rate and PulseBlockEnsemble object.
-                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
-                                       the provided PulseBlockEnsemble.
-                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
-                                                               PulseBlockElement in chronological
-                                                               order (incl. repetitions).
-                 digital_rising_bins (dict): Dictionary with keys being the digital channel
-                                             descriptor string and items being arrays of
-                                             chronological low-to-high transition positions
-                                             (in timebins; incl. repetitions) for each digital
-                                             channel.
+        Parameters
+        ----------
+        ensemble
+            A PulseBlockEnsemble object (see logic.pulse_objects.py).
+
+        Returns
+        -------
+        number_of_samples : int
+            The total number of samples in a Waveform provided the current sample_rate and
+            PulseBlockEnsemble object.
+        total_elements : int
+            The total number of PulseBlockElements (incl. repetitions) in the provided
+            PulseBlockEnsemble.
+        elements_length_bins : 1D numpy.ndarray[int]
+            Array of number of timebins for each PulseBlockElement in chronological order
+            (incl. repetitions).
+        digital_rising_bins : dict
+            Dictionary with keys being the digital channel descriptor string and items being
+            arrays of chronological low-to-high transition positions (in timebins; incl.
+            repetitions) for each digital channel.
         """
         return self.sequencegeneratorlogic().analyze_block_ensemble(ensemble=ensemble)
 
@@ -1163,19 +1239,26 @@ class PulsedMasterLogic(LogicBase):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param sequence: A PulseSequence object (see logic.pulse_objects.py)
-        @return: number_of_samples (int): The total number of samples in a Waveform provided the
-                                              current sample_rate and PulseBlockEnsemble object.
-                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
-                                       the provided PulseBlockEnsemble.
-                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
-                                                               PulseBlockElement in chronological
-                                                               order (incl. repetitions).
-                 digital_rising_bins (dict): Dictionary with keys being the digital channel
-                                             descriptor string and items being arrays of
-                                             chronological low-to-high transition positions
-                                             (in timebins; incl. repetitions) for each digital
-                                             channel.
+        Parameters
+        ----------
+        sequence
+            A PulseSequence object (see logic.pulse_objects.py).
+
+        Returns
+        -------
+        number_of_samples : int
+            The total number of samples in a Waveform provided the current sample_rate and
+            PulseBlockEnsemble object.
+        total_elements : int
+            The total number of PulseBlockElements (incl. repetitions) in the provided
+            PulseBlockEnsemble.
+        elements_length_bins : 1D numpy.ndarray[int]
+            Array of number of timebins for each PulseBlockElement in chronological order
+            (incl. repetitions).
+        digital_rising_bins : dict
+            Dictionary with keys being the digital channel descriptor string and items being
+            arrays of chronological low-to-high transition positions (in timebins; incl.
+            repetitions) for each digital channel.
         """
         return self.sequencegeneratorlogic().analyze_sequence(sequence=sequence)
 
@@ -1185,8 +1268,9 @@ class PulsedMasterLogic(LogicBase):
     # def _get_asset_parameters(self, asset_obj):
     #     """
     #
-    #     @param asset_obj:
-    #     @return:
+    #     Parameters
+    #     ----------
+    #     asset_obj
     #     """
     #     if type(asset_obj).__name__ == 'PulseSequence':
     #         self.log.warning('Calculation of measurement sequence parameters not implemented yet '

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -34,7 +34,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     ReadoutSettings,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
-    GenerationParameters,
+    generation_parameters_class,
     PulseGeneratorSettings,
 )
 from qudi.logic.pulsed.pulsed_data.settings_coercion import SettingsTypeError, as_settings_dict
@@ -1105,7 +1105,7 @@ class PulsedMasterLogic(LogicBase):
         kwargs
         """
         try:
-            settings_dict = as_settings_dict(settings, kwargs, GenerationParameters)
+            settings_dict = as_settings_dict(settings, kwargs, generation_parameters_class())
         except SettingsTypeError as err:
             self.log.error(f'Unable to change generation parameters. {err}')
             return

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -27,6 +27,12 @@ from qudi.core.connector import Connector
 from qudi.core.module import LogicBase
 from qudi.logic.pulsed.pulsed_measurement_logic import PulsedMeasurementLogic
 from qudi.logic.pulsed.sequence_generator_logic import SequenceGeneratorLogic
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    MeasurementInformation,
+    GenerationMethodParameters,
+)
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
+from qudi.logic.pulsed.pulsed_data.pulsed_master_logic_data import PulsedMasterStatus, FitContainers
 
 
 class PulsedMasterLogic(LogicBase):
@@ -124,24 +130,15 @@ class PulsedMasterLogic(LogicBase):
         """
         super().__init__(*args, **kwargs)
 
-        # Dictionary servings as status register
-        self.status_dict = dict()
+        # Container serving as status register
+        self.status_dict = PulsedMasterStatus()
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
 
         # Initialize status register
-        self.status_dict = {'sampling_ensemble_busy': False,
-                            'sampling_sequence_busy': False,
-                            'sampload_busy': False,
-                            'loading_busy': False,
-                            'pulser_running': False,
-                            'measurement_running': False,
-                            'microwave_running': False,
-                            'predefined_generation_busy': False,
-                            'fitting_busy': False,
-                            'benchmark_busy': False}
+        self.status_dict = PulsedMasterStatus()
 
         # Connect signals controlling PulsedMeasurementLogic
         self.sigDoFit.connect(
@@ -393,7 +390,8 @@ class PulsedMasterLogic(LogicBase):
 
     @property
     def fit_containers(self):
-        return self.pulsedmeasurementlogic().fc, self.pulsedmeasurementlogic().alt_fc
+        return FitContainers(primary=self.pulsedmeasurementlogic().fc,
+                             alternative=self.pulsedmeasurementlogic().alt_fc)
 
     @property
     def fit_config_model(self):
@@ -517,7 +515,7 @@ class PulsedMasterLogic(LogicBase):
         @param is_running:
         """
         if isinstance(is_running, bool):
-            self.status_dict['microwave_running'] = is_running
+            self.status_dict.microwave_running = is_running
             self.sigExtMicrowaveRunningUpdated.emit(is_running)
         return
 
@@ -538,7 +536,7 @@ class PulsedMasterLogic(LogicBase):
         @param is_running:
         """
         if isinstance(is_running, bool):
-            self.status_dict['pulser_running'] = is_running
+            self.status_dict.pulser_running = is_running
             self.sigPulserRunningUpdated.emit(is_running)
         return
 
@@ -572,7 +570,7 @@ class PulsedMasterLogic(LogicBase):
         @param is_paused:
         """
         if isinstance(is_running, bool) and isinstance(is_paused, bool):
-            self.status_dict['measurement_running'] = is_running
+            self.status_dict.measurement_running = is_running
             self.sigMeasurementStatusUpdated.emit(is_running, is_paused)
         return
 
@@ -585,7 +583,7 @@ class PulsedMasterLogic(LogicBase):
         @param bool use_alternative_data:
         """
         if isinstance(fit_function, str) and isinstance(use_alternative_data, bool):
-            self.status_dict['fitting_busy'] = True
+            self.status_dict.fitting_busy = True
             self.sigDoFit.emit(fit_function, use_alternative_data)
         return
 
@@ -595,13 +593,13 @@ class PulsedMasterLogic(LogicBase):
 
         @return:
         """
-        self.status_dict['fitting_busy'] = False
+        self.status_dict.fitting_busy = False
         self.sigFitUpdated.emit(fit_name, fit_result, use_alternative_data)
         return
 
     @QtCore.Slot()
     def benchmark_completed(self):
-        self.status_dict['benchmark_busy'] = False
+        self.status_dict.benchmark_busy = False
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
                               with_error=True, save_laser_pulses=True, save_pulsed_measurement=True,
@@ -690,15 +688,16 @@ class PulsedMasterLogic(LogicBase):
     #######################################################################
     @QtCore.Slot()
     def clear_pulse_generator(self):
-        still_busy = self.status_dict['sampling_ensemble_busy'] or self.status_dict[
-            'sampling_sequence_busy'] or self.status_dict['loading_busy'] or self.status_dict[
-                                   'sampload_busy']
+        still_busy = (self.status_dict.sampling_ensemble_busy
+                      or self.status_dict.sampling_sequence_busy
+                      or self.status_dict.loading_busy
+                      or self.status_dict.sampload_busy)
         if still_busy:
             self.log.error('Can not clear pulse generator. Sampling/Loading still in progress.')
-        elif self.status_dict['measurement_running']:
+        elif self.status_dict.measurement_running:
             self.log.error('Can not clear pulse generator. Measurement is still running.')
         else:
-            if self.status_dict['pulser_running']:
+            if self.status_dict.pulser_running:
                 self.log.warning('Can not clear pulse generator while it is still running. '
                                  'Turned off.')
                 self.pulsedmeasurementlogic().pulse_generator_off()
@@ -708,25 +707,26 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str)
     @QtCore.Slot(str, bool)
     def sample_ensemble(self, ensemble_name, with_load=False):
-        already_busy = self.status_dict['sampling_ensemble_busy'] or self.status_dict[
-            'sampling_sequence_busy'] or self.sequencegeneratorlogic().module_state() == 'locked'
+        already_busy = (self.status_dict.sampling_ensemble_busy
+                        or self.status_dict.sampling_sequence_busy
+                        or self.sequencegeneratorlogic().module_state() == 'locked')
         if already_busy:
             self.log.error('Sampling of a different asset already in progress.\n'
                            'PulseBlockEnsemble "{0}" not sampled!'.format(ensemble_name))
         else:
             if with_load:
-                self.status_dict['sampload_busy'] = True
-            self.status_dict['sampling_ensemble_busy'] = True
+                self.status_dict.sampload_busy = True
+            self.status_dict.sampling_ensemble_busy = True
             self.sigSampleBlockEnsemble.emit(ensemble_name)
         return
 
     @QtCore.Slot(object)
     def sample_ensemble_finished(self, ensemble):
-        self.status_dict['sampling_ensemble_busy'] = False
+        self.status_dict.sampling_ensemble_busy = False
         self.sigSampleEnsembleComplete.emit(ensemble)
-        if self.status_dict['sampload_busy'] and not self.status_dict['sampling_sequence_busy']:
+        if self.status_dict.sampload_busy and not self.status_dict.sampling_sequence_busy:
             if ensemble is None:
-                self.status_dict['sampload_busy'] = False
+                self.status_dict.sampload_busy = False
                 self.sigLoadedAssetUpdated.emit(*self.loaded_asset)
             else:
                 self.load_ensemble(ensemble.name)
@@ -735,25 +735,26 @@ class PulsedMasterLogic(LogicBase):
     @QtCore.Slot(str)
     @QtCore.Slot(str, bool)
     def sample_sequence(self, sequence_name, with_load=False):
-        already_busy = self.status_dict['sampling_ensemble_busy'] or self.status_dict[
-            'sampling_sequence_busy'] or self.sequencegeneratorlogic().module_state() == 'locked'
+        already_busy = (self.status_dict.sampling_ensemble_busy
+                        or self.status_dict.sampling_sequence_busy
+                        or self.sequencegeneratorlogic().module_state() == 'locked')
         if already_busy:
             self.log.error('Sampling of a different asset already in progress.\n'
                            'PulseSequence "{0}" not sampled!'.format(sequence_name))
         else:
             if with_load:
-                self.status_dict['sampload_busy'] = True
-            self.status_dict['sampling_sequence_busy'] = True
+                self.status_dict.sampload_busy = True
+            self.status_dict.sampling_sequence_busy = True
             self.sigSampleSequence.emit(sequence_name)
         return
 
     @QtCore.Slot(object)
     def sample_sequence_finished(self, sequence):
-        self.status_dict['sampling_sequence_busy'] = False
+        self.status_dict.sampling_sequence_busy = False
         self.sigSampleSequenceComplete.emit(sequence)
-        if self.status_dict['sampload_busy']:
+        if self.status_dict.sampload_busy:
             if sequence is None:
-                self.status_dict['sampload_busy'] = False
+                self.status_dict.sampload_busy = False
                 self.sigLoadedAssetUpdated.emit(*self.loaded_asset)
             else:
                 self.load_sequence(sequence.name)
@@ -761,17 +762,17 @@ class PulsedMasterLogic(LogicBase):
 
     @QtCore.Slot(str)
     def load_ensemble(self, ensemble_name):
-        if self.status_dict['loading_busy']:
+        if self.status_dict.loading_busy:
             self.log.error('Loading of a different asset already in progress.\n'
                            'PulseBlockEnsemble "{0}" not loaded!'.format(ensemble_name))
             self.loaded_asset_updated(*self.loaded_asset)
-        elif self.status_dict['measurement_running']:
+        elif self.status_dict.measurement_running:
             self.log.error('Loading of ensemble not possible while measurement is running.\n'
                            'PulseBlockEnsemble "{0}" not loaded!'.format(ensemble_name))
             self.loaded_asset_updated(*self.loaded_asset)
         else:
-            self.status_dict['loading_busy'] = True
-            if self.status_dict['pulser_running']:
+            self.status_dict.loading_busy = True
+            if self.status_dict.pulser_running:
                 self.log.warning('Can not load new asset into pulse generator while it is still '
                                  'running. Turned off.')
                 self.pulsedmeasurementlogic().pulse_generator_off()
@@ -780,17 +781,17 @@ class PulsedMasterLogic(LogicBase):
 
     @QtCore.Slot(str)
     def load_sequence(self, sequence_name):
-        if self.status_dict['loading_busy']:
+        if self.status_dict.loading_busy:
             self.log.error('Loading of a different asset already in progress.\n'
                            'PulseSequence "{0}" not loaded!'.format(sequence_name))
             self.loaded_asset_updated(*self.loaded_asset)
-        elif self.status_dict['measurement_running']:
+        elif self.status_dict.measurement_running:
             self.log.error('Loading of sequence not possible while measurement is running.\n'
                            'PulseSequence "{0}" not loaded!'.format(sequence_name))
             self.loaded_asset_updated(*self.loaded_asset)
         else:
-            self.status_dict['loading_busy'] = True
-            if self.status_dict['pulser_running']:
+            self.status_dict.loading_busy = True
+            if self.status_dict.pulser_running:
                 self.log.warning('Can not load new asset into pulse generator while it is still '
                                  'running. Turned off.')
                 self.pulsedmeasurementlogic().pulse_generator_off()
@@ -805,14 +806,14 @@ class PulsedMasterLogic(LogicBase):
         @param asset_type:
         @return:
         """
-        self.status_dict['sampload_busy'] = False
-        self.status_dict['loading_busy'] = False
+        self.status_dict.sampload_busy = False
+        self.status_dict.loading_busy = False
         self.sigLoadedAssetUpdated.emit(asset_name, asset_type)
         # Transfer sequence information from PulseBlockEnsemble or PulseSequence to
         # PulsedMeasurementLogic to be able to invoke measurement settings from them
         if not asset_type:
-            # If no asset loaded or asset type unknown, clear sequence_information dict
-
+            # If no asset loaded or asset type unknown, clear the sampling/measurement/generation
+            # information containers below
             object_instance = None
         elif asset_type == 'PulseBlockEnsemble':
             object_instance = self.saved_pulse_block_ensembles.get(asset_name)
@@ -822,9 +823,9 @@ class PulsedMasterLogic(LogicBase):
             object_instance = None
 
         if object_instance is None:
-            self.pulsedmeasurementlogic().sampling_information = dict()
-            self.pulsedmeasurementlogic().measurement_information = dict()
-            self.pulsedmeasurementlogic().generation_method_parameters =  dict()
+            self.pulsedmeasurementlogic().sampling_information = SamplingInformation()
+            self.pulsedmeasurementlogic().measurement_information = MeasurementInformation()
+            self.pulsedmeasurementlogic().generation_method_parameters = GenerationMethodParameters()
         else:
             self.pulsedmeasurementlogic().sampling_information = object_instance.sampling_information
             self.pulsedmeasurementlogic().measurement_information = object_instance.measurement_information
@@ -889,7 +890,8 @@ class PulsedMasterLogic(LogicBase):
         @param ensemble_name:
         @return:
         """
-        if self.status_dict['pulser_running'] and self.loaded_asset[0] == ensemble_name and self.loaded_asset[1] == 'PulseBlockEnsemble':
+        if (self.status_dict.pulser_running and self.loaded_asset.name == ensemble_name
+                and self.loaded_asset.asset_type == 'PulseBlockEnsemble'):
             self.log.error('Can not delete PulseBlockEnsemble "{0}" since the corresponding '
                            'waveform(s) is(are) currently loaded and running.'
                            ''.format(ensemble_name))
@@ -902,7 +904,7 @@ class PulsedMasterLogic(LogicBase):
         """
         Helper method to delete all pulse block ensembles at once.
         """
-        if self.status_dict['pulser_running'] or self.status_dict['measurement_running']:
+        if self.status_dict.pulser_running or self.status_dict.measurement_running:
             self.log.error('Can not delete all PulseBlockEnsembles. Pulse generator is currently '
                            'running or measurement is in progress.')
         else:
@@ -918,7 +920,8 @@ class PulsedMasterLogic(LogicBase):
         @param sequence_name:
         @return:
         """
-        if self.status_dict['pulser_running'] and self.loaded_asset[0] == sequence_name and self.loaded_asset[1] == 'PulseSequence':
+        if (self.status_dict.pulser_running and self.loaded_asset.name == sequence_name
+                and self.loaded_asset.asset_type == 'PulseSequence'):
             self.log.error('Can not delete PulseSequence "{0}" since the corresponding sequence is '
                            'currently loaded and running.'.format(sequence_name))
         else:
@@ -930,7 +933,7 @@ class PulsedMasterLogic(LogicBase):
         """
         Helper method to delete all pulse sequences at once.
         """
-        if self.status_dict['pulser_running'] or self.status_dict['measurement_running']:
+        if self.status_dict.pulser_running or self.status_dict.measurement_running:
             self.log.error('Can not delete all PulseSequences. Pulse generator is currently '
                            'running or measurement is in progress.')
         else:
@@ -1004,19 +1007,19 @@ class PulsedMasterLogic(LogicBase):
         """
         if not isinstance(kwarg_dict, dict):
             kwarg_dict = dict()
-        self.status_dict['predefined_generation_busy'] = True
+        self.status_dict.predefined_generation_busy = True
         if sample_and_load:
-            self.status_dict['sampload_busy'] = True
+            self.status_dict.sampload_busy = True
         self.sigGeneratePredefinedSequence.emit(generator_method_name, kwarg_dict)
         return
 
     @QtCore.Slot(object, bool)
     def predefined_sequence_generated(self, asset_name, is_sequence):
-        self.status_dict['predefined_generation_busy'] = False
+        self.status_dict.predefined_generation_busy = False
         if asset_name is None:
-            self.status_dict['sampload_busy'] = False
+            self.status_dict.sampload_busy = False
         self.sigPredefinedSequenceGenerated.emit(asset_name, is_sequence)
-        if self.status_dict['sampload_busy']:
+        if self.status_dict.sampload_busy:
             if is_sequence:
                 self.sample_sequence(asset_name, True)
             else:

--- a/src/qudi/logic/pulsed/pulsed_master_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_master_logic.py
@@ -232,6 +232,13 @@ class PulsedMasterLogic(LogicBase):
             self.sigGeneratorSettingsUpdated, QtCore.Qt.ConnectionType.QueuedConnection)
         self.sequencegeneratorlogic().sigSamplingSettingsUpdated.connect(
             self.sigSamplingSettingsUpdated, QtCore.Qt.ConnectionType.QueuedConnection)
+        # Step 3 of the PulsedMeasurement consolidation: keep PulsedMeasurementLogic's held
+        # generator_settings fresh without giving SequenceGeneratorLogic a Connector to it -
+        # PulsedMasterLogic already has connectors to both, so it relays the push instead.
+        self.sequencegeneratorlogic().sigGeneratorSettingsUpdated.connect(
+            self._refresh_measurement_logic_generator_settings, QtCore.Qt.ConnectionType.QueuedConnection)
+        self.sequencegeneratorlogic().sigSamplingSettingsUpdated.connect(
+            self._refresh_measurement_logic_generator_settings, QtCore.Qt.ConnectionType.QueuedConnection)
         self.sequencegeneratorlogic().sigPredefinedSequenceGenerated.connect(
             self.predefined_sequence_generated, QtCore.Qt.ConnectionType.QueuedConnection)
         self.sequencegeneratorlogic().sigSampleEnsembleComplete.connect(
@@ -597,23 +604,29 @@ class PulsedMasterLogic(LogicBase):
         self.status_dict.benchmark_busy = False
 
     def get_pulsed_measurement(self):
-        """Full settings+data+sequence snapshot of the current measurement, combining both
+        """Full settings+data+objects snapshot of the current measurement, combining both
         sub-modules' state - for scripting/notebook use (see this module's own docstring, which
         already names that as a design goal). PulsedMasterLogic is the only module with
         Connectors to both PulsedMeasurementLogic and SequenceGeneratorLogic, so it is the only
-        place that can build the combined object.
+        place that can build the combined object - including resolving the loaded asset's
+        ensemble/block closure, which requires SequenceGeneratorLogic's saved-asset registries.
 
         @return PulsedMeasurement: snapshot built from independent copies (see
             PulsedMeasurementLogic.get_pulsed_measurement()) - safe to hold onto, will not change
             as the measurement continues running or assets get reloaded/edited later.
         """
+        ensembles, blocks = self.sequencegeneratorlogic().resolve_asset_closure(
+            self.pulsedmeasurementlogic().loaded_asset
+        )
         return self.pulsedmeasurementlogic().get_pulsed_measurement(
-            generator_settings=self.sequencegeneratorlogic().generator_settings
+            generator_settings=self.sequencegeneratorlogic().generator_settings,
+            ensembles=ensembles,
+            blocks=blocks,
         )
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
                               with_error=True, save_laser_pulses=True, save_pulsed_measurement=True,
-                              save_figure=None):
+                              save_figure=None, save_measurement_snapshot=False):
         """ Prepare data to be saved and create a proper plot of the data.
         Combines the current SequenceGeneratorLogic settings with the measurement logic's own
         settings/data before handing off, since only this module has Connectors to both.
@@ -627,6 +640,9 @@ class PulsedMasterLogic(LogicBase):
         @param bool save_pulsed_measurement: select whether final measurement should be saved
         @param bool save_figure: select whether a thumbnail plot should be saved
         @param str notes: optional, string that is included in the metadata "as-is" without a field
+        @param bool save_measurement_snapshot: optional, additionally pickle the complete
+            PulsedMeasurement snapshot (settings + data + the loaded sequence/ensemble) to a
+            single '.pulsedmeasurement' file - see PulsedMeasurementLogic.save_measurement_data().
         """
         still_busy = (self.status_dict.loading_busy
                       or self.status_dict.sampload_busy
@@ -638,6 +654,13 @@ class PulsedMasterLogic(LogicBase):
                            'propagated yet - saving now would save stale data from the previously '
                            'loaded asset. Wait for loading/sampling to finish and try again.')
             return
+        # Resolve the ensemble/block closure unconditionally - it's embedded in every
+        # raw/laser/signal .dat file's metadata now (see
+        # PulsedMeasurementLogic._get_loaded_asset_metadata()), not just the optional full
+        # snapshot, so it's needed on every save, not only when save_measurement_snapshot=True.
+        ensembles, blocks = self.sequencegeneratorlogic().resolve_asset_closure(
+            self.pulsedmeasurementlogic().loaded_asset
+        )
         return self.pulsedmeasurementlogic().save_measurement_data(
             tag=tag,
             file_path=file_path,
@@ -647,6 +670,9 @@ class PulsedMasterLogic(LogicBase):
             save_pulsed_measurement=save_pulsed_measurement,
             save_figure=save_figure,
             notes=notes,
+            save_measurement_snapshot=save_measurement_snapshot,
+            ensembles=ensembles,
+            blocks=blocks,
             # PulsedMasterLogic is the only module with Connectors to both PulsedMeasurementLogic
             # and SequenceGeneratorLogic, so it is the one place that can hand the sequence
             # generator's settings down to be included in the saved measurement metadata (see
@@ -825,6 +851,15 @@ class PulsedMasterLogic(LogicBase):
         return
 
     @QtCore.Slot(str, str)
+    def _refresh_measurement_logic_generator_settings(self, _changed_dict=None):
+        """Slot for SequenceGeneratorLogic.sigGeneratorSettingsUpdated/sigSamplingSettingsUpdated -
+        pushes the current generator_settings into PulsedMeasurementLogic's held PulsedMeasurement
+        (see PulsedMeasurementLogic.refresh_generator_settings()). The emitted dict itself isn't
+        used - both signals just indicate "something changed", so this always re-fetches the
+        current, complete generator_settings rather than trying to patch in only what changed.
+        """
+        self.pulsedmeasurementlogic().refresh_generator_settings(self.sequencegeneratorlogic().generator_settings)
+
     def loaded_asset_updated(self, asset_name, asset_type):
         """
 
@@ -849,6 +884,11 @@ class PulsedMasterLogic(LogicBase):
             object_instance = None
 
         self.pulsedmeasurementlogic().loaded_asset = object_instance
+        # Step 3 of the PulsedMeasurement consolidation: keep the held PulsedMeasurement's
+        # resolved ensembles/blocks fresh too, reusing the same closure-resolution helper the
+        # on-demand get_pulsed_measurement()/save_measurement_data() snapshot paths already use.
+        ensembles, blocks = self.sequencegeneratorlogic().resolve_asset_closure(object_instance)
+        self.pulsedmeasurementlogic().refresh_loaded_asset_closure(ensembles, blocks)
         return
 
     @QtCore.Slot(object)

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -70,13 +70,17 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     ReadoutSettings,
     PulsedMeasurementSettings,
     PulsedMeasurementData,
-    _as_bool,
     _DEFAULT_MICROWAVE_SETTINGS,
     _DEFAULT_FAST_COUNTER_SETTINGS,
     _DEFAULT_READOUT_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, PulseObjects, Settings
+from qudi.logic.pulsed.pulsed_data.settings_coercion import (
+    SettingsTypeError,
+    as_settings_dict,
+    coerce_settings,
+)
 
 
 
@@ -386,7 +390,7 @@ class PulsedMeasurementLogic(LogicBase):
         if asset is not self._loaded_asset:
             self.log.warning(
                 'A new sequence/ensemble has been loaded, but its settings have not been applied '
-                'to the measurement yet - press Play to apply them. Saving before that uses the '
+                'to the measurement yet - Saving before starting the measurement uses the '
                 'previous asset\'s name, settings, and data.'
             )
         self._pending_loaded_asset = asset
@@ -426,13 +430,21 @@ class PulsedMeasurementLogic(LogicBase):
 
         Returns independent copies (not live references), so the snapshot is frozen in time.
 
-        @param SequenceGeneratorSettings generator_settings: optional, the sequence generator
-            settings in effect for this measurement.
-        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved and copied
-            by the caller (see SequenceGeneratorLogic.resolve_asset_closure()).
-        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
-        @return PulsedMeasurement: snapshot of this module's current settings/data/loaded asset,
-            plus the given generator_settings/ensembles/blocks.
+        Parameters
+        ----------
+        generator_settings : SequenceGeneratorSettings
+            Optional, the sequence generator settings in effect for this measurement.
+        ensembles : dict
+            Optional, {name: PulseBlockEnsemble} already resolved and copied by the caller (see
+            SequenceGeneratorLogic.resolve_asset_closure()).
+        blocks : dict
+            Optional, {name: PulseBlock}, same caveat as `ensembles`.
+
+        Returns
+        -------
+        PulsedMeasurement
+            Snapshot of this module's current settings/data/loaded asset, plus the given
+            generator_settings/ensembles/blocks.
         """
         current = self._pulsed_measurement
         return PulsedMeasurement(
@@ -632,11 +644,11 @@ class PulsedMeasurementLogic(LogicBase):
         return self._settings.fast_counter_settings.to_dict()
 
     @fast_counter_settings.setter
-    def fast_counter_settings(self, settings_dict):
-        if isinstance(settings_dict, FastCounterSettings):
-            self.set_fast_counter_settings(settings_dict.to_dict())
-        elif isinstance(settings_dict, dict):
-            self.set_fast_counter_settings(settings_dict)
+    def fast_counter_settings(self, settings):
+        if not isinstance(settings, (FastCounterSettings, dict)):
+            raise SettingsTypeError(f'fast_counter_settings expects FastCounterSettings or dict, '
+                                    f'got {type(settings).__name__}')
+        self.set_fast_counter_settings(settings)
         return
 
     @property
@@ -644,34 +656,38 @@ class PulsedMeasurementLogic(LogicBase):
         return self._fastcounter().get_constraints()
 
     @QtCore.Slot(dict)
-    def set_fast_counter_settings(self, settings_dict=None, **kwargs):
+    def set_fast_counter_settings(self, settings=None, **kwargs):
         """
-        Either accepts a settings dictionary as positional argument or keyword arguments.
-        If both are present, both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accepts a FastCounterSettings instance or a settings dictionary as positional
+        argument, or keyword arguments. A dict/kwargs is a partial patch of the current settings,
+        a FastCounterSettings is a full replacement. If both a settings_dict and kwargs are
+        present, the keyword arguments take precedence for conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings : FastCounterSettings or dict or None
+        kwargs
         """
+        try:
+            requested = coerce_settings(
+                settings, kwargs, self._settings.fast_counter_settings, FastCounterSettings
+            )
+        except SettingsTypeError as err:
+            # A caller mistake - log it and leave the settings untouched. Deliberately not raised:
+            # this is a queued cross-thread slot, where an escaping exception cannot reach the
+            # emitter and may take the whole application down mid-measurement.
+            self.log.error(f'Unable to apply new fast counter settings. {err}')
+            self.sigFastCounterSettingsUpdated.emit(self.fast_counter_settings)
+            return self.fast_counter_settings
+
         # Check if fast counter is running and do nothing if that is the case
         counter_status = self._fastcounter().get_status()
         if not counter_status >= 2 and not counter_status < 0:
-            # Determine complete settings dictionary
-            if isinstance(settings_dict, FastCounterSettings):
-                settings_dict = settings_dict.to_dict()
-                settings_dict.update(kwargs)
-            elif not isinstance(settings_dict, dict):
-                settings_dict = kwargs
-            else:
-                settings_dict.update(kwargs)
-
             # Set parameters, check if it is gated
-            if 'number_of_gates' in settings_dict and not self._fastcounter().is_gated():
-                settings_dict['number_of_gates'] = 0
+            if not self._fastcounter().is_gated():
+                requested = replace(requested, number_of_gates=0)
 
-            self._apply_fast_counter_settings(self._settings.fast_counter_settings.update_from_dict(settings_dict))
+            self._apply_fast_counter_settings(requested)
 
             # Apply the settings to hardware
             bin_width, record_length, number_of_gates = self._fastcounter().configure(
@@ -697,16 +713,22 @@ class PulsedMeasurementLogic(LogicBase):
         return self.fast_counter_settings
 
     def fast_counter_on(self):
-        """Switching on the fast counter
+        """Switching on the fast counter.
 
-        @return int: error code (0:OK, -1:error)
+        Returns
+        -------
+        int
+            Error code (0:OK, -1:error).
         """
         return self._fastcounter().start_measure()
 
     def fast_counter_off(self):
-        """Switching off the fast counter
+        """Switching off the fast counter.
 
-        @return int: error code (0:OK, -1:error)
+        Returns
+        -------
+        int
+            Error code (0:OK, -1:error).
         """
         return self._fastcounter().stop_measure()
 
@@ -724,16 +746,22 @@ class PulsedMeasurementLogic(LogicBase):
         return err
 
     def fast_counter_pause(self):
-        """Switching off the fast counter
+        """Switching off the fast counter.
 
-        @return int: error code (0:OK, -1:error)
+        Returns
+        -------
+        int
+            Error code (0:OK, -1:error).
         """
         return self._fastcounter().pause_measure()
 
     def fast_counter_continue(self):
-        """Switching off the fast counter
+        """Switching off the fast counter.
 
-        @return int: error code (0:OK, -1:error)
+        Returns
+        -------
+        int
+            Error code (0:OK, -1:error).
         """
         return self._fastcounter().continue_measure()
 
@@ -787,11 +815,11 @@ class PulsedMeasurementLogic(LogicBase):
         return self._settings.microwave_settings.to_dict()
 
     @ext_microwave_settings.setter
-    def ext_microwave_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
-            self.set_microwave_settings(settings_dict)
-        elif isinstance(settings_dict, MicrowaveSettings):
-            self.set_microwave_settings(settings_dict.to_dict())
+    def ext_microwave_settings(self, settings):
+        if not isinstance(settings, (MicrowaveSettings, dict)):
+            raise SettingsTypeError(f'ext_microwave_settings expects MicrowaveSettings or dict, '
+                                    f'got {type(settings).__name__}')
+        self.set_microwave_settings(settings)
         return
     
     @property
@@ -853,39 +881,40 @@ class PulsedMeasurementLogic(LogicBase):
         return err
 
     @QtCore.Slot(dict)
-    def set_microwave_settings(self, settings_dict=None, **kwargs):
+    def set_microwave_settings(self, settings=None, **kwargs):
         """
         Apply new settings to the external microwave device.
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accepts a MicrowaveSettings instance or a settings dictionary as positional
+        argument, or keyword arguments. A dict/kwargs is a partial patch of the current settings,
+        a MicrowaveSettings is a full replacement. If both a settings_dict and kwargs are present,
+        the keyword arguments take precedence for conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings : MicrowaveSettings or dict or None
+        kwargs
         """
+        try:
+            requested = coerce_settings(
+                settings, kwargs, self._settings.microwave_settings, MicrowaveSettings
+            )
+        except SettingsTypeError as err:
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to apply new microwave settings. {err}')
+            self.sigExtMicrowaveSettingsUpdated.emit(self.ext_microwave_settings)
+            return self.ext_microwave_settings
+
         # Check if microwave is running and do nothing if that is the case
         try:
             microwave = self._microwave()
             if (microwave is not None) and (microwave.module_state() != 'idle') :
                 self.log.warning('Microwave device is running.\nUnable to apply new settings.')
             else:
-                # Determine complete settings dictionary
-                if isinstance(settings_dict, MicrowaveSettings):
-                    settings_dict = settings_dict.to_dict()
-                    settings_dict.update(kwargs)
-                elif not isinstance(settings_dict, dict):
-                    settings_dict = kwargs
-                else:
-                    settings_dict.update(kwargs)
-
-                # Set parameters if present
                 # use_ext_microwave can only ever be True if a microwave connector is actually
                 # present - otherwise force it back to False regardless of what was requested.
-                if 'use_ext_microwave' in settings_dict:
-                    settings_dict['use_ext_microwave'] = _as_bool(settings_dict['use_ext_microwave']) and microwave is not None
-                self._apply_microwave_settings(self._settings.microwave_settings.update_from_dict(settings_dict))
+                if requested.use_ext_microwave and microwave is None:
+                    requested = replace(requested, use_ext_microwave=False)
+                self._apply_microwave_settings(requested)
                 if self._settings.microwave_settings.use_ext_microwave and microwave is not None:
                     # Apply the settings to hardware
                     microwave.set_cw(
@@ -958,11 +987,11 @@ class PulsedMeasurementLogic(LogicBase):
         return self._settings.readout_settings.to_dict()
 
     @measurement_settings.setter
-    def measurement_settings(self, settings_dict):
-        if isinstance(settings_dict, ReadoutSettings):
-            self.set_measurement_settings(settings_dict.to_dict())
-        elif isinstance(settings_dict, dict):
-            self.set_measurement_settings(settings_dict)
+    def measurement_settings(self, settings):
+        if not isinstance(settings, (ReadoutSettings, dict)):
+            raise SettingsTypeError(f'measurement_settings expects ReadoutSettings or dict, '
+                                    f'got {type(settings).__name__}')
+        self.set_measurement_settings(settings)
         return
 
     @property
@@ -1057,8 +1086,10 @@ class PulsedMeasurementLogic(LogicBase):
 
     @timer_interval.setter
     def timer_interval(self, value):
-        if isinstance(value, (int, float)):
-            self.set_timer_interval(value)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise SettingsTypeError(f'timer_interval expects int or float, '
+                                    f'got {type(value).__name__}')
+        self.set_timer_interval(value)
         return
 
     @property
@@ -1068,8 +1099,10 @@ class PulsedMeasurementLogic(LogicBase):
 
     @alternative_data_type.setter
     def alternative_data_type(self, alt_data_type):
-        if isinstance(alt_data_type, str) or alt_data_type is None:
-            self.set_alternative_data_type(alt_data_type)
+        if not (isinstance(alt_data_type, str) or alt_data_type is None):
+            raise SettingsTypeError(f'alternative_data_type expects str or None, '
+                                    f'got {type(alt_data_type).__name__}')
+        self.set_alternative_data_type(alt_data_type)
         return
 
     @property
@@ -1096,8 +1129,12 @@ class PulsedMeasurementLogic(LogicBase):
 
     @analysis_settings.setter
     def analysis_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
-            self.set_analysis_settings(settings_dict)
+        # No dataclass counterpart: AnalysisParameters is a dict subclass because the parameter
+        # names are discovered at runtime from whichever analysis method is selected.
+        if not isinstance(settings_dict, dict):
+            raise SettingsTypeError(f'analysis_settings expects a dict, '
+                                    f'got {type(settings_dict).__name__}')
+        self.set_analysis_settings(settings_dict)
         return
 
     @property
@@ -1106,8 +1143,11 @@ class PulsedMeasurementLogic(LogicBase):
 
     @extraction_settings.setter
     def extraction_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
-            self.set_extraction_settings(settings_dict)
+        # No dataclass counterpart - see analysis_settings above.
+        if not isinstance(settings_dict, dict):
+            raise SettingsTypeError(f'extraction_settings expects a dict, '
+                                    f'got {type(settings_dict).__name__}')
+        self.set_extraction_settings(settings_dict)
         return
 
     @QtCore.Slot(dict)
@@ -1119,20 +1159,26 @@ class PulsedMeasurementLogic(LogicBase):
         The keyword arguments take precedence over the items in settings_dict if there are
         conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings_dict
+        kwargs
         """
-        # Determine complete settings dictionary
-        if not isinstance(settings_dict, dict):
-            settings_dict = kwargs
-        else:
-            settings_dict.update(kwargs)
+        # Determine complete settings dictionary. Built as a new dict rather than updated in
+        # place, so the caller's dict is never mutated by the bin snapping below.
+        try:
+            settings_dict = as_settings_dict(settings_dict, kwargs)
+        except SettingsTypeError as err:
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to apply new analysis settings. {err}')
+            self.sigAnalysisSettingsUpdated.emit(self.analysis_settings)
+            return
 
+        bin_width = self.fast_counter_settings['bin_width']
         for key in settings_dict:
             if key in ['signal_start', 'signal_end', 'norm_start', 'norm_end']:
-                num_bins_fast = round(settings_dict[key]/self.fast_counter_settings['bin_width'])
-                settings_dict[key] = num_bins_fast * self.fast_counter_settings['bin_width']
+                num_bins_fast = round(settings_dict[key] / bin_width)
+                settings_dict[key] = num_bins_fast * bin_width
 
         # Use threadlock to update settings during a running measurement
         with self._threadlock:
@@ -1143,21 +1189,25 @@ class PulsedMeasurementLogic(LogicBase):
     @QtCore.Slot(dict)
     def set_extraction_settings(self, settings_dict=None, **kwargs):
         """
-        Apply new analysis settings.
+        Apply new extraction settings.
         Either accept a settings dictionary as positional argument or keyword arguments.
         If both are present both are being used by updating the settings_dict with kwargs.
         The keyword arguments take precedence over the items in settings_dict if there are
         conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings_dict
+        kwargs
         """
         # Determine complete settings dictionary
-        if not isinstance(settings_dict, dict):
-            settings_dict = kwargs
-        else:
-            settings_dict.update(kwargs)
+        try:
+            settings_dict = as_settings_dict(settings_dict, kwargs)
+        except SettingsTypeError as err:
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to apply new extraction settings. {err}')
+            self.sigExtractionSettingsUpdated.emit(self.extraction_settings)
+            return
 
         # Use threadlock to update settings during a running measurement
         with self._threadlock:
@@ -1166,55 +1216,71 @@ class PulsedMeasurementLogic(LogicBase):
         return
 
     @QtCore.Slot(dict)
-    def set_measurement_settings(self, settings_dict=None, **kwargs):
+    def set_measurement_settings(self, settings=None, **kwargs):
         """
-        Apply new measurement settings.
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Apply new measurement (readout) settings.
+        Either accepts a ReadoutSettings instance or a settings dictionary as positional argument,
+        or keyword arguments. A dict/kwargs is a partial patch of the current settings, a
+        ReadoutSettings is a full replacement. If both a settings_dict and kwargs are present, the
+        keyword arguments take precedence for conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Note that not every field can be applied in every module state: only invoke_settings,
+        units and labels are accepted while a measurement is running. Fields the current state
+        does not permit keep their current value, whether they were named explicitly or arrived
+        as part of a complete ReadoutSettings.
+
+        Parameters
+        ----------
+        settings : ReadoutSettings or dict or None
+        kwargs
         """
-        # Determine complete settings dictionary
-        if isinstance(settings_dict, ReadoutSettings):
-            settings_dict = settings_dict.to_dict()
-            settings_dict.update(kwargs)
-        elif not isinstance(settings_dict, dict):
-            settings_dict = kwargs
-        else:
-            settings_dict.update(kwargs)
+        try:
+            requested = coerce_settings(
+                settings, kwargs, self._settings.readout_settings, ReadoutSettings
+            )
+        except SettingsTypeError as err:
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to apply new measurement settings. {err}')
+            self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
+            return self.measurement_settings
 
         # invoke_settings flag can change regardless of module state
-        if 'invoke_settings' in settings_dict:
-            self._apply_readout_settings(
-                replace(
-                    self._settings.readout_settings,
-                    invoke_settings=_as_bool(settings_dict['invoke_settings'])
-                )
-            )
+        self._apply_readout_settings(
+            replace(self._settings.readout_settings, invoke_settings=requested.invoke_settings)
+        )
         if self._settings.readout_settings.invoke_settings:
             if self.measurement_information:
                 self._apply_invoked_settings()
         else:
             # units/labels can change while a measurement is running
             with self._threadlock:
-                units_labels = {}
-                if 'units' in settings_dict:
-                    units_labels['units'] = settings_dict['units']
-                if 'labels' in settings_dict:
-                    units_labels['labels'] = settings_dict['labels']
-                if units_labels:
-                    self._apply_readout_settings(self._settings.readout_settings.update_from_dict(units_labels))
+                self._apply_readout_settings(
+                    replace(
+                        self._settings.readout_settings,
+                        units=requested.units,
+                        labels=requested.labels,
+                    )
+                )
             if self.module_state() == 'idle':
-                idle_only_keys = ('controlled_variable', 'number_of_lasers', 'laser_ignore_list', 'alternating')
-                idle_updates = {k: settings_dict[k] for k in idle_only_keys if k in settings_dict}
-                if idle_updates:
-                    self._apply_readout_settings(self._settings.readout_settings.update_from_dict(idle_updates))
-                if 'number_of_lasers' in idle_updates and self._fastcounter().is_gated():
-                    self.set_fast_counter_settings(number_of_gates=self._settings.readout_settings.number_of_lasers)
+                # Everything else describes the pulse sequence being measured and can only change
+                # while no measurement is running.
+                self._apply_readout_settings(
+                    replace(
+                        self._settings.readout_settings,
+                        controlled_variable=requested.controlled_variable,
+                        number_of_lasers=requested.number_of_lasers,
+                        laser_ignore_list=requested.laser_ignore_list,
+                        alternating=requested.alternating,
+                    )
+                )
+                # A gated fast counter needs exactly one gate per laser pulse. Driven off the
+                # actual values rather than "was number_of_lasers named in the call", so this also
+                # heals the two ever drifting apart.
+                if (self._fastcounter().is_gated()
+                        and self._settings.fast_counter_settings.number_of_gates
+                        != self._settings.readout_settings.number_of_lasers):
+                    self.set_fast_counter_settings(
+                        number_of_gates=self._settings.readout_settings.number_of_lasers)
         self._measurement_settings_sanity_check()
         self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return self.measurement_settings
@@ -1222,9 +1288,12 @@ class PulsedMeasurementLogic(LogicBase):
     @QtCore.Slot(bool, str)
     def toggle_pulsed_measurement(self, start, stash_raw_data_tag=''):
         """
-        Convenience method to start/stop measurement
+        Convenience method to start/stop measurement.
 
-        @param bool start: Start the measurement (True) or stop the measurement (False)
+        Parameters
+        ----------
+        start : bool
+            Start the measurement (True) or stop the measurement (False).
         """
         if start:
             self.start_pulsed_measurement(stash_raw_data_tag)
@@ -1334,9 +1403,12 @@ class PulsedMeasurementLogic(LogicBase):
     @QtCore.Slot(bool)
     def toggle_measurement_pause(self, pause):
         """
-        Convenience method to pause/continue measurement
+        Convenience method to pause/continue measurement.
 
-        @param bool pause: Pause the measurement (True) or continue the measurement (False)
+        Parameters
+        ----------
+        pause : bool
+            Pause the measurement (True) or continue the measurement (False).
         """
         if pause:
             self.pause_pulsed_measurement()
@@ -1399,10 +1471,18 @@ class PulsedMeasurementLogic(LogicBase):
     @QtCore.Slot(int)
     def set_timer_interval(self, interval):
         """
-        Change the interval of the measurement analysis timer
+        Change the interval of the measurement analysis timer.
 
-        @param int|float interval: Interval of the timer in s
+        Parameters
+        ----------
+        interval : int or float
+            Interval of the timer in s.
         """
+        if not isinstance(interval, (int, float)) or isinstance(interval, bool):
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to set timer interval. Expected int or float, got '
+                           f'{type(interval).__name__}.')
+            return
         with self._threadlock:
             self._apply_timer_interval(interval)
             if self._timer_interval_s > 0:
@@ -1419,6 +1499,11 @@ class PulsedMeasurementLogic(LogicBase):
     @QtCore.Slot(str)
     def set_alternative_data_type(self, alt_data_type):
         """ Set the selected alternative (second) plot method by name ('None'/None disables it). """
+        if not (isinstance(alt_data_type, str) or alt_data_type is None):
+            # See set_fast_counter_settings() on why a caller mistake is logged, not raised, here.
+            self.log.error(f'Unable to set alternative data type. Expected str or None, got '
+                           f'{type(alt_data_type).__name__}.')
+            return
         with self._threadlock:
             if alt_data_type != self.alternative_data_type:
                 self.do_fit('No Fit', True)
@@ -1454,12 +1539,18 @@ class PulsedMeasurementLogic(LogicBase):
         """
         Performs the chosen fit on the measured data.
 
-        @param str fit_config: name of the fit configuration to use
-        @param bool use_alternative_data: Flag indicating if the signal data (False) or the
-                                          alternative signal data (True) should be fitted.
-                                          Ignored if data is given as parameter
+        Parameters
+        ----------
+        fit_config : str
+            Name of the fit configuration to use.
+        use_alternative_data : bool
+            Flag indicating if the signal data (False) or the alternative signal data (True)
+            should be fitted. Ignored if data is given as parameter.
 
-        @return result_object: the lmfit result object
+        Returns
+        -------
+        result_object
+            The lmfit result object.
         """
         container = self.alt_fc if use_alternative_data else self.fc
         data = self.measurement_data.signal_alt_data if use_alternative_data else self.measurement_data.signal_data
@@ -1674,8 +1765,12 @@ class PulsedMeasurementLogic(LogicBase):
         """
         Get the raw count data from the fast counting hardware and perform sanity checks.
         Also add recalled raw data to the newly received data.
-        @return tuple(numpy.ndarray, info_dict): The count data (1D for ungated, 2D for gated counter) and
-                                                 info_dict with keys 'elapsed_sweeps' and 'elapsed_time'
+
+        Returns
+        -------
+        tuple(numpy.ndarray, info_dict)
+            The count data (1D for ungated, 2D for gated counter) and info_dict with keys
+            'elapsed_sweeps' and 'elapsed_time'.
         """
         # get raw data from fast counter
         fc_data = self._fastcounter().get_data_trace()
@@ -1789,10 +1884,14 @@ class PulsedMeasurementLogic(LogicBase):
         display-only variant that drops duplicate/bulky SamplingInformation fields (see its
         docstring); the full snapshot file still uses to_dict() for lossless round-tripping.
 
-        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved by the
-            caller (see SequenceGeneratorLogic.resolve_asset_closure()) - PulsedMeasurementLogic
-            has no Connector to SequenceGeneratorLogic and cannot resolve this itself.
-        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
+        Parameters
+        ----------
+        ensembles : dict
+            Optional, {name: PulseBlockEnsemble} already resolved by the caller (see
+            SequenceGeneratorLogic.resolve_asset_closure()) - PulsedMeasurementLogic has no
+            Connector to SequenceGeneratorLogic and cannot resolve this itself.
+        blocks : dict
+            Optional, {name: PulseBlock}, same caveat as `ensembles`.
         """
         if self._loaded_asset is None:
             return {}
@@ -1882,17 +1981,17 @@ class PulsedMeasurementLogic(LogicBase):
             file_name_stub, file_extension = file_name.rsplit('.', 1)
             return f'{file_name_stub}{suffix_str}.{file_extension}', None
 
-    def _get_signal_column_headers(self, with_error):
+    def _get_signal_column_headers(self):
         """ Helper method to retrieve formatted column header strings for pulsed measurement data.
 
-        @param bool with_error: Boolean flag indicating if error data should be included
-
-        @return list: List of column header strings
+        Returns
+        -------
+        list
+            List of column header strings.
         """
         labels, units = self._settings.readout_settings.labels, self._settings.readout_settings.units
         column_headers = [f'{labels[0]} ({units[0]})', f'{labels[1]} ({units[1]})']
-        if with_error:
-            column_headers.append(f'{labels[1]} ({units[1]})')
+        column_headers.append(f'{labels[1]} ({units[1]})')
         return column_headers
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
@@ -1901,33 +2000,47 @@ class PulsedMeasurementLogic(LogicBase):
                               save_measurement_snapshot=False):
         """ Prepare data to be saved and create a proper plot of the data
 
-        @param str tag: a name tag which will be included in the filename if file_path is None
-        @param str file_path: optional, custom full file path including file extension to use.
-                              If given, tag is ignored.
-        @param type storage_cls: optional, override for data storage class to use
-        @param bool with_error: select whether errors should be saved/plotted
-        @param bool save_laser_pulses: select whether extracted lasers should be saved
-        @param bool save_pulsed_measurement: select whether final measurement should be saved
-        @param bool save_figure: select whether a thumbnail plot should be saved
-        @param str notes: optional, string that is included in the metadata "as-is" without a field
-        @param SequenceGeneratorSettings generator_settings: optional, the SequenceGeneratorLogic
-            settings in effect for this measurement. PulsedMeasurementLogic has no Connector to
-            SequenceGeneratorLogic and cannot fetch this itself - PulsedMasterLogic.
-            save_measurement_data supplies it. Included in the saved signal metadata as part of
-            a combined PulsedMeasurement snapshot (see get_pulsed_measurement()); left out (None)
-            if this method is called directly without going through PulsedMasterLogic.
-        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved and copied
-            by the caller (see SequenceGeneratorLogic.resolve_asset_closure()) - same caveat as
-            generator_settings. Embedded in every raw/laser/signal .dat file's metadata (see
+        Parameters
+        ----------
+        tag : str
+            A name tag which will be included in the filename if file_path is None.
+        file_path : str
+            Optional, custom full file path including file extension to use.
+            If given, tag is ignored.
+        storage_cls : type
+            Optional, override for data storage class to use.
+        with_error : bool
+            Select whether errors should be plotted.
+        save_laser_pulses : bool
+            Select whether extracted lasers should be saved.
+        save_pulsed_measurement : bool
+            Select whether final measurement should be saved.
+        save_figure : bool
+            Select whether a thumbnail plot should be saved.
+        notes : str
+            Optional, string that is included in the metadata "as-is" without a field.
+        generator_settings : SequenceGeneratorSettings
+            Optional, the SequenceGeneratorLogic settings in effect for this measurement.
+            PulsedMeasurementLogic has no Connector to SequenceGeneratorLogic and cannot fetch
+            this itself - PulsedMasterLogic. save_measurement_data supplies it. Included in the
+            saved signal metadata as part of a combined PulsedMeasurement snapshot (see
+            get_pulsed_measurement()); left out (None) if this method is called directly without
+            going through PulsedMasterLogic.
+        ensembles : dict
+            Optional, {name: PulseBlockEnsemble} already resolved and copied by the caller (see
+            SequenceGeneratorLogic.resolve_asset_closure()) - same caveat as generator_settings.
+            Embedded in every raw/laser/signal .dat file's metadata (see
             _get_loaded_asset_metadata()) as well as the optional full snapshot below.
-        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
-        @param bool save_measurement_snapshot: optional, additionally pickle the complete
-            PulsedMeasurement snapshot (settings + data + the loaded sequence/ensemble/ensembles/
-            blocks, see get_pulsed_measurement()) to a single '.pulsedmeasurement' file alongside
-            the raw/laser/signal files - see load_measurement_snapshot() to restore it. Off by
-            default since it's a new, potentially large binary artifact; the sequence/ensembles/
-            blocks/elements themselves are always in the raw/laser/signal .dat metadata regardless
-            of this flag - this only adds settings/data/fit results on top, in one loadable object.
+        blocks : dict
+            Optional, {name: PulseBlock}, same caveat as `ensembles`.
+        save_measurement_snapshot : bool
+            Optional, additionally pickle the complete PulsedMeasurement snapshot (settings +
+            data + the loaded sequence/ensemble/ensembles/blocks, see get_pulsed_measurement())
+            to a single '.pulsedmeasurement' file alongside the raw/laser/signal files - see
+            load_measurement_snapshot() to restore it. Off by default since it's a new,
+            potentially large binary artifact; the sequence/ensembles/blocks/elements themselves
+            are always in the raw/laser/signal .dat metadata regardless of this flag - this only
+            adds settings/data/fit results on top, in one loadable object.
         """
         # Use default data storage type if none has been given explicitly
         if storage_cls is None:
@@ -1997,11 +2110,8 @@ class PulsedMeasurementLogic(LogicBase):
                                                                         tag,
                                                                         '_pulsed_measurement')
 
-            # Format data to save
-            if with_error:
-                data = np.vstack((self.measurement_data.signal_data, self.measurement_data.measurement_error[1:])).transpose()
-            else:
-                data = self.measurement_data.signal_data.transpose()
+            # Format data to save - error columns are always included; with_error only affects the plot.
+            data = np.vstack((self.measurement_data.signal_data, self.measurement_data.measurement_error[1:])).transpose()
 
             save_path, _, _ = data_storage.save_data(
                 data,
@@ -2012,7 +2122,7 @@ class PulsedMeasurementLogic(LogicBase):
                 filename=save_filename,
                 timestamp=timestamp,
                 notes=notes,
-                column_headers=self._get_signal_column_headers(with_error)
+                column_headers=self._get_signal_column_headers()
             )
 
             # save thumbnail figure if required
@@ -2047,8 +2157,15 @@ class PulsedMeasurementLogic(LogicBase):
         """Load a PulsedMeasurement snapshot previously saved via
         save_measurement_data(save_measurement_snapshot=True).
 
-        @param str file_path: full path to the '.pulsedmeasurement' file to load
-        @return PulsedMeasurement: the restored snapshot (settings + data + sequence)
+        Parameters
+        ----------
+        file_path : str
+            Full path to the '.pulsedmeasurement' file to load.
+
+        Returns
+        -------
+        PulsedMeasurement
+            The restored snapshot (settings + data + sequence).
         """
         with open(file_path, 'rb') as snapshot_file:
             return pickle.load(snapshot_file)

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -52,16 +52,20 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     ExecutionState,
     ExtractionParameters,
     GenerationMethodParameters,
-    AlternativeSignalSettings,
     MeasurementInformation,
     MicrowaveSettings,
     FastCounterSettings,
     ReadoutSettings,
     PulsedMeasurementSettings,
     PulsedMeasurementData,
-    _as_bool
+    _as_bool,
+    _DEFAULT_MICROWAVE_SETTINGS,
+    _DEFAULT_FAST_COUNTER_SETTINGS,
+    _DEFAULT_READOUT_SETTINGS,
+    _DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, Settings
 
 
 
@@ -76,27 +80,93 @@ def _data_storage_from_cfg_option(cfg_str):
     raise ValueError('Invalid ConfigOption value to specify data storage type.')
 
 
+_DEFAULT_FIT_CONFIGS = (
+    {'name': 'Gaussian Dip',
+     'model': 'Gaussian',
+     'estimator': 'Dip',
+     'custom_parameters': None},
+
+    {'name': 'Gaussian Peak',
+     'model': 'Gaussian',
+     'estimator': 'Peak',
+     'custom_parameters': None},
+
+    {'name': 'Lorentzian Dip',
+     'model': 'Lorentzian',
+     'estimator': 'Dip',
+     'custom_parameters': None},
+
+    {'name': 'Lorentzian Peak',
+     'model': 'Lorentzian',
+     'estimator': 'Peak',
+     'custom_parameters': None},
+
+    {'name': 'Double Lorentzian Dips',
+     'model': 'DoubleLorentzian',
+     'estimator': 'Dips',
+     'custom_parameters': None},
+
+    {'name': 'Double Lorentzian Peaks',
+     'model': 'DoubleLorentzian',
+     'estimator': 'Peaks',
+     'custom_parameters': None},
+
+    {'name': 'Triple Lorentzian Dip',
+     'model': 'TripleLorentzian',
+     'estimator': 'Dips',
+     'custom_parameters': None},
+
+    {'name': 'Triple Lorentzian Peaks',
+     'model': 'TripleLorentzian',
+     'estimator': 'Peaks',
+     'custom_parameters': None},
+
+    {'name': 'Sine',
+     'model': 'Sine',
+     'estimator': 'default',
+     'custom_parameters': None},
+
+    {'name': 'Double Sine',
+     'model': 'DoubleSine',
+     'estimator': 'default',
+     'custom_parameters': None},
+
+    {'name': 'Exp. Decay Sine',
+     'model': 'ExponentialDecaySine',
+     'estimator': 'Decay',
+     'custom_parameters': None},
+
+    {'name': 'Stretched Exp. Decay Sine',
+     'model': 'ExponentialDecaySine',
+     'estimator': 'Stretched Decay',
+     'custom_parameters': None},
+
+    {'name': 'Stretched Exp. Decay',
+     'model': 'ExponentialDecay',
+     'estimator': 'Stretched Decay',
+     'custom_parameters': None},
+)
+
+
 def _default_measurement_settings():
     """Factory for the default PulsedMeasurementSettings, used both as the StatusVar default
-    and as the fallback when restoring a malformed/legacy status value."""
+    and as the fallback when restoring a malformed/legacy status value.
+
+    microwave_settings/fast_counter_settings/readout_settings/alternate_signal_settings reuse
+    the single shared default instances defined in pulsed_measurement_logic_data.py (that file
+    can't import back from this one, so it owns these literals rather than duplicating them
+    here) - PulsedMeasurementSettings.from_dict() falls back to the exact same instances when a
+    saved settings file is missing one of these keys.
+    """
     return PulsedMeasurementSettings(
-        microwave_settings=MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
-        fast_counter_settings=FastCounterSettings(
-            record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False
-        ),
-        readout_settings=ReadoutSettings(
-            invoke_settings=False,
-            controlled_variable=np.array(list(range(50)), dtype=float),
-            number_of_lasers=50,
-            laser_ignore_list=list(),
-            alternating=False,
-            units=('s', ''),
-            labels=('Tau', 'Signal'),
-        ),
-        alternate_signal_settings=AlternativeSignalSettings(alternative_data_type=None),
+        microwave_settings=_DEFAULT_MICROWAVE_SETTINGS,
+        fast_counter_settings=_DEFAULT_FAST_COUNTER_SETTINGS,
+        readout_settings=_DEFAULT_READOUT_SETTINGS,
+        alternate_signal_settings=_DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
         extraction_parameters=ExtractionParameters(),
         analysis_parameters=AnalysisParameters(),
         timer_interval_s=5.0,
+        fit_configs=_DEFAULT_FIT_CONFIGS,
     )
 
 
@@ -136,8 +206,13 @@ class PulsedMeasurementLogic(LogicBase):
     # status variables
     # Bundles the external microwave settings, fast counter settings, readout settings
     # (controlled variable/units/labels/...), alternative signal processing settings,
-    # extraction/analysis parameters, and the analysis-loop timer interval into a single
-    # settings object instead of independently stored/persisted attributes.
+    # extraction/analysis parameters, the analysis-loop timer interval, and the available
+    # data-fit configurations into a single settings object instead of independently
+    # stored/persisted attributes. fit_configs used to be its own separate StatusVar
+    # (_fit_configs) with decorator-based representer/constructor hooks reaching into
+    # self.fit_config_model, mirroring what extraction_parameters/analysis_parameters looked
+    # like before those were folded in here - see _apply_fit_configs()/on_activate() for how
+    # fit_configs is now kept in sync with fit_config_model instead.
     _settings = StatusVar(
         default=_default_measurement_settings(),
         constructor=lambda x: PulsedMeasurementSettings.from_dict(x)
@@ -145,9 +220,6 @@ class PulsedMeasurementLogic(LogicBase):
         else _default_measurement_settings(),
         representer=lambda obj: obj.to_dict(),
     )
-
-    # Data fitting
-    _fit_configs = StatusVar(name='fit_configs', default=None)
 
     # notification signals for master module (i.e. GUI)
     sigMeasurementDataUpdated = QtCore.Signal()
@@ -164,73 +236,6 @@ class PulsedMeasurementLogic(LogicBase):
     # Internal signals
     sigStartTimer = QtCore.Signal()
     sigStopTimer = QtCore.Signal()
-
-    __default_fit_configs = (
-        {'name': 'Gaussian Dip',
-         'model': 'Gaussian',
-         'estimator': 'Dip',
-         'custom_parameters': None},
-
-        {'name': 'Gaussian Peak',
-         'model': 'Gaussian',
-         'estimator': 'Peak',
-         'custom_parameters': None},
-
-        {'name': 'Lorentzian Dip',
-         'model': 'Lorentzian',
-         'estimator': 'Dip',
-         'custom_parameters': None},
-
-        {'name': 'Lorentzian Peak',
-         'model': 'Lorentzian',
-         'estimator': 'Peak',
-         'custom_parameters': None},
-
-        {'name': 'Double Lorentzian Dips',
-         'model': 'DoubleLorentzian',
-         'estimator': 'Dips',
-         'custom_parameters': None},
-
-        {'name': 'Double Lorentzian Peaks',
-         'model': 'DoubleLorentzian',
-         'estimator': 'Peaks',
-         'custom_parameters': None},
-
-        {'name': 'Triple Lorentzian Dip',
-         'model': 'TripleLorentzian',
-         'estimator': 'Dips',
-         'custom_parameters': None},
-
-        {'name': 'Triple Lorentzian Peaks',
-         'model': 'TripleLorentzian',
-         'estimator': 'Peaks',
-         'custom_parameters': None},
-
-        {'name': 'Sine',
-         'model': 'Sine',
-         'estimator': 'default',
-         'custom_parameters': None},
-
-        {'name': 'Double Sine',
-         'model': 'DoubleSine',
-         'estimator': 'default',
-         'custom_parameters': None},
-
-        {'name': 'Exp. Decay Sine',
-         'model': 'ExponentialDecaySine',
-         'estimator': 'Decay',
-         'custom_parameters': None},
-
-        {'name': 'Stretched Exp. Decay Sine',
-         'model': 'ExponentialDecaySine',
-         'estimator': 'Stretched Decay',
-         'custom_parameters': None},
-
-        {'name': 'Stretched Exp. Decay',
-         'model': 'ExponentialDecay',
-         'estimator': 'Stretched Decay',
-         'custom_parameters': None},
-    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -289,6 +294,9 @@ class PulsedMeasurementLogic(LogicBase):
     def _apply_timer_interval(self, new_interval):
         self._settings = replace(self._settings, timer_interval_s=float(new_interval))
 
+    def _apply_fit_configs(self, new_configs):
+        self._settings = replace(self._settings, fit_configs=tuple(new_configs))
+
     @property
     def loaded_asset(self):
         return self._loaded_asset
@@ -300,6 +308,41 @@ class PulsedMeasurementLogic(LogicBase):
             self._apply_invoked_settings()
             self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return
+
+    def get_pulsed_measurement(self, generator_settings=None):
+        """Build a PulsedMeasurement snapshot bundling this module's own settings/data/loaded
+        asset with the SequenceGeneratorSettings supplied by the caller.
+
+        PulsedMeasurementLogic has no Connector to SequenceGeneratorLogic, so it cannot fetch
+        generator_settings itself - pass in SequenceGeneratorLogic.generator_settings (see
+        PulsedMasterLogic.get_pulsed_measurement()/save_measurement_data(), the only module with
+        Connectors to both PulsedMeasurementLogic and SequenceGeneratorLogic). Leave
+        generator_settings=None to get a measurement-only snapshot.
+
+        data/sequence are populated from independent copies (measurement_data.copy() /
+        loaded_asset.copy()), not live references, so the returned snapshot is frozen in time -
+        it will not keep changing under the caller as a running measurement continues or the
+        loaded asset gets reloaded/edited later under the same name. fit_result/fit_result_alt
+        are included by reference, not copied - see PulsedData's class docstring for why that's
+        safe.
+
+        @param SequenceGeneratorSettings generator_settings: optional, the sequence generator
+            settings in effect for this measurement.
+        @return PulsedMeasurement: snapshot with settings=Settings(measurement_settings=
+            self._settings, generator_settings=generator_settings), data=PulsedData(
+            measurement_data=measurement_data.copy(), fit_result=self._fit_result,
+            fit_result_alt=self._fit_result_alt), sequence=loaded_asset.copy() (or None if
+            nothing is loaded).
+        """
+        return PulsedMeasurement(
+            settings=Settings(measurement_settings=self._settings, generator_settings=generator_settings),
+            data=PulsedData(
+                measurement_data=self.measurement_data.copy(),
+                fit_result=self._fit_result,
+                fit_result_alt=self._fit_result_alt,
+            ),
+            sequence=self._loaded_asset.copy() if self._loaded_asset is not None else None,
+        )
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.
@@ -318,7 +361,16 @@ class PulsedMeasurementLogic(LogicBase):
 
         # Fitting
         self.fit_config_model = FitConfigurationsModel(parent=self)
-        self.fit_config_model.load_configs(self._fit_configs)
+        self.fit_config_model.load_configs(self._settings.fit_configs)
+        # FitConfigurationsModel keeps its own internal storage behind Qt's row-based model API
+        # (it's a QAbstractListModel from the separately-installed qudi-core package) - this
+        # dataclass-based settings container can't hold a live reference into it the way
+        # extraction_parameters/analysis_parameters do for PulseExtractor/PulseAnalyzer. Instead,
+        # keep _settings.fit_configs in sync by listening for the model's own change signal,
+        # emitted whenever its contents change (e.g. from GUI edits via pulsed_maingui.py).
+        self.fit_config_model.sigFitConfigurationsChanged.connect(
+            lambda _names: self._apply_fit_configs(self.fit_config_model.dump_configs())
+        )
         self.fc = FitContainer(parent=self, config_model=self.fit_config_model)
         self.alt_fc = FitContainer(parent=self, config_model=self.fit_config_model)
 
@@ -364,6 +416,7 @@ class PulsedMeasurementLogic(LogicBase):
         self.__analysis_timer.timeout.disconnect()
         self.sigStartTimer.disconnect()
         self.sigStopTimer.disconnect()
+        self.fit_config_model.sigFitConfigurationsChanged.disconnect()
         return
 
     @property
@@ -378,18 +431,10 @@ class PulsedMeasurementLogic(LogicBase):
         a reference to this exact instance and mutates it in place as its live state."""
         return self._settings.analysis_parameters
 
-    @_fit_configs.representer
-    def __repr_fit_configs(self, value):
-        configs = self.fit_config_model.dump_configs()
-        if len(configs) < 1:
-            configs = None
-        return configs
-
-    @_fit_configs.constructor
-    def __constr_fit_configs(self, value):
-        if not value:
-            return self.__default_fit_configs
-        return value
+    @property
+    def fit_configs(self):
+        """The persisted tuple of fit configuration dicts - see _apply_fit_configs()."""
+        return self._settings.fit_configs
 
     ############################################################################
     # Fast counter control methods and properties
@@ -1469,8 +1514,17 @@ class PulsedMeasurementLogic(LogicBase):
             'gated counting'       : fc.is_gated,
             'extraction parameters': self.extraction_settings}
 
-    def _get_signal_metadata(self):
+    def _get_signal_metadata(self, generator_settings=None):
         ms = self._settings.readout_settings
+        # 'generation parameters' used to always be None here: it read
+        # self.sampling_information.get('generation_parameters'), a key SamplingInformation
+        # never actually holds (generation parameters live on SequenceGeneratorLogic, which
+        # this module has no Connector to). generator_settings, handed down from
+        # PulsedMasterLogic (see save_measurement_data), is the real source.
+        generation_parameters = (
+            generator_settings.generation_parameters.to_dict() if generator_settings is not None
+            else self.sampling_information.get('generation_parameters')
+        )
         metadata = {'Approx. measurement time (s)': self.measurement_data.elapsed_time,
                 'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
                 'Number of laser pulses'      : ms.number_of_lasers,
@@ -1479,8 +1533,20 @@ class PulsedMeasurementLogic(LogicBase):
                 'analysis parameters'         : self.analysis_settings,
                 'extraction parameters'       : self.extraction_settings,
                 'fast counter settings'       : self.fast_counter_settings,
-                'generation parameters'       : self.sampling_information.get('generation_parameters'),
-                'generation method parameters': self.generation_method_parameters}
+                'generation parameters'       : generation_parameters,
+                'generation method parameters': self.generation_method_parameters,
+                # Built directly (not via get_pulsed_measurement()) to avoid that method's
+                # measurement_data/loaded_asset .copy() calls - wasted work here since only
+                # .settings is used below.
+                'pulsed measurement settings' : Settings(
+                    measurement_settings=self._settings, generator_settings=generator_settings
+                ).to_dict()}
+        # Cheap identifying reference to the loaded asset that produced this data - not the full
+        # object (bulky, and per PulsedMeasurement's docstring, not how these objects are meant
+        # to be dict-serialized). Use get_pulsed_measurement().sequence for the full asset.
+        if self._loaded_asset is not None:
+            metadata['loaded asset name'] = self._loaded_asset.name
+            metadata['loaded asset type'] = type(self._loaded_asset).__name__
         if self._fit_result:
             metadata['fit result'] = FitContainer.dict_result(self._fit_result)
         if self._fit_result_alt:
@@ -1516,7 +1582,7 @@ class PulsedMeasurementLogic(LogicBase):
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
                               with_error=True, save_laser_pulses=True, save_pulsed_measurement=True,
-                              save_figure=None):
+                              save_figure=None, generator_settings=None):
         """ Prepare data to be saved and create a proper plot of the data
 
         @param str tag: a name tag which will be included in the filename if file_path is None
@@ -1528,6 +1594,12 @@ class PulsedMeasurementLogic(LogicBase):
         @param bool save_pulsed_measurement: select whether final measurement should be saved
         @param bool save_figure: select whether a thumbnail plot should be saved
         @param str notes: optional, string that is included in the metadata "as-is" without a field
+        @param SequenceGeneratorSettings generator_settings: optional, the SequenceGeneratorLogic
+            settings in effect for this measurement. PulsedMeasurementLogic has no Connector to
+            SequenceGeneratorLogic and cannot fetch this itself - PulsedMasterLogic.
+            save_measurement_data supplies it. Included in the saved signal metadata as part of
+            a combined PulsedMeasurement snapshot (see get_pulsed_measurement()); left out (None)
+            if this method is called directly without going through PulsedMasterLogic.
         """
         # Use default data storage type if none has been given explicitly
         if storage_cls is None:
@@ -1601,7 +1673,7 @@ class PulsedMeasurementLogic(LogicBase):
 
             save_path, _, _ = data_storage.save_data(
                 data,
-                metadata=self._get_signal_metadata(),
+                metadata=self._get_signal_metadata(generator_settings=generator_settings),
                 nametag=nametag,
                 filename=save_filename,
                 timestamp=timestamp,

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -19,6 +19,8 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 import os.path
+import pickle
+import shutil
 
 from PySide6 import QtCore
 import numpy as np
@@ -35,7 +37,15 @@ from qudi.util.mutex import Mutex
 from qudi.util.network import netobtain
 from qudi.util.datafitting import FitConfigurationsModel, FitContainer
 from qudi.util.math import compute_ft
-from qudi.util.datastorage import TextDataStorage, CsvDataStorage, NpyDataStorage
+from qudi.util.datastorage import (
+    TextDataStorage,
+    CsvDataStorage,
+    NpyDataStorage,
+    create_dir_for_file,
+    get_timestamp_filename,
+)
+from qudi.util.paths import get_module_app_data_path
+from qudi.util.yaml import yaml_load
 from qudi.util.units import ScaledFloat
 from qudi.util.colordefs import QudiMatplotlibStyle
 from qudi.logic.pulsed.pulse_extractor import PulseExtractor
@@ -53,6 +63,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     ExtractionParameters,
     GenerationMethodParameters,
     MeasurementInformation,
+    MetadataDictRepresentation,
     MicrowaveSettings,
     FastCounterSettings,
     ReadoutSettings,
@@ -65,7 +76,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     _DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
-from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, Settings
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, PulseObjects, Settings
 
 
 
@@ -165,8 +176,6 @@ def _default_measurement_settings():
         alternate_signal_settings=_DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
         extraction_parameters=ExtractionParameters(),
         analysis_parameters=AnalysisParameters(),
-        timer_interval_s=5.0,
-        fit_configs=_DEFAULT_FIT_CONFIGS,
     )
 
 
@@ -204,25 +213,43 @@ class PulsedMeasurementLogic(LogicBase):
     _save_thumbnails = ConfigOption(name='save_thumbnails', default=True)
 
     # status variables
-    # Bundles the external microwave settings, fast counter settings, readout settings
-    # (controlled variable/units/labels/...), alternative signal processing settings,
-    # extraction/analysis parameters, the analysis-loop timer interval, and the available
-    # data-fit configurations into a single settings object instead of independently
-    # stored/persisted attributes. fit_configs used to be its own separate StatusVar
-    # (_fit_configs) with decorator-based representer/constructor hooks reaching into
-    # self.fit_config_model, mirroring what extraction_parameters/analysis_parameters looked
-    # like before those were folded in here - see _apply_fit_configs()/on_activate() for how
-    # fit_configs is now kept in sync with fit_config_model instead.
-    _settings = StatusVar(
-        default=_default_measurement_settings(),
-        constructor=lambda x: PulsedMeasurementSettings.from_dict(x)
-        if isinstance(x, dict)
-        else _default_measurement_settings(),
-        representer=lambda obj: obj.to_dict(),
+    # Single PulsedMeasurement instance holding this module's working state: settings,
+    # acquired/evaluated data, and the loaded pulse asset. Only measurement_settings is actually
+    # persisted (see representer/constructor below) - `data`/`objects` are transient, rebuilt on
+    # every activation. name='_settings' keeps the on-disk key unchanged despite the Python
+    # attribute rename, so _migrate_legacy_settings_if_needed() keeps working off that string key.
+    _pulsed_measurement = StatusVar(
+        name='_settings',
+        default=PulsedMeasurement(settings=Settings(measurement_settings=_default_measurement_settings())),
+        constructor=lambda x: PulsedMeasurement(
+            settings=Settings(
+                measurement_settings=PulsedMeasurementSettings.from_dict(x)
+                if isinstance(x, dict)
+                else _default_measurement_settings()
+            )
+        ),
+        representer=lambda obj: obj.settings.measurement_settings.to_dict(),
     )
+
+    # timer_interval_s/fit_configs are deliberately independent StatusVars, NOT part of
+    # PulsedMeasurementSettings/_pulsed_measurement above - they're operational/GUI bookkeeping
+    # (analysis-loop cadence, available fit-curve definitions), not measurement-defining settings,
+    # so they shouldn't show up in a saved measurement's settings dict. This mirrors exactly how
+    # both were persisted before this module's settings were consolidated into one dataclass.
+    _timer_interval_s = StatusVar(name='timer_interval_s', default=5.0)
+    # fit_configs' representer/constructor read/write self.fit_config_model directly (see below) -
+    # the model (a QAbstractListModel from qudi-core) is the live, authoritative state; this
+    # StatusVar is just a thin persistence bridge over it, so no separate sync-on-change plumbing
+    # is needed the way a plain stored value would require.
+    _fit_configs = StatusVar(name='fit_configs', default=None)
 
     # notification signals for master module (i.e. GUI)
     sigMeasurementDataUpdated = QtCore.Signal()
+    # Emitted whenever a pulsed-analysis tick fails (length mismatch, extraction/analysis
+    # exception, ...) with a human-readable message, and again with '' once a subsequent tick
+    # succeeds - see _report_analysis_problem()/_clear_analysis_problem(). GUI code MAY subscribe
+    # to show/clear a warning; nothing relies on it being connected.
+    sigAnalysisProblem = QtCore.Signal(str)
     sigTimerUpdated = QtCore.Signal(float, int, float)
     sigFitUpdated = QtCore.Signal(str, object, bool)
     sigMeasurementStatusUpdated = QtCore.Signal(bool, bool)
@@ -243,41 +270,91 @@ class PulsedMeasurementLogic(LogicBase):
         # timer for measurement
         self.__analysis_timer = None
         self.__execution_state = ExecutionState()
+        # last message reported via sigAnalysisProblem - lets _report_analysis_problem() dedup
+        # repeated identical failures instead of logging/emitting on every single tick.
+        self.__last_analysis_problem = None
 
         # threading
         self._threadlock = Mutex()
 
-        # measurement data
-        signal_data = np.empty((2, 0), dtype=float)
-        signal_alt_data = np.empty((2, 0), dtype=float)
-        measurement_error = np.empty((2, 0), dtype=float)
-        laser_data = np.zeros((10, 20), dtype='int64')
-        raw_data = np.zeros((10, 20), dtype='int64')
-        self.measurement_data = PulsedMeasurementData(signal_data=signal_data,
-                                                     signal_alt_data=signal_alt_data,
-                                                     measurement_error=measurement_error,
-                                                     laser_data=laser_data,
-                                                     raw_data=raw_data)
         self._data_stash=DataStashCache()  # manages the memory for stashed/recalled raw data
 
         # for fit:
         self.fit_config_model = None  # Model for custom fit configurations
         self.fc = None  # Fit container
         self.alt_fc = None
-        self._fit_result = None
-        self._fit_result_alt = None
 
-        # Reference to whichever PulseBlockEnsemble/PulseSequence is currently loaded (owned by
-        # SequenceGeneratorLogic). Not a StatusVar - PulsedMeasurementLogic has no Connector to
-        # SequenceGeneratorLogic/pulser hardware asset info, so unlike
-        # SequenceGeneratorLogic.loaded_asset this cannot be independently re-derived on
-        # activation; it is only ever set by PulsedMasterLogic (matching today's behavior - this
-        # was also only ever populated externally before). sampling_information/
-        # measurement_information/generation_method_parameters are exposed as properties over
-        # this single reference rather than as independently persisted copies, which is what
-        # actually eliminates the save/load race that used to exist when that data was copied on
-        # every load instead.
-        self._loaded_asset = None
+        # Holding area for a newly loaded asset/closure that hasn't been committed as the
+        # actively-measured one yet - see loaded_asset setter/_commit_pending_asset().
+        self._pending_loaded_asset = None
+        self._pending_ensembles = {}
+        self._pending_blocks = {}
+
+        # measurement data/loaded asset/fit results are NOT initialized here - they live on
+        # self._pulsed_measurement.data/.objects (see the _settings/measurement_data/
+        # _loaded_asset/_fit_result/_fit_result_alt properties below), which is only meaningfully
+        # populated once qudi-core's StatusVar restoration has run (before on_activate()) and
+        # once _initialize_data_arrays() has built real data arrays (start of on_activate()) -
+        # exactly mirroring how _settings itself already worked before this class held a single
+        # consolidated PulsedMeasurement instance: nothing here reads/writes settings-derived
+        # state before activation either.
+
+    @property
+    def _settings(self):
+        """The real, shared PulsedMeasurementSettings this module actually works with - lives on
+        self._pulsed_measurement.settings.measurement_settings. Kept as a property backed by one
+        consolidated PulsedMeasurement instance (rather than renaming every one of this class's
+        many internal `self._settings.xxx` call sites) so this really is a change in storage -
+        _settings/measurement_data/_loaded_asset/_fit_result/_fit_result_alt no longer
+        independently exist as attributes - without needing to touch every existing read/write
+        site below, which continue to work completely unchanged.
+        """
+        return self._pulsed_measurement.settings.measurement_settings
+
+    @_settings.setter
+    def _settings(self, new_settings):
+        self._pulsed_measurement.settings = replace(
+            self._pulsed_measurement.settings, measurement_settings=new_settings
+        )
+
+    @property
+    def measurement_data(self):
+        """The real, shared PulsedMeasurementData held on self._pulsed_measurement.data - mutated
+        in place by the measurement loop exactly as before (PulsedMeasurementData is a plain,
+        non-frozen dataclass); see _initialize_data_arrays() for how the object itself gets
+        (re)built."""
+        return self._pulsed_measurement.data.measurement_data
+
+    @property
+    def _loaded_asset(self):
+        """Whichever PulseBlockEnsemble/PulseSequence is currently loaded, held on
+        self._pulsed_measurement.objects.sequence. Not independently persisted - only ever set
+        externally by PulsedMasterLogic, since this module has no Connector to
+        SequenceGeneratorLogic to re-derive it on its own. sampling_information/
+        measurement_information/generation_method_parameters are exposed as properties over this
+        one reference rather than copied, avoiding the save/load race that existed when they were
+        copied on every load."""
+        return self._pulsed_measurement.objects.sequence
+
+    @_loaded_asset.setter
+    def _loaded_asset(self, asset):
+        self._pulsed_measurement.objects.sequence = asset
+
+    @property
+    def _fit_result(self):
+        return self._pulsed_measurement.data.fit_result
+
+    @_fit_result.setter
+    def _fit_result(self, result):
+        self._pulsed_measurement.data.fit_result = result
+
+    @property
+    def _fit_result_alt(self):
+        return self._pulsed_measurement.data.fit_result_alt
+
+    @_fit_result_alt.setter
+    def _fit_result_alt(self, result):
+        self._pulsed_measurement.data.fit_result_alt = result
 
     def _apply_microwave_settings(self, new_settings):
         self._settings = replace(self._settings, microwave_settings=new_settings)
@@ -292,10 +369,7 @@ class PulsedMeasurementLogic(LogicBase):
         self._settings = replace(self._settings, alternate_signal_settings=new_settings)
 
     def _apply_timer_interval(self, new_interval):
-        self._settings = replace(self._settings, timer_interval_s=float(new_interval))
-
-    def _apply_fit_configs(self, new_configs):
-        self._settings = replace(self._settings, fit_configs=tuple(new_configs))
+        self._timer_interval_s = float(new_interval)
 
     @property
     def loaded_asset(self):
@@ -303,50 +377,148 @@ class PulsedMeasurementLogic(LogicBase):
 
     @loaded_asset.setter
     def loaded_asset(self, asset):
-        self._loaded_asset = asset
-        if self._settings.readout_settings.invoke_settings and self.measurement_information:
-            self._apply_invoked_settings()
-            self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
+        """Does NOT apply the new asset's settings immediately - only stores it as pending.
+        Settings/data/the active loaded-asset reference all stay whatever they were before,
+        fully self-consistent for saving, until _commit_pending_asset() runs at Play - see
+        start_pulsed_measurement()."""
+        if asset is not self._loaded_asset:
+            self.log.warning(
+                'A new sequence/ensemble has been loaded, but its settings have not been applied '
+                'to the measurement yet - press Play to apply them. Saving before that uses the '
+                'previous asset\'s name, settings, and data.'
+            )
+        self._pending_loaded_asset = asset
         return
 
-    def get_pulsed_measurement(self, generator_settings=None):
-        """Build a PulsedMeasurement snapshot bundling this module's own settings/data/loaded
-        asset with the SequenceGeneratorSettings supplied by the caller.
+    def refresh_generator_settings(self, generator_settings):
+        """Keep self._pulsed_measurement.settings.generator_settings fresh without a Connector to
+        SequenceGeneratorLogic. PulsedMasterLogic (which has that connector) calls this whenever
+        SequenceGeneratorLogic emits sigGeneratorSettingsUpdated/sigSamplingSettingsUpdated, so
+        this module's held live state - not just its on-demand get_pulsed_measurement() snapshots
+        - reflects the current generator settings."""
+        self._pulsed_measurement.settings = replace(
+            self._pulsed_measurement.settings, generator_settings=generator_settings
+        )
 
-        PulsedMeasurementLogic has no Connector to SequenceGeneratorLogic, so it cannot fetch
-        generator_settings itself - pass in SequenceGeneratorLogic.generator_settings (see
-        PulsedMasterLogic.get_pulsed_measurement()/save_measurement_data(), the only module with
-        Connectors to both PulsedMeasurementLogic and SequenceGeneratorLogic). Leave
-        generator_settings=None to get a measurement-only snapshot.
+    def refresh_loaded_asset_closure(self, ensembles, blocks):
+        """Stores the resolved closure as pending, same as the loaded_asset setter - not applied
+        until _commit_pending_asset() runs at Play, so the sequence and its ensembles/blocks
+        always commit together, never independently."""
+        self._pending_ensembles = dict(ensembles) if ensembles else {}
+        self._pending_blocks = dict(blocks) if blocks else {}
 
-        data/sequence are populated from independent copies (measurement_data.copy() /
-        loaded_asset.copy()), not live references, so the returned snapshot is frozen in time -
-        it will not keep changing under the caller as a running measurement continues or the
-        loaded asset gets reloaded/edited later under the same name. fit_result/fit_result_alt
-        are included by reference, not copied - see PulsedData's class docstring for why that's
-        safe.
+    def _commit_pending_asset(self):
+        """Promote whatever's pending (from the last loaded_asset/refresh_loaded_asset_closure()
+        call) to the actively-measured asset - called at the start of start_pulsed_measurement(),
+        right before settings get invoked from it and data arrays get rebuilt to match."""
+        self._loaded_asset = self._pending_loaded_asset
+        self._pulsed_measurement.objects.ensembles = self._pending_ensembles
+        self._pulsed_measurement.objects.blocks = self._pending_blocks
+
+    def get_pulsed_measurement(self, generator_settings=None, ensembles=None, blocks=None):
+        """Build a PulsedMeasurement snapshot bundling this module's settings/data/loaded asset
+        with the caller-supplied SequenceGeneratorSettings and resolved ensemble/block closure
+        (this module has no Connector to SequenceGeneratorLogic, so it can't fetch those itself -
+        see PulsedMasterLogic.get_pulsed_measurement()). Leave all three at their defaults for a
+        measurement-only snapshot.
+
+        Returns independent copies (not live references), so the snapshot is frozen in time.
 
         @param SequenceGeneratorSettings generator_settings: optional, the sequence generator
             settings in effect for this measurement.
-        @return PulsedMeasurement: snapshot with settings=Settings(measurement_settings=
-            self._settings, generator_settings=generator_settings), data=PulsedData(
-            measurement_data=measurement_data.copy(), fit_result=self._fit_result,
-            fit_result_alt=self._fit_result_alt), sequence=loaded_asset.copy() (or None if
-            nothing is loaded).
+        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved and copied
+            by the caller (see SequenceGeneratorLogic.resolve_asset_closure()).
+        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
+        @return PulsedMeasurement: snapshot of this module's current settings/data/loaded asset,
+            plus the given generator_settings/ensembles/blocks.
         """
+        current = self._pulsed_measurement
         return PulsedMeasurement(
-            settings=Settings(measurement_settings=self._settings, generator_settings=generator_settings),
-            data=PulsedData(
-                measurement_data=self.measurement_data.copy(),
-                fit_result=self._fit_result,
-                fit_result_alt=self._fit_result_alt,
+            settings=Settings(
+                measurement_settings=current.settings.measurement_settings,
+                generator_settings=generator_settings,
             ),
-            sequence=self._loaded_asset.copy() if self._loaded_asset is not None else None,
+            data=PulsedData(
+                measurement_data=current.data.measurement_data.copy(),
+                fit_result=current.data.fit_result,
+                fit_result_alt=current.data.fit_result_alt,
+            ),
+            objects=PulseObjects(
+                sequence=current.objects.sequence.copy() if current.objects.sequence is not None else None,
+                ensembles=dict(ensembles) if ensembles else {},
+                blocks=dict(blocks) if blocks else {},
+            ),
         )
+
+    def _migrate_legacy_settings_if_needed(self):
+        """One-time upgrade path for a status file saved by either the pre-refactor version of
+        this module (~20 individually-keyed StatusVars instead of one '_settings' key), or a
+        later format with timer_interval_s/fit_configs nested inside '_settings' instead of their
+        own independent StatusVars.
+
+        qudi-core's StatusVar loading only looks up each StatusVar's own top-level key by name -
+        it can't see old sibling keys or nested values elsewhere in the file, so without this,
+        those values would silently reset to defaults and then be permanently lost on the next
+        save (which overwrites, not merges). This detects both cases, backs up the raw file
+        (pre-refactor case only), and rebuilds the affected attributes from the old values.
+        """
+        file_path = get_module_app_data_path(self.__class__.__name__, self.module_base, self.module_name)
+        try:
+            raw_status = yaml_load(file_path, ignore_missing=True)
+        except Exception:
+            self.log.exception('Failed to read status file while checking for legacy settings format:')
+            return
+
+        if '_settings' not in raw_status and PulsedMeasurementSettings.LEGACY_STATUS_VAR_KEYS.intersection(raw_status):
+            self.log.warning(
+                'Found measurement settings saved by a pre-refactor version of this module '
+                '(individually-keyed microwave/fast counter/readout/etc. settings instead of the '
+                'current consolidated format). Migrating them now instead of silently resetting to '
+                'defaults. The original file has been backed up to "{0}.legacy_backup".'.format(file_path)
+            )
+            try:
+                backup_path = file_path + '.legacy_backup'
+                if not os.path.exists(backup_path):
+                    shutil.copy2(file_path, backup_path)
+            except Exception:
+                self.log.exception(
+                    'Failed to back up legacy status file before migrating (continuing anyway):'
+                )
+
+            try:
+                self._settings = PulsedMeasurementSettings.from_legacy_dict(raw_status)
+            except Exception:
+                self.log.exception('Failed to migrate legacy measurement settings - keeping defaults:')
+
+            # fit_configs' pre-refactor top-level key ('fit_configs') is identical to its current
+            # independent StatusVar's key - qudi-core's normal restore already found it with no
+            # help needed here. timer_interval_s's pre-refactor key was mangled/private, so it
+            # still needs migrating explicitly.
+            self._timer_interval_s = float(
+                raw_status.get('_PulsedMeasurementLogic__timer_interval', self._timer_interval_s)
+            )
+            return
+
+        # A status file saved by this session's brief in-between "everything in one dataclass"
+        # format has timer_interval_s/fit_configs nested one level deeper (inside '_settings')
+        # than either the pre-refactor or the current independent-StatusVar format expects - back
+        # -fill them so upgrading from that format doesn't silently reset to defaults either.
+        nested = raw_status.get('_settings')
+        if isinstance(nested, dict):
+            if 'timer_interval_s' in nested:
+                self._timer_interval_s = float(nested['timer_interval_s'])
+            if nested.get('fit_configs'):
+                self._fit_configs = tuple(nested['fit_configs'])
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
+        # Must run first: self._settings has already been restored (or defaulted) by qudi-core's
+        # StatusVar machinery by this point - see this method's docstring for why that default
+        # can be wrong for a pre-refactor status file, and why this has to be corrected here
+        # rather than in the StatusVar's own constructor function.
+        self._migrate_legacy_settings_if_needed()
+
         # Create an instance of PulseExtractor
         self._pulseextractor = PulseExtractor(pulsedmeasurementlogic=self)
         self._pulseanalyzer = PulseAnalyzer(pulsedmeasurementlogic=self)
@@ -355,22 +527,19 @@ class PulsedMeasurementLogic(LogicBase):
         # in this logic's thread but in the manager instead.
         self.__analysis_timer = QtCore.QTimer()
         self.__analysis_timer.setSingleShot(False)
-        self.__analysis_timer.setInterval(round(1000. * self._settings.timer_interval_s))
+        self.__analysis_timer.setInterval(round(1000. * self._timer_interval_s))
         self.__analysis_timer.timeout.connect(self._pulsed_analysis_loop,
                                               QtCore.Qt.ConnectionType.QueuedConnection)
 
         # Fitting
         self.fit_config_model = FitConfigurationsModel(parent=self)
-        self.fit_config_model.load_configs(self._settings.fit_configs)
+        self.fit_config_model.load_configs(self._fit_configs)
         # FitConfigurationsModel keeps its own internal storage behind Qt's row-based model API
-        # (it's a QAbstractListModel from the separately-installed qudi-core package) - this
-        # dataclass-based settings container can't hold a live reference into it the way
-        # extraction_parameters/analysis_parameters do for PulseExtractor/PulseAnalyzer. Instead,
-        # keep _settings.fit_configs in sync by listening for the model's own change signal,
-        # emitted whenever its contents change (e.g. from GUI edits via pulsed_maingui.py).
-        self.fit_config_model.sigFitConfigurationsChanged.connect(
-            lambda _names: self._apply_fit_configs(self.fit_config_model.dump_configs())
-        )
+        # (it's a QAbstractListModel from the separately-installed qudi-core package). No
+        # sync-on-change listener is needed here - _fit_configs' representer (see its declaration)
+        # reads self.fit_config_model.dump_configs() directly at save time, so the model is always
+        # the live, authoritative source rather than something that needs mirroring into a
+        # separately-stored value.
         self.fc = FitContainer(parent=self, config_model=self.fit_config_model)
         self.alt_fc = FitContainer(parent=self, config_model=self.fit_config_model)
 
@@ -416,7 +585,6 @@ class PulsedMeasurementLogic(LogicBase):
         self.__analysis_timer.timeout.disconnect()
         self.sigStartTimer.disconnect()
         self.sigStopTimer.disconnect()
-        self.fit_config_model.sigFitConfigurationsChanged.disconnect()
         return
 
     @property
@@ -433,8 +601,18 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def fit_configs(self):
-        """The persisted tuple of fit configuration dicts - see _apply_fit_configs()."""
-        return self._settings.fit_configs
+        """The persisted tuple of fit configuration dicts, backed by the independent _fit_configs
+        StatusVar (see its declaration and the representer/constructor hooks below)."""
+        return self._fit_configs
+
+    @_fit_configs.representer
+    def __repr_fit_configs(self, value):
+        configs = self.fit_config_model.dump_configs()
+        return configs if len(configs) >= 1 else None
+
+    @_fit_configs.constructor
+    def __constr_fit_configs(self, value):
+        return value if value else _DEFAULT_FIT_CONFIGS
 
     ############################################################################
     # Fast counter control methods and properties
@@ -497,6 +675,7 @@ class PulsedMeasurementLogic(LogicBase):
                     bin_width=bin_width,
                     record_length=record_length,
                     number_of_gates=number_of_gates,
+                    is_gated=self._fastcounter().is_gated(),
                 )
             )
         else:
@@ -819,10 +998,12 @@ class PulsedMeasurementLogic(LogicBase):
     @property
     def sampling_information(self):
         """Sampling metadata for whichever PulseBlockEnsemble/PulseSequence is currently loaded
-        - read live off the loaded_asset reference, not an independently stored copy."""
+        - read live off the loaded_asset reference, not an independently stored copy. Returns a
+        plain dict, consistent with the sibling measurement_information/generation_method_parameters
+        properties (previously returned the raw SamplingInformation dataclass instance)."""
         if self._loaded_asset is None:
-            return SamplingInformation()
-        return self._loaded_asset.sampling_information
+            return SamplingInformation().to_dict()
+        return self._loaded_asset.sampling_information.to_dict()
 
     @sampling_information.setter
     def sampling_information(self, info_dict):
@@ -862,7 +1043,7 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def timer_interval(self):
-        return float(self._settings.timer_interval_s)
+        return float(self._timer_interval_s)
 
     @timer_interval.setter
     def timer_interval(self, value):
@@ -1035,6 +1216,8 @@ class PulsedMeasurementLogic(LogicBase):
         """Start the analysis loop."""
         self.sigMeasurementStatusUpdated.emit(True, False)
 
+        self._commit_pending_asset()
+
         # Check if measurement settings need to be invoked
         if self._settings.readout_settings.invoke_settings:
             if self.measurement_information:
@@ -1082,7 +1265,7 @@ class PulsedMeasurementLogic(LogicBase):
                 # initialize analysis_timer
                 self.sigTimerUpdated.emit(self.measurement_data.elapsed_time,
                                           self.measurement_data.elapsed_sweeps,
-                                          self._settings.timer_interval_s)
+                                          self._timer_interval_s)
 
                 self.sigStartTimer.emit()
             else:
@@ -1094,11 +1277,13 @@ class PulsedMeasurementLogic(LogicBase):
         """
         Stop the measurement
         """
-        # Get raw data and analyze it a last time just before stopping the measurement.
+        # Get raw data and analyze it a last time just before stopping the measurement. Best
+        # effort - must never block stopping the measurement - but still logged, unlike a bare
+        # `except: pass` which would also swallow KeyboardInterrupt/SystemExit.
         try:
             self._pulsed_analysis_loop()
-        except:
-            pass
+        except Exception:
+            self.log.exception('Final analysis pass before stopping measurement failed:')
 
         with self._threadlock:
             if self.module_state() == 'locked':
@@ -1199,15 +1384,15 @@ class PulsedMeasurementLogic(LogicBase):
         """
         with self._threadlock:
             self._apply_timer_interval(interval)
-            if self._settings.timer_interval_s > 0:
-                self.__analysis_timer.setInterval(int(1000. * self._settings.timer_interval_s))
+            if self._timer_interval_s > 0:
+                self.__analysis_timer.setInterval(int(1000. * self._timer_interval_s))
                 if self.module_state() == 'locked' and not self.__execution_state.is_paused:
                     self.sigStartTimer.emit()
             else:
                 self.sigStopTimer.emit()
 
             self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
-                                      self._settings.timer_interval_s)
+                                      self._timer_interval_s)
         return
 
     @QtCore.Slot(str)
@@ -1346,62 +1531,117 @@ class PulsedMeasurementLogic(LogicBase):
                                                                     self._settings.fast_counter_settings.number_of_gates))
         return
 
+    def _report_analysis_problem(self, message, level='error'):
+        """Report a problem hit during a pulsed-analysis tick: logged (at `level`, default
+        'error' - pass 'warning' for a more routine/transient condition) and emitted via
+        sigAnalysisProblem, but only when `message` differs from the last-reported one - a
+        persistent problem (e.g. a settings mismatch that isn't self-correcting) logs/emits once
+        instead of spamming identically on every single tick. Always pair a call to this with an
+        early `return` from the tick that hit the problem - see _pulsed_analysis_loop()."""
+        if message != self.__last_analysis_problem:
+            getattr(self.log, level)(message)
+            self.sigAnalysisProblem.emit(message)
+        self.__last_analysis_problem = message
+
+    def _clear_analysis_problem(self):
+        """Signal that analysis has recovered, if it was previously reported as broken."""
+        if self.__last_analysis_problem is not None:
+            self.sigAnalysisProblem.emit('')
+        self.__last_analysis_problem = None
+
     @QtCore.Slot()
     def _pulsed_analysis_loop(self):
         """ Acquires laser pulses from fast counter,
             calculates fluorescence signal and creates plots.
         """
         with self._threadlock:
-            if self.module_state() == 'locked':
-                # Update elapsed time
 
+            try:
                 self._extract_laser_pulses()
-
                 tmp_signal, tmp_error = self._analyze_laser_pulses()
+            except Exception:
+                self.log.exception('Pulsed analysis failed this tick - keeping previous data:')
+                self._report_analysis_problem(
+                    'Pulsed analysis raised an exception - see log for the full traceback.'
+                )
+                return
 
-                # exclude laser pulses to ignore
-                ignore_list = list(self._settings.readout_settings.laser_ignore_list)
-                if ignore_list:
-                    ignore_list = sorted(idx if idx >= 0 else len(tmp_signal) + idx for idx in ignore_list)
-                    tmp_signal = np.delete(tmp_signal, ignore_list)
-                    tmp_error = np.delete(tmp_error, ignore_list)
-                    
-
-                # order data according to alternating flag
-                if self._settings.readout_settings.alternating:
-                    if len(self.measurement_data.signal_data[0]) != len(tmp_signal[::2]):
-                        self.log.error('Length of controlled variable ({0}) does not match length of number of readout '
-                                       'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal[::2])))
-                        return
-                    self.measurement_data.signal_data[1] = tmp_signal[::2]
-                    self.measurement_data.signal_data[2] = tmp_signal[1::2]
-                    self.measurement_data.measurement_error[1] = tmp_error[::2]
-                    self.measurement_data.measurement_error[2] = tmp_error[1::2]
+            # laser_data legitimately being all-zero is effectively never valid experimental data
+            # (shot noise alone makes an exactly-zero trace vanishingly unlikely) - it means
+            # extraction either got a flat/undetectable trace or explicitly gave up (several
+            # built-in extraction methods, and potentially custom ones, silently return all-zeros
+            # on failure rather than raising). raw_data is already available from
+            # _extract_laser_pulses() above, so distinguish the two likely causes for free rather
+            # than reporting one generic message.
+            if not self.measurement_data.laser_data.any():
+                if not self.measurement_data.raw_data.any():
+                    self._report_analysis_problem(
+                        'No new laser pulses: the fast counter returned all zeros this tick. '
+                        'Check that the laser/trigger sequence is actually running and the '
+                        'counter is wired/gated correctly.',
+                        level='warning',
+                    )
                 else:
-                    if len(self.measurement_data.signal_data[0]) != len(tmp_signal):
-                        self.log.error('Length of controlled variable ({0}) does not match length of number of readout '
-                                       'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal)))
-                        return
-                    self.measurement_data.signal_data[1] = tmp_signal
-                    self.measurement_data.measurement_error[1] = tmp_error
+                    self._report_analysis_problem(
+                        'No new laser pulses: raw counts were received, but extraction could not '
+                        'find a laser pulse edge in the trace. Check the extraction method/'
+                        'parameters against the actual pulse sequence.',
+                        level='warning',
+                    )
+                return
 
-                # Compute alternative data array from signal
-                self._compute_alt_data()
+            # exclude laser pulses to ignore
+            ignore_list = list(self._settings.readout_settings.laser_ignore_list)
+            if ignore_list:
+                ignore_list = sorted(idx if idx >= 0 else len(tmp_signal) + idx for idx in ignore_list)
+                tmp_signal = np.delete(tmp_signal, ignore_list)
+                tmp_error = np.delete(tmp_error, ignore_list)
+
+
+            # order data according to alternating flag
+            if self._settings.readout_settings.alternating:
+                if len(self.measurement_data.signal_data[0]) != len(tmp_signal[::2]):
+                    self._report_analysis_problem(
+                        'Length of controlled variable ({0}) does not match length of number of readout '
+                        'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal[::2]))
+                    )
+                    return
+                self.measurement_data.signal_data[1] = tmp_signal[::2]
+                self.measurement_data.signal_data[2] = tmp_signal[1::2]
+                self.measurement_data.measurement_error[1] = tmp_error[::2]
+                self.measurement_data.measurement_error[2] = tmp_error[1::2]
+            else:
+                if len(self.measurement_data.signal_data[0]) != len(tmp_signal):
+                    self._report_analysis_problem(
+                        'Length of controlled variable ({0}) does not match length of number of readout '
+                        'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal))
+                    )
+                    return
+                self.measurement_data.signal_data[1] = tmp_signal
+                self.measurement_data.measurement_error[1] = tmp_error
+
+            # Compute alternative data array from signal
+            self._compute_alt_data()
+
+            self._clear_analysis_problem()
 
             # emit signals
             self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
-                                      self._settings.timer_interval_s)
+                                      self._timer_interval_s)
             self.sigMeasurementDataUpdated.emit()
             return
 
     def _extract_laser_pulses(self):
         # Get counter raw data (including recalled raw data from previous measurement)
-        fc_data, info_dict = self._get_raw_data()
-        self.measurement_data.raw_data = fc_data
-        self.measurement_data.elapsed_sweeps = info_dict['elapsed_sweeps']
-        self.measurement_data.elapsed_time = info_dict['elapsed_time']
+        if self.module_state() == 'locked':
+            fc_data, info_dict = self._get_raw_data()
+            self.measurement_data.raw_data = fc_data
+            self.measurement_data.elapsed_sweeps = info_dict['elapsed_sweeps']
+            self.measurement_data.elapsed_time = info_dict['elapsed_time']
 
-        # extract laser pulses from raw data
+        # extract laser pulses from raw data - runs every tick, using whichever raw_data is
+        # currently available (freshly fetched above if locked, otherwise whatever was there
+        # before), so analysis/plotting keeps refreshing even with no measurement running
         return_dict = self._pulseextractor.extract_laser_pulses(self.measurement_data.raw_data)
         self.measurement_data.laser_data = return_dict['laser_counts_arr']
         return
@@ -1469,62 +1709,132 @@ class PulsedMeasurementLogic(LogicBase):
     def _initialize_data_arrays(self):
         """
         Initializing the signal, error, laser and raw data arrays.
+
+        Builds a fresh PulsedMeasurementData/PulsedData and assigns self._pulsed_measurement.data
+        wholesale (rather than mutating an existing object's fields in place), since - unlike
+        before this class held one consolidated PulsedMeasurement instance - self._pulsed_measurement.data
+        may not exist yet the very first time this runs (defaults to None; see PulsedMeasurement).
+        fit_result/fit_result_alt are carried over from whatever data object existed before (or
+        None on first call) - this method has never touched them, on either side of this change.
         """
         settings = self._settings.readout_settings
         fc_settings = self._settings.fast_counter_settings
         signal_dim = 3 if settings.alternating else 2
-        self.measurement_data.signal_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
-        self.measurement_data.signal_data[0] = settings.controlled_variable
 
-        self.measurement_data.signal_alt_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
-        self.measurement_data.signal_alt_data[0] = settings.controlled_variable
+        signal_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        signal_data[0] = settings.controlled_variable
 
-        self.measurement_data.measurement_error = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
-        self.measurement_data.measurement_error[0] = settings.controlled_variable
+        signal_alt_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        signal_alt_data[0] = settings.controlled_variable
+
+        measurement_error = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        measurement_error[0] = settings.controlled_variable
 
         number_of_bins = int(fc_settings.record_length / fc_settings.bin_width)
         laser_length = number_of_bins if fc_settings.number_of_gates > 0 else 500
-        self.measurement_data.laser_data = np.zeros((settings.number_of_lasers, laser_length), dtype='int64')
+        laser_data = np.zeros((settings.number_of_lasers, laser_length), dtype='int64')
 
         if fc_settings.number_of_gates > 0:
-            self.measurement_data.raw_data = np.zeros((settings.number_of_lasers, number_of_bins), dtype='int64')
+            raw_data = np.zeros((settings.number_of_lasers, number_of_bins), dtype='int64')
         else:
-            self.measurement_data.raw_data = np.zeros(number_of_bins, dtype='int64')
+            raw_data = np.zeros(number_of_bins, dtype='int64')
+
+        new_measurement_data = PulsedMeasurementData(
+            signal_data=signal_data,
+            signal_alt_data=signal_alt_data,
+            measurement_error=measurement_error,
+            laser_data=laser_data,
+            raw_data=raw_data,
+        )
+        existing_data = self._pulsed_measurement.data
+        self._pulsed_measurement.data = PulsedData(
+            measurement_data=new_measurement_data,
+            fit_result=existing_data.fit_result if existing_data is not None else None,
+            fit_result_alt=existing_data.fit_result_alt if existing_data is not None else None,
+        )
 
         self.sigMeasurementDataUpdated.emit()
         return
 
     ############################################################################
-    def _get_raw_metadata(self):
+    def _get_master_settings_metadata(self, generator_settings=None):
+        """Builds the single 'pulsed measurement settings' dict shared by all three saved-file
+        metadata functions below (_get_raw_metadata/_get_laser_metadata/_get_signal_metadata),
+        so raw/laser/signal files all describe the exact same configuration without duplicating
+        this construction logic three times. Built directly (not via get_pulsed_measurement())
+        to avoid that method's measurement_data/loaded_asset .copy() calls - wasted work here
+        since only .settings is used."""
+        return Settings(
+            measurement_settings=self._settings, generator_settings=generator_settings
+        ).to_dict()
+
+    def _get_loaded_asset_metadata(self, ensembles=None, blocks=None):
+        """Resolved closure of the currently loaded sequence/ensemble - name/type plus the
+        sequence/ensembles/blocks/elements structure, embedded directly into every raw/laser/
+        signal .dat file's metadata rather than requiring a separate '.pulsedmeasurement'
+        snapshot file. Uses PulseObjects.to_metadata_dict() (not to_dict()) - the trimmed,
+        display-only variant that drops duplicate/bulky SamplingInformation fields (see its
+        docstring); the full snapshot file still uses to_dict() for lossless round-tripping.
+
+        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved by the
+            caller (see SequenceGeneratorLogic.resolve_asset_closure()) - PulsedMeasurementLogic
+            has no Connector to SequenceGeneratorLogic and cannot resolve this itself.
+        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
+        """
+        if self._loaded_asset is None:
+            return {}
+        objects = PulseObjects(
+            sequence=self._loaded_asset,
+            ensembles=dict(ensembles) if ensembles else {},
+            blocks=dict(blocks) if blocks else {},
+        )
+        return {'loaded asset name': self._loaded_asset.name,
+                'loaded asset type': type(self._loaded_asset).__name__,
+                'loaded asset objects': objects.to_metadata_dict()}
+
+    def _get_raw_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         fc = self._settings.fast_counter_settings
         ms = self._settings.readout_settings
-        return {'bin width (s)'               : fc.bin_width,
+        metadata = {'bin width (s)'               : fc.bin_width,
             'record length (s)'           : fc.record_length,
             'gated counting'              : fc.is_gated,
             'Number of laser pulses'      : ms.number_of_lasers,
             'alternating'                 : ms.alternating,
             'Controlled variable'         : list(self.measurement_data.signal_data[0]),
             'Approx. measurement time (s)': self.measurement_data.elapsed_time,
-            'Measurement sweeps'          : self.measurement_data.elapsed_sweeps}
+            'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
+            'pulsed measurement settings' : self._get_master_settings_metadata(generator_settings)}
+        metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
+        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
+                for key, value in metadata.items()}
 
-    def _get_laser_metadata(self):
+    def _get_laser_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         fc = self._settings.fast_counter_settings
-        return {'bin width (s)'        : fc.bin_width,
+        metadata = {'bin width (s)'        : fc.bin_width,
             'record length (s)'    : fc.record_length,
             'gated counting'       : fc.is_gated,
-            'extraction parameters': self.extraction_settings}
+            'extraction parameters': self.extraction_settings,
+            'pulsed measurement settings': self._get_master_settings_metadata(generator_settings)}
+        metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
+        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
+                for key, value in metadata.items()}
 
-    def _get_signal_metadata(self, generator_settings=None):
+    def _get_signal_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         ms = self._settings.readout_settings
-        # 'generation parameters' used to always be None here: it read
-        # self.sampling_information.get('generation_parameters'), a key SamplingInformation
-        # never actually holds (generation parameters live on SequenceGeneratorLogic, which
-        # this module has no Connector to). generator_settings, handed down from
-        # PulsedMasterLogic (see save_measurement_data), is the real source.
-        generation_parameters = (
-            generator_settings.generation_parameters.to_dict() if generator_settings is not None
-            else self.sampling_information.get('generation_parameters')
-        )
+        # 'generation parameters' fallback: self.sampling_information.get('generation_parameters')
+        # CAN be populated - SequenceGeneratorLogic's sample_pulse_block_ensemble()/
+        # sample_pulse_sequence() store an EnsembleAnalysisResult/SequenceAnalysisResult (which has
+        # its own generation_parameters field) into sampling_information; since that key isn't a
+        # declared SamplingInformation field, it lands in _legacy_data as a raw GenerationParameters
+        # instance, not a dict. Normalize it here so this key is always a dict (or None) regardless
+        # of which branch supplied it. generator_settings, handed down from PulsedMasterLogic (see
+        # save_measurement_data), is preferred when available.
+        if generator_settings is not None:
+            generation_parameters = generator_settings.generation_parameters.to_dict()
+        else:
+            generation_parameters = self.sampling_information.get('generation_parameters')
+            if hasattr(generation_parameters, 'to_dict'):
+                generation_parameters = generation_parameters.to_dict()
         metadata = {'Approx. measurement time (s)': self.measurement_data.elapsed_time,
                 'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
                 'Number of laser pulses'      : ms.number_of_lasers,
@@ -1535,23 +1845,15 @@ class PulsedMeasurementLogic(LogicBase):
                 'fast counter settings'       : self.fast_counter_settings,
                 'generation parameters'       : generation_parameters,
                 'generation method parameters': self.generation_method_parameters,
-                # Built directly (not via get_pulsed_measurement()) to avoid that method's
-                # measurement_data/loaded_asset .copy() calls - wasted work here since only
-                # .settings is used below.
-                'pulsed measurement settings' : Settings(
-                    measurement_settings=self._settings, generator_settings=generator_settings
-                ).to_dict()}
-        # Cheap identifying reference to the loaded asset that produced this data - not the full
-        # object (bulky, and per PulsedMeasurement's docstring, not how these objects are meant
-        # to be dict-serialized). Use get_pulsed_measurement().sequence for the full asset.
-        if self._loaded_asset is not None:
-            metadata['loaded asset name'] = self._loaded_asset.name
-            metadata['loaded asset type'] = type(self._loaded_asset).__name__
+                'pulsed measurement settings' : self._get_master_settings_metadata(generator_settings)}
+        metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
         if self._fit_result:
             metadata['fit result'] = FitContainer.dict_result(self._fit_result)
         if self._fit_result_alt:
             metadata['fit result alt'] = FitContainer.dict_result(self._fit_result_alt)
-        return metadata
+        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
+                for key, value in metadata.items()}
+
     @staticmethod
     def _get_patched_filename_nametag(file_name=None, nametag=None, suffix_str=''):
         """ Helper method to return either a full file name or a nametag to be used as arguments in
@@ -1582,7 +1884,8 @@ class PulsedMeasurementLogic(LogicBase):
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
                               with_error=True, save_laser_pulses=True, save_pulsed_measurement=True,
-                              save_figure=None, generator_settings=None):
+                              save_figure=None, generator_settings=None, ensembles=None, blocks=None,
+                              save_measurement_snapshot=False):
         """ Prepare data to be saved and create a proper plot of the data
 
         @param str tag: a name tag which will be included in the filename if file_path is None
@@ -1600,6 +1903,18 @@ class PulsedMeasurementLogic(LogicBase):
             save_measurement_data supplies it. Included in the saved signal metadata as part of
             a combined PulsedMeasurement snapshot (see get_pulsed_measurement()); left out (None)
             if this method is called directly without going through PulsedMasterLogic.
+        @param dict ensembles: optional, {name: PulseBlockEnsemble} already resolved and copied
+            by the caller (see SequenceGeneratorLogic.resolve_asset_closure()) - same caveat as
+            generator_settings. Embedded in every raw/laser/signal .dat file's metadata (see
+            _get_loaded_asset_metadata()) as well as the optional full snapshot below.
+        @param dict blocks: optional, {name: PulseBlock}, same caveat as `ensembles`.
+        @param bool save_measurement_snapshot: optional, additionally pickle the complete
+            PulsedMeasurement snapshot (settings + data + the loaded sequence/ensemble/ensembles/
+            blocks, see get_pulsed_measurement()) to a single '.pulsedmeasurement' file alongside
+            the raw/laser/signal files - see load_measurement_snapshot() to restore it. Off by
+            default since it's a new, potentially large binary artifact; the sequence/ensembles/
+            blocks/elements themselves are always in the raw/laser/signal .dat metadata regardless
+            of this flag - this only adds settings/data/fit results on top, in one loadable object.
         """
         # Use default data storage type if none has been given explicitly
         if storage_cls is None:
@@ -1634,7 +1949,9 @@ class PulsedMeasurementLogic(LogicBase):
         # Save data to file
         data_storage.save_data(
             self.measurement_data.raw_data.astype('int64')[:, np.newaxis] if self.measurement_data.raw_data.ndim == 1 else self.measurement_data.raw_data.astype('int64'),
-            metadata=self._get_raw_metadata(),
+            metadata=self._get_raw_metadata(
+                generator_settings=generator_settings, ensembles=ensembles, blocks=blocks
+            ),
             nametag=nametag,
             filename=save_filename,
             timestamp=timestamp,
@@ -1650,7 +1967,9 @@ class PulsedMeasurementLogic(LogicBase):
                                                                         tag,
                                                                         '_laser_pulses')
             data_storage.save_data(self.measurement_data.laser_data,
-                                   metadata=self._get_laser_metadata(),
+                                   metadata=self._get_laser_metadata(
+                                       generator_settings=generator_settings, ensembles=ensembles, blocks=blocks
+                                   ),
                                    nametag=nametag,
                                    filename=save_filename,
                                    timestamp=timestamp,
@@ -1673,7 +1992,9 @@ class PulsedMeasurementLogic(LogicBase):
 
             save_path, _, _ = data_storage.save_data(
                 data,
-                metadata=self._get_signal_metadata(generator_settings=generator_settings),
+                metadata=self._get_signal_metadata(
+                    generator_settings=generator_settings, ensembles=ensembles, blocks=blocks
+                ),
                 nametag=nametag,
                 filename=save_filename,
                 timestamp=timestamp,
@@ -1686,6 +2007,38 @@ class PulsedMeasurementLogic(LogicBase):
                 fig = self._plot_pulsed_thumbnail(with_error=with_error)
                 fig_path = save_path.rsplit('.', 1)[0]
                 data_storage.save_thumbnail(fig, file_path=fig_path)
+
+        ##########################################
+        # Save full PulsedMeasurement snapshot
+        ##########################################
+        if save_measurement_snapshot:
+            save_filename, nametag = self._get_patched_filename_nametag(file_name,
+                                                                        tag,
+                                                                        '_measurement_snapshot')
+            if save_filename is not None:
+                snapshot_filename = save_filename.rsplit('.', 1)[0] + '.pulsedmeasurement'
+            else:
+                snapshot_filename = get_timestamp_filename(timestamp, nametag) + '.pulsedmeasurement'
+            snapshot_path = os.path.join(data_storage.root_dir, snapshot_filename)
+            create_dir_for_file(snapshot_path)
+            with open(snapshot_path, 'wb') as snapshot_file:
+                pickle.dump(
+                    self.get_pulsed_measurement(
+                        generator_settings=generator_settings, ensembles=ensembles, blocks=blocks
+                    ),
+                    snapshot_file,
+                )
+
+    @staticmethod
+    def load_measurement_snapshot(file_path):
+        """Load a PulsedMeasurement snapshot previously saved via
+        save_measurement_data(save_measurement_snapshot=True).
+
+        @param str file_path: full path to the '.pulsedmeasurement' file to load
+        @return PulsedMeasurement: the restored snapshot (settings + data + sequence)
+        """
+        with open(file_path, 'rb') as snapshot_file:
+            return pickle.load(snapshot_file)
 
     def _plot_pulsed_thumbnail(self, with_error=False):
 

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -47,18 +47,20 @@ from qudi.interface.microwave_interface import MicrowaveInterface
 
 #IMPORT ALL CLASSES FROM DATA CLASS
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
-    AnalysisSettings,
+    AnalysisParameters,
     DataStashCache,
     ExecutionState,
-    ExtractionSettings,
+    ExtractionParameters,
+    GenerationMethodParameters,
     AlternativeSignalSettings,
-    FitDefinition,
+    MeasurementInformation,
     MicrowaveSettings,
     FastCounterSettings,
     PulsedMeasurementSettings,
     PulsedMeasurementData,
     _as_bool
 )
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 
 
 
@@ -108,18 +110,11 @@ class PulsedMeasurementLogic(LogicBase):
 
     # status variables
     # ext. microwave settings
-    # __microwave_power = StatusVar(default=-30.0)
-    #__microwave_freq = StatusVar(default=2870e6)
-    #__use_ext_microwave = StatusVar(default=False)
     __microwave_settings= StatusVar(default=MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
                                         constructor=lambda x: MicrowaveSettings.from_dict(x) if isinstance(x, dict) else MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
                                         representer=lambda obj: obj.to_dict())
 
     # fast counter settings
-    """"
-    __fast_counter_record_length = StatusVar(default=3.0e-6)
-    __fast_counter_binwidth = StatusVar(default=1.0e-9)
-    __fast_counter_gates = StatusVar(default=0)"""
     __fast_counter_settings=StatusVar(default=FastCounterSettings(record_length=3.0e-6,
                                         bin_width=1.0e-9,
                                         number_of_gates=0,
@@ -127,17 +122,7 @@ class PulsedMeasurementLogic(LogicBase):
                                        constructor=lambda x: FastCounterSettings.from_dict(x) if isinstance(x, dict) else FastCounterSettings(record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False),
                                        representer=lambda obj: obj.to_dict())
 
-
     # Pulsed measurement settings
-    """_invoke_settings_from_sequence = StatusVar(default=False)
-    _number_of_lasers = StatusVar(default=50)
-    _controlled_variable = StatusVar(default=list(range(50)),
-                                     constructor=lambda x: np.array(x, dtype=float),
-                                     representer=lambda x: list(x))
-    _alternating = StatusVar(default=False)
-    _laser_ignore_list = StatusVar(default=list())
-    _data_units = StatusVar(default=('s', ''))
-    _data_labels = StatusVar(default=('Tau', 'Signal'))"""
     __measurement_settings = StatusVar(default=PulsedMeasurementSettings(invoke_settings=False,
                                                 controlled_variable=np.array(list(range(50)), dtype=float),
                                                 number_of_lasers=50,
@@ -149,24 +134,30 @@ class PulsedMeasurementLogic(LogicBase):
                         representer=lambda obj: obj.to_dict())
 
     # PulseExtractor settings
-    extraction_parameters = StatusVar(default=None)
-    analysis_parameters = StatusVar(default=None)
+    extraction_parameters = StatusVar(default=ExtractionParameters())
+    analysis_parameters = StatusVar(default=AnalysisParameters())
 
     # Container to store measurement information about the currently loaded sequence
-    _measurement_information = StatusVar(default=dict())
+    _measurement_information = StatusVar(
+        default=MeasurementInformation(),
+        constructor=lambda x: MeasurementInformation.from_dict(x) if isinstance(x, dict)
+        else (x if isinstance(x, MeasurementInformation) else MeasurementInformation()),
+        representer=lambda obj: obj.to_dict())
     # Container to store information about the sampled waveform/sequence currently loaded
-    _sampling_information = StatusVar(default=dict())
-    _generation_method_parameters = StatusVar(default=dict())
+    _sampling_information = StatusVar(
+        default=SamplingInformation(),
+        constructor=lambda x: x if isinstance(x, SamplingInformation)
+        else (SamplingInformation.from_dict(x) if isinstance(x, dict) else SamplingInformation()))
+    _generation_method_parameters = StatusVar(
+        default=GenerationMethodParameters(),
+        constructor=lambda x: GenerationMethodParameters.from_dict(x) if isinstance(x, dict)
+        else (x if isinstance(x, GenerationMethodParameters) else GenerationMethodParameters()),
+        representer=lambda obj: obj.to_dict())
 
     # Data fitting
     _fit_configs = StatusVar(name='fit_configs', default=None)
 
-    # alternative signal computation settings:
-    """_alternative_data_type = StatusVar(default=None)
-    zeropad = StatusVar(default=0)
-    psd = StatusVar(default=False)
-    window = StatusVar(default='none')
-    base_corr = StatusVar(default=True)"""
+    # alternative signal computation settings
     alternate_signal_settings = StatusVar(default=AlternativeSignalSettings(alternative_data_type=None),
                                         constructor=lambda x: AlternativeSignalSettings.from_dict(x) if isinstance(x, dict) else AlternativeSignalSettings(alternative_data_type=None),
                                         representer=lambda obj: obj.to_dict())
@@ -259,12 +250,7 @@ class PulsedMeasurementLogic(LogicBase):
 
         # timer for measurement
         self.__analysis_timer = None
-        #self.__start_time = 0
-        #self.__elapsed_time = 0
-        #self.__elapsed_sweeps = 0
         self.__execution_state = ExecutionState()
-        #ExecutionState is the dataclass containing the following data:
-        #start_time, time_of_pause, elapsed_pause, is_paused, timer_interval_s where _s represents seconds.
 
         # threading
         self._threadlock = Mutex()
@@ -280,17 +266,7 @@ class PulsedMeasurementLogic(LogicBase):
                                                      measurement_error=measurement_error,
                                                      laser_data=laser_data,
                                                      raw_data=raw_data)
-        """
-        self._saved_raw_data = dict()  # temporary saved raw data
-        self._recalled_raw_data_tag = None  # the currently recalled raw data dict key
-        """
         self._data_stash=DataStashCache()  # manages the memory for stashed/recalled raw data
-        
-        # Paused measurement flag
-        """self.__is_paused = False
-        self._time_of_pause = None
-        self._elapsed_pause = 0"""
-        #Already defined up in ExecutionState, so we don't need to redefine it here.
 
         # for fit:
         self.fit_config_model = None  # Model for custom fit configurations
@@ -347,9 +323,6 @@ class PulsedMeasurementLogic(LogicBase):
         # initialize arrays for the measurement data
         self._initialize_data_arrays()
 
-        # recalled saved raw data dict key
-        self._recalled_raw_data_tag = None
-
         # Connect internal signals
         self.sigStartTimer.connect(self.__analysis_timer.start, QtCore.Qt.ConnectionType.QueuedConnection)
         self.sigStopTimer.connect(self.__analysis_timer.stop, QtCore.Qt.ConnectionType.QueuedConnection)
@@ -365,9 +338,17 @@ class PulsedMeasurementLogic(LogicBase):
         self.sigStopTimer.disconnect()
         return
 
+    @extraction_parameters.constructor
+    def __constr_extraction_parameters(self, value):
+        return ExtractionParameters.from_dict(value) if isinstance(value, dict) else ExtractionParameters()
+
     @extraction_parameters.representer
     def __repr_extraction_parameters(self, value):
         return self._pulseextractor.full_settings_dict
+
+    @analysis_parameters.constructor
+    def __constr_analysis_parameters(self, value):
+        return AnalysisParameters.from_dict(value) if isinstance(value, dict) else AnalysisParameters()
 
     @analysis_parameters.representer
     def __repr_analysis_parameters(self, value):
@@ -517,6 +498,26 @@ class PulsedMeasurementLogic(LogicBase):
     @property
     def elapsed_time(self):
         return self.measurement_data.elapsed_time
+
+    @property
+    def raw_data(self):
+        return self.measurement_data.raw_data
+
+    @property
+    def laser_data(self):
+        return self.measurement_data.laser_data
+
+    @property
+    def signal_data(self):
+        return self.measurement_data.signal_data
+
+    @property
+    def signal_alt_data(self):
+        return self.measurement_data.signal_alt_data
+
+    @property
+    def measurement_error(self):
+        return self.measurement_data.measurement_error
     ############################################################################
 
     ############################################################################
@@ -621,6 +622,10 @@ class PulsedMeasurementLogic(LogicBase):
                     settings_dict.update(kwargs)
 
                 # Set parameters if present
+                # use_ext_microwave can only ever be True if a microwave connector is actually
+                # present - otherwise force it back to False regardless of what was requested.
+                if 'use_ext_microwave' in settings_dict:
+                    settings_dict['use_ext_microwave'] = _as_bool(settings_dict['use_ext_microwave']) and microwave is not None
                 self.__microwave_settings = self.__microwave_settings.update_from_dict(settings_dict)
                 if self.__microwave_settings.use_ext_microwave and microwave is not None:
                     # Apply the settings to hardware
@@ -698,24 +703,27 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def measurement_information(self):
-        return self._measurement_information
+        return self._measurement_information.to_dict()
 
     @measurement_information.setter
     def measurement_information(self, info_dict):
-        # Check if mandatory params to invoke settings are missing and set empty dict in that case.
-        mand_params = ('number_of_lasers',
-                       'controlled_variable',
-                       'laser_ignore_list',
-                       'alternating',
-                       'counting_length')
-        if not isinstance(info_dict, dict) or not all(param in info_dict for param in mand_params):
+        if isinstance(info_dict, MeasurementInformation):
+            info = info_dict
+        elif isinstance(info_dict, dict):
+            info = MeasurementInformation.from_dict(info_dict)
+        else:
+            info = MeasurementInformation()
+
+        # Check if mandatory params to invoke settings are missing and set empty container in
+        # that case.
+        if not info.is_valid:
             self.log.debug('The set measurement_information did not contain all the necessary '
-                           'information or was not a dict. Setting empty dict.')
-            self._measurement_information = dict()
+                           'information or was not a dict. Setting empty container.')
+            self._measurement_information = MeasurementInformation()
             return
 
-        # Set measurement_information dict
-        self._measurement_information = info_dict.copy()
+        # Set measurement_information container
+        self._measurement_information = info
 
         # invoke settings if needed
         if self.__measurement_settings.invoke_settings and self._measurement_information:
@@ -729,22 +737,26 @@ class PulsedMeasurementLogic(LogicBase):
 
     @sampling_information.setter
     def sampling_information(self, info_dict):
-        if isinstance(info_dict, dict):
+        if isinstance(info_dict, SamplingInformation):
             self._sampling_information = info_dict
+        elif isinstance(info_dict, dict):
+            self._sampling_information = SamplingInformation.from_dict(info_dict)
         else:
-            self._sampling_information = dict()
+            self._sampling_information = SamplingInformation()
         return
 
     @property
     def generation_method_parameters(self):
-        return self._generation_method_parameters
+        return self._generation_method_parameters.to_dict()
 
     @generation_method_parameters.setter
     def generation_method_parameters(self, info_dict):
-        if isinstance(info_dict, dict):
+        if isinstance(info_dict, GenerationMethodParameters):
             self._generation_method_parameters = info_dict
+        elif isinstance(info_dict, dict):
+            self._generation_method_parameters = GenerationMethodParameters.from_dict(info_dict)
         else:
-            self._generation_method_parameters = dict()
+            self._generation_method_parameters = GenerationMethodParameters()
         return
 
     @property
@@ -1160,17 +1172,18 @@ class PulsedMeasurementLogic(LogicBase):
         return result
 
     def _apply_invoked_settings(self):
-        if not isinstance(self._measurement_information, dict) or not self._measurement_information:
+        info = self._measurement_information
+        if not isinstance(info, MeasurementInformation) or not info.is_valid:
             self.log.warning('Can\'t invoke measurement settings from sequence information '
                          'since no measurement_information container is given.')
             return
 
         # First try to set parameters that can be changed during a running measurement
         units_labels = {}
-        if 'units' in self._measurement_information:
-            units_labels['units'] = self._measurement_information.get('units')
-        if 'labels' in self._measurement_information:
-            units_labels['labels'] = self._measurement_information.get('labels')
+        if info.units is not None:
+            units_labels['units'] = info.units
+        if info.labels is not None:
+            units_labels['labels'] = info.labels
         if units_labels:
             with self._threadlock:
                 self.__measurement_settings = self.__measurement_settings.update_from_dict(units_labels)
@@ -1180,19 +1193,19 @@ class PulsedMeasurementLogic(LogicBase):
 
         required = ('number_of_lasers', 'laser_ignore_list', 'alternating', 'controlled_variable', 'counting_length')
         for key in required:
-            if key not in self._measurement_information:
+            if getattr(info, key) is None:
                 self.log.error(f'Unable to invoke setting for "{key}".\n'
                            'Measurement information container is incomplete/invalid.')
                 return
 
         self.__measurement_settings = self.__measurement_settings.update_from_dict({
-            'number_of_lasers': int(self._measurement_information['number_of_lasers']),
-            'laser_ignore_list': sorted(self._measurement_information['laser_ignore_list']),
-            'alternating': bool(self._measurement_information['alternating']),
-            'controlled_variable': self._measurement_information['controlled_variable'],
+            'number_of_lasers': int(info.number_of_lasers),
+            'laser_ignore_list': sorted(info.laser_ignore_list),
+            'alternating': bool(info.alternating),
+            'controlled_variable': info.controlled_variable,
         })
 
-        fast_counter_record_length = self._measurement_information['counting_length']
+        fast_counter_record_length = info.counting_length
         if self._fastcounter().is_gated():
             self.set_fast_counter_settings(number_of_gates=self.__measurement_settings.number_of_lasers,
                                        record_length=fast_counter_record_length)
@@ -1318,10 +1331,11 @@ class PulsedMeasurementLogic(LogicBase):
             elapsed_time = self.__execution_state.get_live_elapsed_time()
 
         # add old raw data from previous measurements if necessary
+        # (the "starting measurement with stashed raw data" info log already happens once, in
+        # start_pulsed_measurement() - logging it again here on every analysis timer tick would
+        # spam the log for the whole duration of the measurement)
         stashed_data = self._data_stash.get_active()
         if stashed_data is not None:
-            # self.log.info('Found old saved raw data with tag "{0}".'
-            #               ''.format(self._recalled_raw_data_tag))
             elapsed_sweeps += stashed_data['elapsed_sweeps']
             elapsed_time += stashed_data['elapsed_time']
             if not fc_data.any():

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -36,7 +36,6 @@ from qudi.core.module import LogicBase
 from qudi.util.mutex import Mutex
 from qudi.util.network import netobtain
 from qudi.util.datafitting import FitConfigurationsModel, FitContainer
-from qudi.util.math import compute_ft
 from qudi.util.datastorage import (
     TextDataStorage,
     CsvDataStorage,
@@ -58,6 +57,7 @@ from qudi.interface.microwave_interface import MicrowaveInterface
 
 #IMPORT ALL CLASSES FROM DATA CLASS
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    AlternativeSignalSettings,
     AnalysisParameters,
     DataStashCache,
     ExecutionState,
@@ -74,7 +74,6 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     _DEFAULT_MICROWAVE_SETTINGS,
     _DEFAULT_FAST_COUNTER_SETTINGS,
     _DEFAULT_READOUT_SETTINGS,
-    _DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, PulseObjects, Settings
@@ -164,17 +163,20 @@ def _default_measurement_settings():
     """Factory for the default PulsedMeasurementSettings, used both as the StatusVar default
     and as the fallback when restoring a malformed/legacy status value.
 
-    microwave_settings/fast_counter_settings/readout_settings/alternate_signal_settings reuse
-    the single shared default instances defined in pulsed_measurement_logic_data.py (that file
-    can't import back from this one, so it owns these literals rather than duplicating them
-    here) - PulsedMeasurementSettings.from_dict() falls back to the exact same instances when a
-    saved settings file is missing one of these keys.
+    microwave_settings/fast_counter_settings/readout_settings reuse the single shared default
+    instances defined in pulsed_measurement_logic_data.py (that file can't import back from this
+    one, so it owns these literals rather than duplicating them here) - PulsedMeasurementSettings.
+    from_dict() falls back to the exact same instances when a saved settings file is missing one
+    of these keys. alternate_signal_settings/extraction_parameters/analysis_parameters are mutable
+    (AltPlotAnalyzer/PulseExtractor/PulseAnalyzer hold and mutate them in place as live state), so
+    - unlike the frozen settings above - each one is built fresh here rather than sharing a single
+    module-level instance, to avoid one measurement's live state leaking into another's defaults.
     """
     return PulsedMeasurementSettings(
         microwave_settings=_DEFAULT_MICROWAVE_SETTINGS,
         fast_counter_settings=_DEFAULT_FAST_COUNTER_SETTINGS,
         readout_settings=_DEFAULT_READOUT_SETTINGS,
-        alternate_signal_settings=_DEFAULT_ALTERNATE_SIGNAL_SETTINGS,
+        alternate_signal_settings=AlternativeSignalSettings(),
         extraction_parameters=ExtractionParameters(),
         analysis_parameters=AnalysisParameters(),
     )
@@ -206,6 +208,8 @@ class PulsedMeasurementLogic(LogicBase):
     # Optional additional paths to import from
     extraction_import_path = ConfigOption(name='additional_extraction_path', default=None)
     analysis_import_path = ConfigOption(name='additional_analysis_path', default=None)
+    # Optional additional path to import alternative (second) plot methods from
+    alt_plot_import_path = ConfigOption(name='additional_alt_plot_path', default=None)
     # Optional file type descriptor for saving raw data to file.
     # todo: doesn't warn if checker not satisfied
     _default_data_storage_cls = ConfigOption(name='default_data_storage_type',
@@ -365,9 +369,6 @@ class PulsedMeasurementLogic(LogicBase):
 
     def _apply_readout_settings(self, new_settings):
         self._settings = replace(self._settings, readout_settings=new_settings)
-
-    def _apply_alternate_signal_settings(self, new_settings):
-        self._settings = replace(self._settings, alternate_signal_settings=new_settings)
 
     def _apply_timer_interval(self, new_interval):
         self._timer_interval_s = float(new_interval)
@@ -601,6 +602,12 @@ class PulsedMeasurementLogic(LogicBase):
         """The real, shared AnalysisParameters object (not a copy/dict) - PulseAnalyzer holds
         a reference to this exact instance and mutates it in place as its live state."""
         return self._settings.analysis_parameters
+
+    @property
+    def alternate_signal_settings(self):
+        """The real, shared AlternativeSignalSettings object (not a copy/dict) - AltPlotAnalyzer
+        holds a reference to this exact instance and mutates it in place as its live state."""
+        return self._settings.alternate_signal_settings
 
     @property
     def fit_configs(self):
@@ -1056,7 +1063,8 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def alternative_data_type(self):
-        return str(self._settings.alternate_signal_settings.alternative_data_type)
+        method = self._altplotanalyzer.current_method
+        return str(method) if method is not None else 'None'
 
     @alternative_data_type.setter
     def alternative_data_type(self, alt_data_type):
@@ -1412,25 +1420,21 @@ class PulsedMeasurementLogic(LogicBase):
     def set_alternative_data_type(self, alt_data_type):
         """ Set the selected alternative (second) plot method by name ('None'/None disables it). """
         with self._threadlock:
-            if alt_data_type != self._settings.alternate_signal_settings.alternative_data_type:
+            if alt_data_type != self.alternative_data_type:
                 self.do_fit('No Fit', True)
-            if alt_data_type == 'Delta' and not self._settings.readout_settings.alternating:
-                if self._settings.alternate_signal_settings.alternative_data_type == 'Delta':
-                    self._apply_alternate_signal_settings(
-                        replace(self._settings.alternate_signal_settings, alternative_data_type=None)
-                    )
-                self.log.error('Can not set "Delta" as alternative data calculation if measurement is '
-                           'not alternating.\n'
-                           'Setting to previous type "{0}".'.format(
-                               self._settings.alternate_signal_settings.alternative_data_type))
-            elif alt_data_type == 'None':
-                self._apply_alternate_signal_settings(
-                    replace(self._settings.alternate_signal_settings, alternative_data_type=None)
-                )
+
+            if alt_data_type in (None, 'None', ''):
+                self._altplotanalyzer.current_method = None
+            elif alt_data_type not in self._altplotanalyzer.alt_plot_methods:
+                self.log.error('Unknown alternative plot method "{0}". Keeping previous type "{1}".'
+                               ''.format(alt_data_type, self.alternative_data_type))
+            elif not self._altplotanalyzer.is_available(alt_data_type):
+                self.log.error('Alternative plot method "{0}" is not available for the current '
+                               'measurement settings. Disabling alternative plot.'
+                               ''.format(alt_data_type))
+                self._altplotanalyzer.current_method = None
             else:
-                self._apply_alternate_signal_settings(
-                    replace(self._settings.alternate_signal_settings, alternative_data_type=alt_data_type)
-                )
+                self._altplotanalyzer.current_method = alt_data_type
 
             self._compute_alt_data()
             self.sigMeasurementDataUpdated.emit()
@@ -2180,29 +2184,24 @@ class PulsedMeasurementLogic(LogicBase):
             x_axis_prefix = scaled_float.scale
             x_axis_ft_scaled = data.signal_alt_data[0] / scaled_float.scale_val
 
-            if alt_type == 'FFT':
-                if settings.units[0] == 's':
-                    inverse_cont_var = 'Hz'
-                elif settings.units[0] == 'Hz':
-                    inverse_cont_var = 's'
-                else:
-                    inverse_cont_var = '(1/{0})'.format(settings.units[0])
-                x_axis_ft_label = 'FT {0} ({1}{2})'.format(
-                    settings.labels[0], x_axis_prefix, inverse_cont_var)
-                y_axis_ft_label = 'FT({0}) (arb. u.)'.format(settings.labels[1])
-                ft_label = 'FT of data trace 1'
-            else:
-                if settings.units[0]:
-                    x_axis_ft_label = '{0} ({1}{2})'.format(settings.labels[0], x_axis_prefix,
-                                                            settings.units[0])
-                else:
-                    x_axis_ft_label = '{0}'.format(settings.labels[0])
-                if settings.units[1]:
-                    y_axis_ft_label = '{0} ({1})'.format(settings.labels[1], settings.units[1])
-                else:
-                    y_axis_ft_label = '{0}'.format(settings.labels[1])
+            # Axis labels are provided by the selected alternative plot method. The x-axis unit is
+            # prefixed with the SI scale of the (scaled) x-axis; the y-axis is not scaled.
+            alt_labels = self._altplotanalyzer.current_labels
+            x_alt_label = alt_labels.get('x_label', '')
+            x_alt_unit = alt_labels.get('x_unit', '')
+            y_alt_label = alt_labels.get('y_label', '')
+            y_alt_unit = alt_labels.get('y_unit', '')
 
-                ft_label = '{0} of data traces'.format(alt_type)
+            if x_alt_unit:
+                x_axis_ft_label = '{0} ({1}{2})'.format(x_alt_label, x_axis_prefix, x_alt_unit)
+            else:
+                x_axis_ft_label = '{0}'.format(x_alt_label)
+            if y_alt_unit:
+                y_axis_ft_label = '{0} ({1})'.format(y_alt_label, y_alt_unit)
+            else:
+                y_axis_ft_label = '{0}'.format(y_alt_label)
+
+            ft_label = '{0} of data trace 1'.format(alt_type)
 
             ax2.plot(x_axis_ft_scaled, data.signal_alt_data[1],
                      linestyle=':', linewidth=0.5, color=colors[0],
@@ -2241,24 +2240,22 @@ class PulsedMeasurementLogic(LogicBase):
         return fig
 
     def _compute_alt_data(self):
-        alt = self._settings.alternate_signal_settings
+        """
+        Compute the alternative (second) plot data via the selected alternative plot method. Falls
+        back to a flat default plot if no method is selected, it is unavailable, or it fails.
+        """
         md = self.measurement_data
-        if alt.alternative_data_type == 'Delta' and len(md.signal_data) == 3:
-            md.signal_alt_data = np.empty((2, md.signal_data.shape[1]), dtype=float)
-            md.signal_alt_data[0] = md.signal_data[0]
-            md.signal_alt_data[1] = md.signal_data[1] - md.signal_data[2]
-        elif alt.alternative_data_type == 'FFT' and md.signal_data.shape[1] >= 2:
-            fft_x, fft_y = compute_ft(x_val=md.signal_data[0], y_val=md.signal_data[1],
-                                  zeropad_num=alt.zeropad, window=alt.window,
-                                  base_corr=alt.base_corr, psd=alt.psd)
-            md.signal_alt_data = np.empty((len(md.signal_data), len(fft_x)), dtype=float)
-            md.signal_alt_data[0] = fft_x
-            md.signal_alt_data[1] = fft_y
-            for dim in range(2, len(md.signal_data)):
-                dummy, md.signal_alt_data[dim] = compute_ft(x_val=md.signal_data[0], y_val=md.signal_data[dim],
-                                                        zeropad_num=alt.zeropad, window=alt.window,
-                                                        base_corr=alt.base_corr, psd=alt.psd)
-        else:
+        alt_data = None
+        try:
+            alt_data = self._altplotanalyzer.compute_alt_data(md.signal_data)
+        except:
+            self.log.exception('Error while computing alternative plot data:')
+            alt_data = None
+
+        if alt_data is None:
             md.signal_alt_data = np.zeros(md.signal_data.shape, dtype=float)
-            md.signal_alt_data[0] = md.signal_data[0]
+            if md.signal_data.shape[1] > 0:
+                md.signal_alt_data[0] = md.signal_data[0]
+        else:
+            md.signal_alt_data = alt_data
         return

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -1915,9 +1915,14 @@ class PulsedMeasurementLogic(LogicBase):
         display-only variant that drops duplicate/bulky SamplingInformation fields (see its
         docstring); the full snapshot file still uses to_dict() for lossless round-tripping.
 
-        Inside 'loaded asset objects' the asset appears under 'loaded_sequence' or
-        'loaded_ensemble' after its kind, and 'ensembles' shows up only for a sequence - see
-        PulseObjects.to_dict().
+        'pulse objects' always carries the same three keys - 'sequence', 'ensembles', 'blocks' -
+        whichever kind of asset is loaded, so evaluation code reads one fixed shape. The kind is
+        reconstructed rather than stated: an empty 'sequence' means a bare PulseBlockEnsemble was
+        loaded, and it is then the single entry under 'ensembles'. See PulseObjects.to_dict().
+
+        There is deliberately no 'loaded asset type' beside it: the structure above already carries
+        that. 'loaded asset name' stays, because a sequence referencing several ensembles gives no
+        other way to say which asset was the loaded one.
 
         Parameters
         ----------
@@ -1939,8 +1944,7 @@ class PulsedMeasurementLogic(LogicBase):
             blocks=dict(blocks) if blocks else {},
         )
         return {'loaded asset name': self._loaded_asset.name,
-                'loaded asset type': type(self._loaded_asset).__name__,
-                'loaded asset objects': objects.to_metadata_dict(
+                'pulse objects': objects.to_metadata_dict(
                     omit_generation_method_parameters=omit_generation_method_parameters
                 )}
 

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -64,7 +64,6 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     ExtractionParameters,
     GenerationMethodParameters,
     MeasurementInformation,
-    MetadataDictRepresentation,
     to_plain_metadata,
     MicrowaveSettings,
     FastCounterSettings,
@@ -338,17 +337,17 @@ class PulsedMeasurementLogic(LogicBase):
     @property
     def _loaded_asset(self):
         """Whichever PulseBlockEnsemble/PulseSequence is currently loaded, held on
-        self._pulsed_measurement.objects.sequence. Not independently persisted - only ever set
+        self._pulsed_measurement.objects.loaded_asset. Not independently persisted - only ever set
         externally by PulsedMasterLogic, since this module has no Connector to
         SequenceGeneratorLogic to re-derive it on its own. sampling_information/
         measurement_information/generation_method_parameters are exposed as properties over this
         one reference rather than copied, avoiding the save/load race that existed when they were
         copied on every load."""
-        return self._pulsed_measurement.objects.sequence
+        return self._pulsed_measurement.objects.loaded_asset
 
     @_loaded_asset.setter
     def _loaded_asset(self, asset):
-        self._pulsed_measurement.objects.sequence = asset
+        self._pulsed_measurement.objects.loaded_asset = asset
 
     @property
     def _fit_result(self):
@@ -459,7 +458,11 @@ class PulsedMeasurementLogic(LogicBase):
                 fit_result_alt=current.data.fit_result_alt,
             ),
             objects=PulseObjects(
-                sequence=current.objects.sequence.copy() if current.objects.sequence is not None else None,
+                loaded_asset=(
+                    current.objects.loaded_asset.copy()
+                    if current.objects.loaded_asset is not None
+                    else None
+                ),
                 ensembles=dict(ensembles) if ensembles else {},
                 blocks=dict(blocks) if blocks else {},
             ),
@@ -1866,24 +1869,55 @@ class PulsedMeasurementLogic(LogicBase):
         return
 
     ############################################################################
-    def _get_master_settings_metadata(self, generator_settings=None):
-        """Builds the single 'pulsed measurement settings' dict shared by all three saved-file
-        metadata functions below (_get_raw_metadata/_get_laser_metadata/_get_signal_metadata),
-        so raw/laser/signal files all describe the exact same configuration without duplicating
-        this construction logic three times. Built directly (not via get_pulsed_measurement())
-        to avoid that method's measurement_data/loaded_asset .copy() calls - wasted work here
-        since only .settings is used."""
+    #: Nested settings containers each saved file leaves out of its 'pulsed measurement settings'
+    #: block, because that same file already writes the container out in full at its top level.
+    #: The rule is one copy of a container per file: two copies could drift apart, and a reader
+    #: would have no way to tell which one to believe. Scalar-level overlap is deliberately left
+    #: alone (e.g. 'bin width (s)' beside fast_counter_settings['bin_width'] in the raw/laser
+    #: files, or 'loaded asset name' beside the asset's own 'name') - those flat keys are the
+    #: long-standing readable convention, their nested homes cannot be dropped without breaking
+    #: reconstruction, and both copies are read off one object in one call so they cannot diverge.
+    _RAW_METADATA_OMIT = ()
+    _LASER_METADATA_OMIT = ('measurement_settings.extraction_parameters',)
+    _SIGNAL_METADATA_OMIT = (
+        'measurement_settings.fast_counter_settings',
+        'measurement_settings.extraction_parameters',
+        'measurement_settings.analysis_parameters',
+        'generator_settings.generation_parameters',
+    )
+
+    def _get_master_settings_metadata(self, generator_settings=None, omit=()):
+        """Builds the 'pulsed measurement settings' dict shared by all three saved-file metadata
+        functions below (_get_raw_metadata/_get_laser_metadata/_get_signal_metadata), so raw/laser/
+        signal files all describe the exact same configuration without duplicating this
+        construction logic three times. Built directly (not via get_pulsed_measurement()) to avoid
+        that method's measurement_data/loaded_asset .copy() calls - wasted work here since only
+        .settings is used.
+
+        Parameters
+        ----------
+        omit : tuple of str
+            Dotted paths to nested containers this file writes out flat at its own top level - see
+            the _*_METADATA_OMIT constants above and Settings.to_metadata_dict(). Each file gets a
+            different set, so the block's contents vary per file while each file stays complete on
+            its own.
+        """
         return Settings(
             measurement_settings=self._settings, generator_settings=generator_settings
-        ).to_dict()
+        ).to_metadata_dict(omit=omit)
 
-    def _get_loaded_asset_metadata(self, ensembles=None, blocks=None):
+    def _get_loaded_asset_metadata(self, ensembles=None, blocks=None,
+                                   omit_generation_method_parameters=False):
         """Resolved closure of the currently loaded sequence/ensemble - name/type plus the
-        sequence/ensembles/blocks/elements structure, embedded directly into every raw/laser/
+        loaded asset/ensembles/blocks/elements structure, embedded directly into every raw/laser/
         signal .dat file's metadata rather than requiring a separate '.pulsedmeasurement'
         snapshot file. Uses PulseObjects.to_metadata_dict() (not to_dict()) - the trimmed,
         display-only variant that drops duplicate/bulky SamplingInformation fields (see its
         docstring); the full snapshot file still uses to_dict() for lossless round-tripping.
+
+        Inside 'loaded asset objects' the asset appears under 'loaded_sequence' or
+        'loaded_ensemble' after its kind, and 'ensembles' shows up only for a sequence - see
+        PulseObjects.to_dict().
 
         Parameters
         ----------
@@ -1893,17 +1927,22 @@ class PulsedMeasurementLogic(LogicBase):
             Connector to SequenceGeneratorLogic and cannot resolve this itself.
         blocks : dict
             Optional, {name: PulseBlock}, same caveat as `ensembles`.
+        omit_generation_method_parameters : bool
+            Optional, drop the loaded asset's own 'generation_method_parameters' because this file
+            already writes it out at its top level - only _get_signal_metadata() does.
         """
         if self._loaded_asset is None:
             return {}
         objects = PulseObjects(
-            sequence=self._loaded_asset,
+            loaded_asset=self._loaded_asset,
             ensembles=dict(ensembles) if ensembles else {},
             blocks=dict(blocks) if blocks else {},
         )
         return {'loaded asset name': self._loaded_asset.name,
                 'loaded asset type': type(self._loaded_asset).__name__,
-                'loaded asset objects': objects.to_metadata_dict()}
+                'loaded asset objects': objects.to_metadata_dict(
+                    omit_generation_method_parameters=omit_generation_method_parameters
+                )}
 
     def _get_raw_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         fc = self._settings.fast_counter_settings
@@ -1916,7 +1955,8 @@ class PulsedMeasurementLogic(LogicBase):
             'Controlled variable'         : list(self.measurement_data.signal_data[0]),
             'Approx. measurement time (s)': self.measurement_data.elapsed_time,
             'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
-            'pulsed measurement settings' : self._get_master_settings_metadata(generator_settings)}
+            'pulsed measurement settings' : self._get_master_settings_metadata(
+                generator_settings, omit=self._RAW_METADATA_OMIT)}
         metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
         return self._finalize_metadata(metadata)
 
@@ -1926,26 +1966,22 @@ class PulsedMeasurementLogic(LogicBase):
             'record length (s)'    : fc.record_length,
             'gated counting'       : fc.is_gated,
             'extraction parameters': self.extraction_settings,
-            'pulsed measurement settings': self._get_master_settings_metadata(generator_settings)}
+            'pulsed measurement settings': self._get_master_settings_metadata(
+                generator_settings, omit=self._LASER_METADATA_OMIT)}
         metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
         return self._finalize_metadata(metadata)
 
     def _get_signal_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         ms = self._settings.readout_settings
-        # 'generation parameters' fallback: self.sampling_information.get('generation_parameters')
-        # CAN be populated - SequenceGeneratorLogic's sample_pulse_block_ensemble()/
-        # sample_pulse_sequence() store an EnsembleAnalysisResult/SequenceAnalysisResult (which has
-        # its own generation_parameters field) into sampling_information; since that key isn't a
-        # declared SamplingInformation field, it lands in _legacy_data as a raw GenerationParameters
-        # instance, not a dict. Normalize it here so this key is always a dict (or None) regardless
-        # of which branch supplied it. generator_settings, handed down from PulsedMasterLogic (see
-        # save_measurement_data), is preferred when available.
-        if generator_settings is not None:
-            generation_parameters = generator_settings.generation_parameters.to_dict()
-        else:
-            generation_parameters = self.sampling_information.get('generation_parameters')
-            if hasattr(generation_parameters, 'to_dict'):
-                generation_parameters = generation_parameters.to_dict()
+        # Generation parameters have exactly one home: SequenceGeneratorSettings, handed down from
+        # PulsedMasterLogic (see save_measurement_data). None when this module is driven directly
+        # without going through it, since PulsedMeasurementLogic has no Connector to
+        # SequenceGeneratorLogic. There used to be a fallback reading them back off the loaded
+        # asset's sampling_information, where they arrived as an undeclared _legacy_data key - that
+        # copy is no longer written (see SamplingInformation) precisely so the two cannot disagree.
+        generation_parameters = (
+            generator_settings.generation_parameters.to_dict() if generator_settings is not None else None
+        )
         metadata = {'Approx. measurement time (s)': self.measurement_data.elapsed_time,
                 'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
                 'Number of laser pulses'      : ms.number_of_lasers,
@@ -1956,8 +1992,10 @@ class PulsedMeasurementLogic(LogicBase):
                 'fast counter settings'       : self.fast_counter_settings,
                 'generation parameters'       : generation_parameters,
                 'generation method parameters': self.generation_method_parameters,
-                'pulsed measurement settings' : self._get_master_settings_metadata(generator_settings)}
-        metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
+                'pulsed measurement settings' : self._get_master_settings_metadata(
+                    generator_settings, omit=self._SIGNAL_METADATA_OMIT)}
+        metadata.update(self._get_loaded_asset_metadata(
+            ensembles=ensembles, blocks=blocks, omit_generation_method_parameters=True))
         if self._fit_result:
             metadata['fit result'] = FitContainer.dict_result(self._fit_result)
         if self._fit_result_alt:
@@ -1968,24 +2006,17 @@ class PulsedMeasurementLogic(LogicBase):
     def _finalize_metadata(metadata):
         """Shared tail of _get_raw_metadata()/_get_laser_metadata()/_get_signal_metadata().
 
-        Two steps, in this order:
+        Runs every value through to_plain_metadata(), which converts it into types whose repr() can
+        be read back by qudi.util.datastorage's eval()-based parser - see its docstring for the
+        three reprs that otherwise arrive as unparsed strings, and for the >1000-element array
+        truncation it avoids.
 
-        1. to_plain_metadata() converts every value into types whose repr() can be read back by
-           qudi.util.datastorage's eval()-based parser - see its docstring for the three reprs that
-           otherwise arrive as unparsed strings, and for the >1000-element array truncation it
-           avoids.
-        2. Dicts are wrapped in MetadataDictRepresentation so the header shows them pretty-printed
-           across several lines instead of one wall-of-text line.
-
-        Sanitizing first matters: the wrapper's repr() is what ends up in the file, so it has to be
-        holding already-plain values. The two are independent otherwise - line breaks never affected
-        whether a value parses back (a dict literal spanning lines is a perfectly valid eval
-        expression, and ConfigParser rejoins continuation lines before the parse).
+        Nothing here reformats the values for display: each one is written as a single line. Line
+        breaks never affected whether a value parses back (a dict literal spanning lines is a
+        perfectly valid eval expression, and ConfigParser rejoins continuation lines before the
+        parse), so the multi-line pretty-printing this used to apply bought readability only.
         """
-        return {
-            key: (MetadataDictRepresentation(plain) if isinstance(plain, dict) else plain)
-            for key, plain in ((key, to_plain_metadata(value)) for key, value in metadata.items())
-        }
+        return {key: to_plain_metadata(value) for key, value in metadata.items()}
 
     @staticmethod
     def _get_patched_filename_nametag(file_name=None, nametag=None, suffix_str=''):

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -56,6 +56,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     MeasurementInformation,
     MicrowaveSettings,
     FastCounterSettings,
+    ReadoutSettings,
     PulsedMeasurementSettings,
     PulsedMeasurementData,
     _as_bool
@@ -73,6 +74,30 @@ def _data_storage_from_cfg_option(cfg_str):
     if cfg_str == 'npy':
         return NpyDataStorage
     raise ValueError('Invalid ConfigOption value to specify data storage type.')
+
+
+def _default_measurement_settings():
+    """Factory for the default PulsedMeasurementSettings, used both as the StatusVar default
+    and as the fallback when restoring a malformed/legacy status value."""
+    return PulsedMeasurementSettings(
+        microwave_settings=MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
+        fast_counter_settings=FastCounterSettings(
+            record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False
+        ),
+        readout_settings=ReadoutSettings(
+            invoke_settings=False,
+            controlled_variable=np.array(list(range(50)), dtype=float),
+            number_of_lasers=50,
+            laser_ignore_list=list(),
+            alternating=False,
+            units=('s', ''),
+            labels=('Tau', 'Signal'),
+        ),
+        alternate_signal_settings=AlternativeSignalSettings(alternative_data_type=None),
+        extraction_parameters=ExtractionParameters(),
+        analysis_parameters=AnalysisParameters(),
+        timer_interval_s=5.0,
+    )
 
 
 class PulsedMeasurementLogic(LogicBase):
@@ -109,58 +134,20 @@ class PulsedMeasurementLogic(LogicBase):
     _save_thumbnails = ConfigOption(name='save_thumbnails', default=True)
 
     # status variables
-    # ext. microwave settings
-    __microwave_settings= StatusVar(default=MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
-                                        constructor=lambda x: MicrowaveSettings.from_dict(x) if isinstance(x, dict) else MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
-                                        representer=lambda obj: obj.to_dict())
-
-    # fast counter settings
-    __fast_counter_settings=StatusVar(default=FastCounterSettings(record_length=3.0e-6,
-                                        bin_width=1.0e-9,
-                                        number_of_gates=0,
-                                        is_gated=False),
-                                       constructor=lambda x: FastCounterSettings.from_dict(x) if isinstance(x, dict) else FastCounterSettings(record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False),
-                                       representer=lambda obj: obj.to_dict())
-
-    # Pulsed measurement settings
-    __measurement_settings = StatusVar(default=PulsedMeasurementSettings(invoke_settings=False,
-                                                controlled_variable=np.array(list(range(50)), dtype=float),
-                                                number_of_lasers=50,
-                                                laser_ignore_list=list(),
-                                                alternating=False,
-                                                units=('s', ''),
-                                                labels=('Tau', 'Signal')),
-                        constructor=lambda x: PulsedMeasurementSettings.from_dict(x) if isinstance(x, dict) else PulsedMeasurementSettings(invoke_settings=False, controlled_variable=np.array(list(range(50)), dtype=float), number_of_lasers=50, laser_ignore_list=list(), alternating=False, units=('s', ''), labels=('Tau', 'Signal')),
-                        representer=lambda obj: obj.to_dict())
-
-    # PulseExtractor settings
-    extraction_parameters = StatusVar(default=ExtractionParameters())
-    analysis_parameters = StatusVar(default=AnalysisParameters())
-
-    # Container to store measurement information about the currently loaded sequence
-    _measurement_information = StatusVar(
-        default=MeasurementInformation(),
-        constructor=lambda x: MeasurementInformation.from_dict(x) if isinstance(x, dict)
-        else (x if isinstance(x, MeasurementInformation) else MeasurementInformation()),
-        representer=lambda obj: obj.to_dict())
-    # Container to store information about the sampled waveform/sequence currently loaded
-    _sampling_information = StatusVar(
-        default=SamplingInformation(),
-        constructor=lambda x: x if isinstance(x, SamplingInformation)
-        else (SamplingInformation.from_dict(x) if isinstance(x, dict) else SamplingInformation()))
-    _generation_method_parameters = StatusVar(
-        default=GenerationMethodParameters(),
-        constructor=lambda x: GenerationMethodParameters.from_dict(x) if isinstance(x, dict)
-        else (x if isinstance(x, GenerationMethodParameters) else GenerationMethodParameters()),
-        representer=lambda obj: obj.to_dict())
+    # Bundles the external microwave settings, fast counter settings, readout settings
+    # (controlled variable/units/labels/...), alternative signal processing settings,
+    # extraction/analysis parameters, and the analysis-loop timer interval into a single
+    # settings object instead of independently stored/persisted attributes.
+    _settings = StatusVar(
+        default=_default_measurement_settings(),
+        constructor=lambda x: PulsedMeasurementSettings.from_dict(x)
+        if isinstance(x, dict)
+        else _default_measurement_settings(),
+        representer=lambda obj: obj.to_dict(),
+    )
 
     # Data fitting
     _fit_configs = StatusVar(name='fit_configs', default=None)
-
-    # alternative signal computation settings
-    alternate_signal_settings = StatusVar(default=AlternativeSignalSettings(alternative_data_type=None),
-                                        constructor=lambda x: AlternativeSignalSettings.from_dict(x) if isinstance(x, dict) else AlternativeSignalSettings(alternative_data_type=None),
-                                        representer=lambda obj: obj.to_dict())
 
     # notification signals for master module (i.e. GUI)
     sigMeasurementDataUpdated = QtCore.Signal()
@@ -275,6 +262,45 @@ class PulsedMeasurementLogic(LogicBase):
         self._fit_result = None
         self._fit_result_alt = None
 
+        # Reference to whichever PulseBlockEnsemble/PulseSequence is currently loaded (owned by
+        # SequenceGeneratorLogic). Not a StatusVar - PulsedMeasurementLogic has no Connector to
+        # SequenceGeneratorLogic/pulser hardware asset info, so unlike
+        # SequenceGeneratorLogic.loaded_asset this cannot be independently re-derived on
+        # activation; it is only ever set by PulsedMasterLogic (matching today's behavior - this
+        # was also only ever populated externally before). sampling_information/
+        # measurement_information/generation_method_parameters are exposed as properties over
+        # this single reference rather than as independently persisted copies, which is what
+        # actually eliminates the save/load race that used to exist when that data was copied on
+        # every load instead.
+        self._loaded_asset = None
+
+    def _apply_microwave_settings(self, new_settings):
+        self._settings = replace(self._settings, microwave_settings=new_settings)
+
+    def _apply_fast_counter_settings(self, new_settings):
+        self._settings = replace(self._settings, fast_counter_settings=new_settings)
+
+    def _apply_readout_settings(self, new_settings):
+        self._settings = replace(self._settings, readout_settings=new_settings)
+
+    def _apply_alternate_signal_settings(self, new_settings):
+        self._settings = replace(self._settings, alternate_signal_settings=new_settings)
+
+    def _apply_timer_interval(self, new_interval):
+        self._settings = replace(self._settings, timer_interval_s=float(new_interval))
+
+    @property
+    def loaded_asset(self):
+        return self._loaded_asset
+
+    @loaded_asset.setter
+    def loaded_asset(self, asset):
+        self._loaded_asset = asset
+        if self._settings.readout_settings.invoke_settings and self.measurement_information:
+            self._apply_invoked_settings()
+            self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
+        return
+
     def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
@@ -286,7 +312,7 @@ class PulsedMeasurementLogic(LogicBase):
         # in this logic's thread but in the manager instead.
         self.__analysis_timer = QtCore.QTimer()
         self.__analysis_timer.setSingleShot(False)
-        self.__analysis_timer.setInterval(round(1000. * self.__execution_state.timer_interval_s))
+        self.__analysis_timer.setInterval(round(1000. * self._settings.timer_interval_s))
         self.__analysis_timer.timeout.connect(self._pulsed_analysis_loop,
                                               QtCore.Qt.ConnectionType.QueuedConnection)
 
@@ -302,24 +328,26 @@ class PulsedMeasurementLogic(LogicBase):
         # Check and configure fast counter
         binning_constraints = self._fastcounter().get_constraints()['hardware_binwidth_list']
         fixes = {}
-        if self.__fast_counter_settings.bin_width not in binning_constraints:
+        if self._settings.fast_counter_settings.bin_width not in binning_constraints:
             fixes['bin_width'] = binning_constraints[0]
-        if self.__fast_counter_settings.record_length <= 0:
+        if self._settings.fast_counter_settings.record_length <= 0:
             fixes['record_length'] = 3e-6
         if fixes:
-            self.__fast_counter_settings = self.__fast_counter_settings.update_from_dict(fixes)
+            self._apply_fast_counter_settings(self._settings.fast_counter_settings.update_from_dict(fixes))
         self.fast_counter_off()
-        if self._fastcounter().is_gated() and self.__fast_counter_settings.number_of_gates < 1:
-            self.__fast_counter_settings = replace(
-                self.__fast_counter_settings,
-                number_of_gates=max(1, self.__measurement_settings.number_of_lasers)
+        if self._fastcounter().is_gated() and self._settings.fast_counter_settings.number_of_gates < 1:
+            self._apply_fast_counter_settings(
+                replace(
+                    self._settings.fast_counter_settings,
+                    number_of_gates=max(1, self._settings.readout_settings.number_of_lasers),
+                )
             )
         self.set_fast_counter_settings()
 
         # Check and configure external microwave
-        if self.__microwave_settings.use_ext_microwave:
+        if self._settings.microwave_settings.use_ext_microwave:
             self.microwave_off()
-            self.set_microwave_settings(self.__microwave_settings.to_dict())
+            self.set_microwave_settings(self._settings.microwave_settings.to_dict())
         # initialize arrays for the measurement data
         self._initialize_data_arrays()
 
@@ -338,21 +366,17 @@ class PulsedMeasurementLogic(LogicBase):
         self.sigStopTimer.disconnect()
         return
 
-    @extraction_parameters.constructor
-    def __constr_extraction_parameters(self, value):
-        return ExtractionParameters.from_dict(value) if isinstance(value, dict) else ExtractionParameters()
+    @property
+    def extraction_parameters(self):
+        """The real, shared ExtractionParameters object (not a copy/dict) - PulseExtractor
+        holds a reference to this exact instance and mutates it in place as its live state."""
+        return self._settings.extraction_parameters
 
-    @extraction_parameters.representer
-    def __repr_extraction_parameters(self, value):
-        return self._pulseextractor.full_settings_dict
-
-    @analysis_parameters.constructor
-    def __constr_analysis_parameters(self, value):
-        return AnalysisParameters.from_dict(value) if isinstance(value, dict) else AnalysisParameters()
-
-    @analysis_parameters.representer
-    def __repr_analysis_parameters(self, value):
-        return self._pulseanalyzer.full_settings_dict
+    @property
+    def analysis_parameters(self):
+        """The real, shared AnalysisParameters object (not a copy/dict) - PulseAnalyzer holds
+        a reference to this exact instance and mutates it in place as its live state."""
+        return self._settings.analysis_parameters
 
     @_fit_configs.representer
     def __repr_fit_configs(self, value):
@@ -372,7 +396,7 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def fast_counter_settings(self):
-        return self.__fast_counter_settings.to_dict()
+        return self._settings.fast_counter_settings.to_dict()
 
     @fast_counter_settings.setter
     def fast_counter_settings(self, settings_dict):
@@ -414,20 +438,21 @@ class PulsedMeasurementLogic(LogicBase):
             if 'number_of_gates' in settings_dict and not self._fastcounter().is_gated():
                 settings_dict['number_of_gates'] = 0
 
-            self.__fast_counter_settings = self.__fast_counter_settings.update_from_dict(settings_dict)
-
+            self._apply_fast_counter_settings(self._settings.fast_counter_settings.update_from_dict(settings_dict))
 
             # Apply the settings to hardware
             bin_width, record_length, number_of_gates = self._fastcounter().configure(
-                self.__fast_counter_settings.bin_width,
-                self.__fast_counter_settings.record_length,
-                self.__fast_counter_settings.number_of_gates
+                self._settings.fast_counter_settings.bin_width,
+                self._settings.fast_counter_settings.record_length,
+                self._settings.fast_counter_settings.number_of_gates
              )
-            self.__fast_counter_settings = replace(
-                self.__fast_counter_settings,
-                bin_width=bin_width,
-                record_length=record_length,
-                number_of_gates=number_of_gates
+            self._apply_fast_counter_settings(
+                replace(
+                    self._settings.fast_counter_settings,
+                    bin_width=bin_width,
+                    record_length=record_length,
+                    number_of_gates=number_of_gates,
+                )
             )
         else:
             self.log.warning('Fast counter is not idle (status: {0}).\n'
@@ -525,7 +550,7 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def ext_microwave_settings(self):
-        return self.__microwave_settings.to_dict()
+        return self._settings.microwave_settings.to_dict()
 
     @ext_microwave_settings.setter
     def ext_microwave_settings(self, settings_dict):
@@ -626,14 +651,19 @@ class PulsedMeasurementLogic(LogicBase):
                 # present - otherwise force it back to False regardless of what was requested.
                 if 'use_ext_microwave' in settings_dict:
                     settings_dict['use_ext_microwave'] = _as_bool(settings_dict['use_ext_microwave']) and microwave is not None
-                self.__microwave_settings = self.__microwave_settings.update_from_dict(settings_dict)
-                if self.__microwave_settings.use_ext_microwave and microwave is not None:
+                self._apply_microwave_settings(self._settings.microwave_settings.update_from_dict(settings_dict))
+                if self._settings.microwave_settings.use_ext_microwave and microwave is not None:
                     # Apply the settings to hardware
-                    microwave.set_cw(frequency=self.__microwave_settings.frequency, power=self.__microwave_settings.power)
-                    self.__microwave_settings = replace(
-                    self.__microwave_settings,
-                    frequency=microwave.cw_frequency,
-                    power=microwave.cw_power)
+                    microwave.set_cw(
+                        frequency=self._settings.microwave_settings.frequency, power=self._settings.microwave_settings.power
+                    )
+                    self._apply_microwave_settings(
+                        replace(
+                            self._settings.microwave_settings,
+                            frequency=microwave.cw_frequency,
+                            power=microwave.cw_power,
+                        )
+                    )
                 
         finally:
             # emit update signal for master (GUI or other logic module)
@@ -691,11 +721,11 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def measurement_settings(self):
-        return self.__measurement_settings.to_dict()
+        return self._settings.readout_settings.to_dict()
 
     @measurement_settings.setter
     def measurement_settings(self, settings_dict):
-        if isinstance(settings_dict, PulsedMeasurementSettings):
+        if isinstance(settings_dict, ReadoutSettings):
             self.set_measurement_settings(settings_dict.to_dict())
         elif isinstance(settings_dict, dict):
             self.set_measurement_settings(settings_dict)
@@ -703,7 +733,12 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def measurement_information(self):
-        return self._measurement_information.to_dict()
+        """Metadata about whichever PulseBlockEnsemble/PulseSequence is currently loaded - read
+        live off the loaded_asset reference (see loaded_asset property), not an independently
+        stored copy."""
+        if self._loaded_asset is None:
+            return MeasurementInformation().to_dict()
+        return self._loaded_asset.measurement_information.to_dict()
 
     @measurement_information.setter
     def measurement_information(self, info_dict):
@@ -714,54 +749,75 @@ class PulsedMeasurementLogic(LogicBase):
         else:
             info = MeasurementInformation()
 
+        if self._loaded_asset is None:
+            self.log.warning('Cannot set measurement_information: no asset is currently loaded.')
+            return
+
         # Check if mandatory params to invoke settings are missing and set empty container in
         # that case.
         if not info.is_valid:
             self.log.debug('The set measurement_information did not contain all the necessary '
                            'information or was not a dict. Setting empty container.')
-            self._measurement_information = MeasurementInformation()
+            self._loaded_asset.measurement_information = MeasurementInformation()
             return
 
-        # Set measurement_information container
-        self._measurement_information = info
+        # Mutate the loaded asset's own measurement_information - the same object
+        # SequenceGeneratorLogic sees, not a copy.
+        self._loaded_asset.measurement_information = info
 
         # invoke settings if needed
-        if self.__measurement_settings.invoke_settings and self._measurement_information:
+        if self._settings.readout_settings.invoke_settings and info:
             self._apply_invoked_settings()
             self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return
 
     @property
     def sampling_information(self):
-        return self._sampling_information
+        """Sampling metadata for whichever PulseBlockEnsemble/PulseSequence is currently loaded
+        - read live off the loaded_asset reference, not an independently stored copy."""
+        if self._loaded_asset is None:
+            return SamplingInformation()
+        return self._loaded_asset.sampling_information
 
     @sampling_information.setter
     def sampling_information(self, info_dict):
         if isinstance(info_dict, SamplingInformation):
-            self._sampling_information = info_dict
+            new_value = info_dict
         elif isinstance(info_dict, dict):
-            self._sampling_information = SamplingInformation.from_dict(info_dict)
+            new_value = SamplingInformation.from_dict(info_dict)
         else:
-            self._sampling_information = SamplingInformation()
+            new_value = SamplingInformation()
+        if self._loaded_asset is None:
+            self.log.warning('Cannot set sampling_information: no asset is currently loaded.')
+            return
+        self._loaded_asset.sampling_information = new_value
         return
 
     @property
     def generation_method_parameters(self):
-        return self._generation_method_parameters.to_dict()
+        """Generation kwargs for whichever PulseBlockEnsemble/PulseSequence is currently loaded
+        - read live off the loaded_asset reference, not an independently stored copy."""
+        if self._loaded_asset is None:
+            return GenerationMethodParameters().to_dict()
+        return self._loaded_asset.generation_method_parameters.to_dict()
 
     @generation_method_parameters.setter
     def generation_method_parameters(self, info_dict):
         if isinstance(info_dict, GenerationMethodParameters):
-            self._generation_method_parameters = info_dict
+            new_value = info_dict
         elif isinstance(info_dict, dict):
-            self._generation_method_parameters = GenerationMethodParameters.from_dict(info_dict)
+            new_value = GenerationMethodParameters.from_dict(info_dict)
         else:
-            self._generation_method_parameters = GenerationMethodParameters()
+            new_value = GenerationMethodParameters()
+        if self._loaded_asset is None:
+            self.log.warning('Cannot set generation_method_parameters: no asset is currently loaded.')
+            return
+        self._loaded_asset.generation_method_parameters = new_value
         return
 
     @property
     def timer_interval(self):
-        return float(self.__execution_state.timer_interval_s)
+        return float(self._settings.timer_interval_s)
 
     @timer_interval.setter
     def timer_interval(self, value):
@@ -771,7 +827,7 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def alternative_data_type(self):
-        return str(self.alternate_signal_settings.alternative_data_type)
+        return str(self._settings.alternate_signal_settings.alternative_data_type)
 
     @alternative_data_type.setter
     def alternative_data_type(self, alt_data_type):
@@ -876,7 +932,7 @@ class PulsedMeasurementLogic(LogicBase):
         @return:
         """
         # Determine complete settings dictionary
-        if isinstance(settings_dict, PulsedMeasurementSettings):
+        if isinstance(settings_dict, ReadoutSettings):
             settings_dict = settings_dict.to_dict()
             settings_dict.update(kwargs)
         elif not isinstance(settings_dict, dict):
@@ -886,12 +942,14 @@ class PulsedMeasurementLogic(LogicBase):
 
         # invoke_settings flag can change regardless of module state
         if 'invoke_settings' in settings_dict:
-            self.__measurement_settings = replace(
-                self.__measurement_settings,
-                invoke_settings=_as_bool(settings_dict['invoke_settings'])
+            self._apply_readout_settings(
+                replace(
+                    self._settings.readout_settings,
+                    invoke_settings=_as_bool(settings_dict['invoke_settings'])
+                )
             )
-        if self.__measurement_settings.invoke_settings:
-            if self._measurement_information:
+        if self._settings.readout_settings.invoke_settings:
+            if self.measurement_information:
                 self._apply_invoked_settings()
         else:
             # units/labels can change while a measurement is running
@@ -902,14 +960,14 @@ class PulsedMeasurementLogic(LogicBase):
                 if 'labels' in settings_dict:
                     units_labels['labels'] = settings_dict['labels']
                 if units_labels:
-                    self.__measurement_settings = self.__measurement_settings.update_from_dict(units_labels)
+                    self._apply_readout_settings(self._settings.readout_settings.update_from_dict(units_labels))
             if self.module_state() == 'idle':
                 idle_only_keys = ('controlled_variable', 'number_of_lasers', 'laser_ignore_list', 'alternating')
                 idle_updates = {k: settings_dict[k] for k in idle_only_keys if k in settings_dict}
                 if idle_updates:
-                    self.__measurement_settings = self.__measurement_settings.update_from_dict(idle_updates)
+                    self._apply_readout_settings(self._settings.readout_settings.update_from_dict(idle_updates))
                 if 'number_of_lasers' in idle_updates and self._fastcounter().is_gated():
-                    self.set_fast_counter_settings(number_of_gates=self.__measurement_settings.number_of_lasers)
+                    self.set_fast_counter_settings(number_of_gates=self._settings.readout_settings.number_of_lasers)
         self._measurement_settings_sanity_check()
         self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return self.measurement_settings
@@ -933,8 +991,8 @@ class PulsedMeasurementLogic(LogicBase):
         self.sigMeasurementStatusUpdated.emit(True, False)
 
         # Check if measurement settings need to be invoked
-        if self.__measurement_settings.invoke_settings:
-            if self._measurement_information:
+        if self._settings.readout_settings.invoke_settings:
+            if self.measurement_information:
                 self._apply_invoked_settings()
                 self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
             else:
@@ -966,7 +1024,7 @@ class PulsedMeasurementLogic(LogicBase):
                 #the log message will not be printed, and the active_tag is cleared internally
 
                 # start microwave source
-                if self.__microwave_settings.use_ext_microwave:
+                if self._settings.microwave_settings.use_ext_microwave:
                     self.microwave_on()
                 # start fast counter
                 self.fast_counter_on()
@@ -979,7 +1037,7 @@ class PulsedMeasurementLogic(LogicBase):
                 # initialize analysis_timer
                 self.sigTimerUpdated.emit(self.measurement_data.elapsed_time,
                                           self.measurement_data.elapsed_sweeps,
-                                          self.__execution_state.timer_interval_s)
+                                          self._settings.timer_interval_s)
 
                 self.sigStartTimer.emit()
             else:
@@ -1006,7 +1064,7 @@ class PulsedMeasurementLogic(LogicBase):
                 # Turn off pulse generator
                 self.pulse_generator_off()
                 # Turn off microwave source
-                if self.__microwave_settings.use_ext_microwave:
+                if self._settings.microwave_settings.use_ext_microwave:
                     self.microwave_off()
 
                 # stash raw data if requested
@@ -1049,7 +1107,7 @@ class PulsedMeasurementLogic(LogicBase):
 
                 self.fast_counter_pause()
                 self.pulse_generator_off()
-                if self.__microwave_settings.use_ext_microwave:
+                if self._settings.microwave_settings.use_ext_microwave:
                     self.microwave_off()
 
                 # Set measurement paused flag
@@ -1068,7 +1126,7 @@ class PulsedMeasurementLogic(LogicBase):
         """
         with self._threadlock:
             if self.module_state() == 'locked':
-                if self.__microwave_settings.use_ext_microwave:
+                if self._settings.microwave_settings.use_ext_microwave:
                     self.microwave_on()
                 self.fast_counter_continue()
                 self.pulse_generator_on()
@@ -1095,16 +1153,16 @@ class PulsedMeasurementLogic(LogicBase):
         @param int|float interval: Interval of the timer in s
         """
         with self._threadlock:
-            self.__execution_state.timer_interval_s = interval
-            if self.__execution_state.timer_interval_s > 0:
-                self.__analysis_timer.setInterval(int(1000. * self.__execution_state.timer_interval_s))
+            self._apply_timer_interval(interval)
+            if self._settings.timer_interval_s > 0:
+                self.__analysis_timer.setInterval(int(1000. * self._settings.timer_interval_s))
                 if self.module_state() == 'locked' and not self.__execution_state.is_paused:
                     self.sigStartTimer.emit()
             else:
                 self.sigStopTimer.emit()
 
             self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
-                                      self.__execution_state.timer_interval_s)
+                                      self._settings.timer_interval_s)
         return
 
     @QtCore.Slot(str)
@@ -1115,18 +1173,25 @@ class PulsedMeasurementLogic(LogicBase):
         @return:
         """
         with self._threadlock:
-            if alt_data_type != self.alternate_signal_settings.alternative_data_type:
+            if alt_data_type != self._settings.alternate_signal_settings.alternative_data_type:
                 self.do_fit('No Fit', True)
-            if alt_data_type == 'Delta' and not self.__measurement_settings.alternating:
-                if self.alternate_signal_settings.alternative_data_type == 'Delta':
-                    self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=None)
+            if alt_data_type == 'Delta' and not self._settings.readout_settings.alternating:
+                if self._settings.alternate_signal_settings.alternative_data_type == 'Delta':
+                    self._apply_alternate_signal_settings(
+                        replace(self._settings.alternate_signal_settings, alternative_data_type=None)
+                    )
                 self.log.error('Can not set "Delta" as alternative data calculation if measurement is '
                            'not alternating.\n'
-                           'Setting to previous type "{0}".'.format(self.alternate_signal_settings.alternative_data_type))
+                           'Setting to previous type "{0}".'.format(
+                               self._settings.alternate_signal_settings.alternative_data_type))
             elif alt_data_type == 'None':
-                self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=None)
+                self._apply_alternate_signal_settings(
+                    replace(self._settings.alternate_signal_settings, alternative_data_type=None)
+                )
             else:
-                self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=alt_data_type)
+                self._apply_alternate_signal_settings(
+                    replace(self._settings.alternate_signal_settings, alternative_data_type=alt_data_type)
+                )
 
             self._compute_alt_data()
             self.sigMeasurementDataUpdated.emit()
@@ -1172,7 +1237,7 @@ class PulsedMeasurementLogic(LogicBase):
         return result
 
     def _apply_invoked_settings(self):
-        info = self._measurement_information
+        info = self._loaded_asset.measurement_information if self._loaded_asset is not None else MeasurementInformation()
         if not isinstance(info, MeasurementInformation) or not info.is_valid:
             self.log.warning('Can\'t invoke measurement settings from sequence information '
                          'since no measurement_information container is given.')
@@ -1186,7 +1251,7 @@ class PulsedMeasurementLogic(LogicBase):
             units_labels['labels'] = info.labels
         if units_labels:
             with self._threadlock:
-                self.__measurement_settings = self.__measurement_settings.update_from_dict(units_labels)
+                self._apply_readout_settings(self._settings.readout_settings.update_from_dict(units_labels))
 
         if self.module_state() == 'locked':
             return
@@ -1198,23 +1263,25 @@ class PulsedMeasurementLogic(LogicBase):
                            'Measurement information container is incomplete/invalid.')
                 return
 
-        self.__measurement_settings = self.__measurement_settings.update_from_dict({
-            'number_of_lasers': int(info.number_of_lasers),
-            'laser_ignore_list': sorted(info.laser_ignore_list),
-            'alternating': bool(info.alternating),
-            'controlled_variable': info.controlled_variable,
-        })
+        self._apply_readout_settings(
+            self._settings.readout_settings.update_from_dict({
+                'number_of_lasers': int(info.number_of_lasers),
+                'laser_ignore_list': sorted(info.laser_ignore_list),
+                'alternating': bool(info.alternating),
+                'controlled_variable': info.controlled_variable,
+            })
+        )
 
         fast_counter_record_length = info.counting_length
         if self._fastcounter().is_gated():
-            self.set_fast_counter_settings(number_of_gates=self.__measurement_settings.number_of_lasers,
+            self.set_fast_counter_settings(number_of_gates=self._settings.readout_settings.number_of_lasers,
                                        record_length=fast_counter_record_length)
         else:
             self.set_fast_counter_settings(record_length=fast_counter_record_length)
         return
 
     def _measurement_settings_sanity_check(self):
-        settings = self.__measurement_settings
+        settings = self._settings.readout_settings
         number_of_analyzed_lasers = settings.number_of_lasers - len(settings.laser_ignore_list)
         if len(settings.controlled_variable) < 1:
             self.log.error('Tried to set empty controlled variables array. This can not work.')
@@ -1228,10 +1295,10 @@ class PulsedMeasurementLogic(LogicBase):
                        'controlled_variable ticks ({1:d}).'
                        ''.format(number_of_analyzed_lasers, len(settings.controlled_variable)))
 
-        if self._fastcounter().is_gated() and settings.number_of_lasers != self.__fast_counter_settings.number_of_gates:
+        if self._fastcounter().is_gated() and settings.number_of_lasers != self._settings.fast_counter_settings.number_of_gates:
             self.log.error('Gated fast counter gate number ({0:d}) differs from number of laser pulses ({1:d})'
                        'configured in measurement settings.'.format(settings.number_of_lasers,
-                                                                    self.__fast_counter_settings.number_of_gates))
+                                                                    self._settings.fast_counter_settings.number_of_gates))
         return
 
     @QtCore.Slot()
@@ -1248,7 +1315,7 @@ class PulsedMeasurementLogic(LogicBase):
                 tmp_signal, tmp_error = self._analyze_laser_pulses()
 
                 # exclude laser pulses to ignore
-                ignore_list = list(self.__measurement_settings.laser_ignore_list)
+                ignore_list = list(self._settings.readout_settings.laser_ignore_list)
                 if ignore_list:
                     ignore_list = sorted(idx if idx >= 0 else len(tmp_signal) + idx for idx in ignore_list)
                     tmp_signal = np.delete(tmp_signal, ignore_list)
@@ -1256,7 +1323,7 @@ class PulsedMeasurementLogic(LogicBase):
                     
 
                 # order data according to alternating flag
-                if self.__measurement_settings.alternating:
+                if self._settings.readout_settings.alternating:
                     if len(self.measurement_data.signal_data[0]) != len(tmp_signal[::2]):
                         self.log.error('Length of controlled variable ({0}) does not match length of number of readout '
                                        'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal[::2])))
@@ -1278,7 +1345,7 @@ class PulsedMeasurementLogic(LogicBase):
 
             # emit signals
             self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
-                                      self.__execution_state.timer_interval_s)
+                                      self._settings.timer_interval_s)
             self.sigMeasurementDataUpdated.emit()
             return
 
@@ -1358,8 +1425,8 @@ class PulsedMeasurementLogic(LogicBase):
         """
         Initializing the signal, error, laser and raw data arrays.
         """
-        settings = self.__measurement_settings
-        fc_settings = self.__fast_counter_settings
+        settings = self._settings.readout_settings
+        fc_settings = self._settings.fast_counter_settings
         signal_dim = 3 if settings.alternating else 2
         self.measurement_data.signal_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
         self.measurement_data.signal_data[0] = settings.controlled_variable
@@ -1384,8 +1451,8 @@ class PulsedMeasurementLogic(LogicBase):
 
     ############################################################################
     def _get_raw_metadata(self):
-        fc = self.__fast_counter_settings
-        ms = self.__measurement_settings
+        fc = self._settings.fast_counter_settings
+        ms = self._settings.readout_settings
         return {'bin width (s)'               : fc.bin_width,
             'record length (s)'           : fc.record_length,
             'gated counting'              : fc.is_gated,
@@ -1396,14 +1463,14 @@ class PulsedMeasurementLogic(LogicBase):
             'Measurement sweeps'          : self.measurement_data.elapsed_sweeps}
 
     def _get_laser_metadata(self):
-        fc = self.__fast_counter_settings
+        fc = self._settings.fast_counter_settings
         return {'bin width (s)'        : fc.bin_width,
             'record length (s)'    : fc.record_length,
             'gated counting'       : fc.is_gated,
             'extraction parameters': self.extraction_settings}
 
     def _get_signal_metadata(self):
-        ms = self.__measurement_settings
+        ms = self._settings.readout_settings
         metadata = {'Approx. measurement time (s)': self.measurement_data.elapsed_time,
                 'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
                 'Number of laser pulses'      : ms.number_of_lasers,
@@ -1441,7 +1508,7 @@ class PulsedMeasurementLogic(LogicBase):
 
         @return list: List of column header strings
         """
-        labels, units = self.__measurement_settings.labels, self.__measurement_settings.units
+        labels, units = self._settings.readout_settings.labels, self._settings.readout_settings.units
         column_headers = [f'{labels[0]} ({units[0]})', f'{labels[1]} ({units[1]})']
         if with_error:
             column_headers.append(f'{labels[1]} ({units[1]})')
@@ -1630,7 +1697,7 @@ class PulsedMeasurementLogic(LogicBase):
         # and to cleanly access our new dataclasses.
         # ------------------------------------------------------------------------
         data = self.measurement_data
-        settings = self.__measurement_settings
+        settings = self._settings.readout_settings
         alt_type = self.alternative_data_type
 
         # scale the x_axis for plotting
@@ -1740,7 +1807,7 @@ class PulsedMeasurementLogic(LogicBase):
         return fig
 
     def _compute_alt_data(self):
-        alt = self.alternate_signal_settings
+        alt = self._settings.alternate_signal_settings
         md = self.measurement_data
         if alt.alternative_data_type == 'Delta' and len(md.signal_data) == 3:
             md.signal_alt_data = np.empty((2, md.signal_data.shape[1]), dtype=float)

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -26,6 +26,7 @@ import time
 import datetime
 import matplotlib.pyplot as plt
 
+from dataclasses import replace
 from qudi.core.connector import Connector
 from qudi.core.configoption import ConfigOption
 from qudi.core.statusvariable import StatusVar
@@ -43,6 +44,22 @@ from qudi.logic.pulsed.pulse_analyzer import PulseAnalyzer
 from qudi.interface.pulser_interface import PulserInterface
 from qudi.interface.fast_counter_interface import FastCounterInterface
 from qudi.interface.microwave_interface import MicrowaveInterface
+
+#IMPORT ALL CLASSES FROM DATA CLASS
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    AnalysisSettings,
+    DataStashCache,
+    ExecutionState,
+    ExtractionSettings,
+    AlternativeSignalSettings,
+    FitDefinition,
+    MicrowaveSettings,
+    FastCounterSettings,
+    PulsedMeasurementSettings,
+    PulsedMeasurementData,
+    _as_bool
+)
+
 
 
 def _data_storage_from_cfg_option(cfg_str):
@@ -91,20 +108,28 @@ class PulsedMeasurementLogic(LogicBase):
 
     # status variables
     # ext. microwave settings
-    __microwave_power = StatusVar(default=-30.0)
-    __microwave_freq = StatusVar(default=2870e6)
-    __use_ext_microwave = StatusVar(default=False)
+    # __microwave_power = StatusVar(default=-30.0)
+    #__microwave_freq = StatusVar(default=2870e6)
+    #__use_ext_microwave = StatusVar(default=False)
+    __microwave_settings= StatusVar(default=MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
+                                        constructor=lambda x: MicrowaveSettings.from_dict(x) if isinstance(x, dict) else MicrowaveSettings(power=-30.0, frequency=2870e6, use_ext_microwave=False),
+                                        representer=lambda obj: obj.to_dict())
 
     # fast counter settings
+    """"
     __fast_counter_record_length = StatusVar(default=3.0e-6)
     __fast_counter_binwidth = StatusVar(default=1.0e-9)
-    __fast_counter_gates = StatusVar(default=0)
+    __fast_counter_gates = StatusVar(default=0)"""
+    __fast_counter_settings=StatusVar(default=FastCounterSettings(record_length=3.0e-6,
+                                        bin_width=1.0e-9,
+                                        number_of_gates=0,
+                                        is_gated=False),
+                                       constructor=lambda x: FastCounterSettings.from_dict(x) if isinstance(x, dict) else FastCounterSettings(record_length=3.0e-6, bin_width=1.0e-9, number_of_gates=0, is_gated=False),
+                                       representer=lambda obj: obj.to_dict())
 
-    # measurement timer settings
-    __timer_interval = StatusVar(default=5)
 
     # Pulsed measurement settings
-    _invoke_settings_from_sequence = StatusVar(default=False)
+    """_invoke_settings_from_sequence = StatusVar(default=False)
     _number_of_lasers = StatusVar(default=50)
     _controlled_variable = StatusVar(default=list(range(50)),
                                      constructor=lambda x: np.array(x, dtype=float),
@@ -112,7 +137,16 @@ class PulsedMeasurementLogic(LogicBase):
     _alternating = StatusVar(default=False)
     _laser_ignore_list = StatusVar(default=list())
     _data_units = StatusVar(default=('s', ''))
-    _data_labels = StatusVar(default=('Tau', 'Signal'))
+    _data_labels = StatusVar(default=('Tau', 'Signal'))"""
+    __measurement_settings = StatusVar(default=PulsedMeasurementSettings(invoke_settings=False,
+                                                controlled_variable=np.array(list(range(50)), dtype=float),
+                                                number_of_lasers=50,
+                                                laser_ignore_list=list(),
+                                                alternating=False,
+                                                units=('s', ''),
+                                                labels=('Tau', 'Signal')),
+                        constructor=lambda x: PulsedMeasurementSettings.from_dict(x) if isinstance(x, dict) else PulsedMeasurementSettings(invoke_settings=False, controlled_variable=np.array(list(range(50)), dtype=float), number_of_lasers=50, laser_ignore_list=list(), alternating=False, units=('s', ''), labels=('Tau', 'Signal')),
+                        representer=lambda obj: obj.to_dict())
 
     # PulseExtractor settings
     extraction_parameters = StatusVar(default=None)
@@ -128,11 +162,14 @@ class PulsedMeasurementLogic(LogicBase):
     _fit_configs = StatusVar(name='fit_configs', default=None)
 
     # alternative signal computation settings:
-    _alternative_data_type = StatusVar(default=None)
+    """_alternative_data_type = StatusVar(default=None)
     zeropad = StatusVar(default=0)
     psd = StatusVar(default=False)
     window = StatusVar(default='none')
-    base_corr = StatusVar(default=True)
+    base_corr = StatusVar(default=True)"""
+    alternate_signal_settings = StatusVar(default=AlternativeSignalSettings(alternative_data_type=None),
+                                        constructor=lambda x: AlternativeSignalSettings.from_dict(x) if isinstance(x, dict) else AlternativeSignalSettings(alternative_data_type=None),
+                                        representer=lambda obj: obj.to_dict())
 
     # notification signals for master module (i.e. GUI)
     sigMeasurementDataUpdated = QtCore.Signal()
@@ -222,27 +259,38 @@ class PulsedMeasurementLogic(LogicBase):
 
         # timer for measurement
         self.__analysis_timer = None
-        self.__start_time = 0
-        self.__elapsed_time = 0
-        self.__elapsed_sweeps = 0
+        #self.__start_time = 0
+        #self.__elapsed_time = 0
+        #self.__elapsed_sweeps = 0
+        self.__execution_state = ExecutionState()
+        #ExecutionState is the dataclass containing the following data:
+        #start_time, time_of_pause, elapsed_pause, is_paused, timer_interval_s where _s represents seconds.
 
         # threading
         self._threadlock = Mutex()
 
         # measurement data
-        self.signal_data = np.empty((2, 0), dtype=float)
-        self.signal_alt_data = np.empty((2, 0), dtype=float)
-        self.measurement_error = np.empty((2, 0), dtype=float)
-        self.laser_data = np.zeros((10, 20), dtype='int64')
-        self.raw_data = np.zeros((10, 20), dtype='int64')
-
+        signal_data = np.empty((2, 0), dtype=float)
+        signal_alt_data = np.empty((2, 0), dtype=float)
+        measurement_error = np.empty((2, 0), dtype=float)
+        laser_data = np.zeros((10, 20), dtype='int64')
+        raw_data = np.zeros((10, 20), dtype='int64')
+        self.measurement_data = PulsedMeasurementData(signal_data=signal_data,
+                                                     signal_alt_data=signal_alt_data,
+                                                     measurement_error=measurement_error,
+                                                     laser_data=laser_data,
+                                                     raw_data=raw_data)
+        """
         self._saved_raw_data = dict()  # temporary saved raw data
         self._recalled_raw_data_tag = None  # the currently recalled raw data dict key
-
+        """
+        self._data_stash=DataStashCache()  # manages the memory for stashed/recalled raw data
+        
         # Paused measurement flag
-        self.__is_paused = False
+        """self.__is_paused = False
         self._time_of_pause = None
-        self._elapsed_pause = 0
+        self._elapsed_pause = 0"""
+        #Already defined up in ExecutionState, so we don't need to redefine it here.
 
         # for fit:
         self.fit_config_model = None  # Model for custom fit configurations
@@ -262,7 +310,7 @@ class PulsedMeasurementLogic(LogicBase):
         # in this logic's thread but in the manager instead.
         self.__analysis_timer = QtCore.QTimer()
         self.__analysis_timer.setSingleShot(False)
-        self.__analysis_timer.setInterval(round(1000. * self.__timer_interval))
+        self.__analysis_timer.setInterval(round(1000. * self.__execution_state.timer_interval_s))
         self.__analysis_timer.timeout.connect(self._pulsed_analysis_loop,
                                               QtCore.Qt.ConnectionType.QueuedConnection)
 
@@ -277,23 +325,25 @@ class PulsedMeasurementLogic(LogicBase):
 
         # Check and configure fast counter
         binning_constraints = self._fastcounter().get_constraints()['hardware_binwidth_list']
-        if self.__fast_counter_binwidth not in binning_constraints:
-            self.__fast_counter_binwidth = binning_constraints[0]
-        if self.__fast_counter_record_length <= 0:
-            self.__fast_counter_record_length = 3e-6
+        fixes = {}
+        if self.__fast_counter_settings.bin_width not in binning_constraints:
+            fixes['bin_width'] = binning_constraints[0]
+        if self.__fast_counter_settings.record_length <= 0:
+            fixes['record_length'] = 3e-6
+        if fixes:
+            self.__fast_counter_settings = self.__fast_counter_settings.update_from_dict(fixes)
         self.fast_counter_off()
-        # Set default number of gates to a reasonable number for gated counters (>0 if gated)
-        if self._fastcounter().is_gated() and self.__fast_counter_gates < 1:
-            self.__fast_counter_gates = max(1, self._number_of_lasers)
+        if self._fastcounter().is_gated() and self.__fast_counter_settings.number_of_gates < 1:
+            self.__fast_counter_settings = replace(
+                self.__fast_counter_settings,
+                number_of_gates=max(1, self.__measurement_settings.number_of_lasers)
+            )
         self.set_fast_counter_settings()
 
         # Check and configure external microwave
-        if self.__use_ext_microwave:
+        if self.__microwave_settings.use_ext_microwave:
             self.microwave_off()
-            self.set_microwave_settings(frequency=self.__microwave_freq,
-                                        power=self.__microwave_power,
-                                        use_ext_microwave=True)
-
+            self.set_microwave_settings(self.__microwave_settings.to_dict())
         # initialize arrays for the measurement data
         self._initialize_data_arrays()
 
@@ -341,16 +391,13 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def fast_counter_settings(self):
-        settings_dict = dict()
-        settings_dict['bin_width'] = float(self.__fast_counter_binwidth)
-        settings_dict['record_length'] = float(self.__fast_counter_record_length)
-        settings_dict['number_of_gates'] = int(self.__fast_counter_gates)
-        settings_dict['is_gated'] = bool(self._fastcounter().is_gated())
-        return settings_dict
+        return self.__fast_counter_settings.to_dict()
 
     @fast_counter_settings.setter
     def fast_counter_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
+        if isinstance(settings_dict, FastCounterSettings):
+            self.set_fast_counter_settings(settings_dict.to_dict())
+        elif isinstance(settings_dict, dict):
             self.set_fast_counter_settings(settings_dict)
         return
 
@@ -374,29 +421,32 @@ class PulsedMeasurementLogic(LogicBase):
         counter_status = self._fastcounter().get_status()
         if not counter_status >= 2 and not counter_status < 0:
             # Determine complete settings dictionary
-            if not isinstance(settings_dict, dict):
+            if isinstance(settings_dict, FastCounterSettings):
+                settings_dict = settings_dict.to_dict()
+                settings_dict.update(kwargs)
+            elif not isinstance(settings_dict, dict):
                 settings_dict = kwargs
             else:
                 settings_dict.update(kwargs)
 
-            # Set parameters if present
-            if 'bin_width' in settings_dict:
-                self.__fast_counter_binwidth = float(settings_dict['bin_width'])
-            if 'record_length' in settings_dict:
-                self.__fast_counter_record_length = float(settings_dict['record_length'])
-            if 'number_of_gates' in settings_dict:
-                if self._fastcounter().is_gated():
-                    self.__fast_counter_gates = int(settings_dict['number_of_gates'])
-                else:
-                    self.__fast_counter_gates = 0
+            # Set parameters, check if it is gated
+            if 'number_of_gates' in settings_dict and not self._fastcounter().is_gated():
+                settings_dict['number_of_gates'] = 0
+
+            self.__fast_counter_settings = self.__fast_counter_settings.update_from_dict(settings_dict)
+
 
             # Apply the settings to hardware
-            self.__fast_counter_binwidth, \
-            self.__fast_counter_record_length, \
-            self.__fast_counter_gates = self._fastcounter().configure(
-                self.__fast_counter_binwidth,
-                self.__fast_counter_record_length,
-                self.__fast_counter_gates
+            bin_width, record_length, number_of_gates = self._fastcounter().configure(
+                self.__fast_counter_settings.bin_width,
+                self.__fast_counter_settings.record_length,
+                self.__fast_counter_settings.number_of_gates
+             )
+            self.__fast_counter_settings = replace(
+                self.__fast_counter_settings,
+                bin_width=bin_width,
+                record_length=record_length,
+                number_of_gates=number_of_gates
             )
         else:
             self.log.warning('Fast counter is not idle (status: {0}).\n'
@@ -462,11 +512,11 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def elapsed_sweeps(self):
-        return self.__elapsed_sweeps
+        return self.measurement_data.elapsed_sweeps
 
     @property
     def elapsed_time(self):
-        return self.__elapsed_time
+        return self.measurement_data.elapsed_time
     ############################################################################
 
     ############################################################################
@@ -474,17 +524,16 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def ext_microwave_settings(self):
-        settings_dict = {'power': float(self.__microwave_power),
-                         'frequency': float(self.__microwave_freq),
-                         'use_ext_microwave': bool(self.__use_ext_microwave)}
-        return settings_dict
+        return self.__microwave_settings.to_dict()
 
     @ext_microwave_settings.setter
     def ext_microwave_settings(self, settings_dict):
         if isinstance(settings_dict, dict):
             self.set_microwave_settings(settings_dict)
+        elif isinstance(settings_dict, MicrowaveSettings):
+            self.set_microwave_settings(settings_dict.to_dict())
         return
-
+    
     @property
     def ext_microwave_constraints(self):
         microwave = self._microwave()
@@ -563,30 +612,28 @@ class PulsedMeasurementLogic(LogicBase):
                 self.log.warning('Microwave device is running.\nUnable to apply new settings.')
             else:
                 # Determine complete settings dictionary
-                if not isinstance(settings_dict, dict):
+                if isinstance(settings_dict, MicrowaveSettings):
+                    settings_dict = settings_dict.to_dict()
+                    settings_dict.update(kwargs)
+                elif not isinstance(settings_dict, dict):
                     settings_dict = kwargs
                 else:
                     settings_dict.update(kwargs)
 
                 # Set parameters if present
-                if 'power' in settings_dict:
-                    self.__microwave_power = float(settings_dict['power'])
-                if 'frequency' in settings_dict:
-                    self.__microwave_freq = float(settings_dict['frequency'])
-                if 'use_ext_microwave' in settings_dict:
-                    self.__use_ext_microwave = bool(settings_dict['use_ext_microwave']) and microwave is not None
-
-                if self.__use_ext_microwave and microwave is not None:
+                self.__microwave_settings = self.__microwave_settings.update_from_dict(settings_dict)
+                if self.__microwave_settings.use_ext_microwave and microwave is not None:
                     # Apply the settings to hardware
-                    microwave.set_cw(frequency=self.__microwave_freq, power=self.__microwave_power)
-                    self.__microwave_freq = microwave.cw_frequency
-                    self.__microwave_power = microwave.cw_power
+                    microwave.set_cw(frequency=self.__microwave_settings.frequency, power=self.__microwave_settings.power)
+                    self.__microwave_settings = replace(
+                    self.__microwave_settings,
+                    frequency=microwave.cw_frequency,
+                    power=microwave.cw_power)
+                
         finally:
             # emit update signal for master (GUI or other logic module)
-            self.sigExtMicrowaveSettingsUpdated.emit({'power': self.__microwave_power,
-                                                      'frequency': self.__microwave_freq,
-                                                      'use_ext_microwave': self.__use_ext_microwave})
-        return self.__microwave_freq, self.__microwave_power, self.__use_ext_microwave
+            self.sigExtMicrowaveSettingsUpdated.emit(self.ext_microwave_settings)
+        return self.ext_microwave_settings
     ############################################################################
 
     ############################################################################
@@ -639,20 +686,13 @@ class PulsedMeasurementLogic(LogicBase):
     ############################################################################
     @property
     def measurement_settings(self):
-        settings_dict = dict()
-        settings_dict['invoke_settings'] = bool(self._invoke_settings_from_sequence)
-        settings_dict['controlled_variable'] = np.array(self._controlled_variable,
-                                                        dtype=float).copy()
-        settings_dict['number_of_lasers'] = int(self._number_of_lasers)
-        settings_dict['laser_ignore_list'] = list(self._laser_ignore_list).copy()
-        settings_dict['alternating'] = bool(self._alternating)
-        settings_dict['units'] = self._data_units
-        settings_dict['labels'] = self._data_labels
-        return settings_dict
+        return self.__measurement_settings.to_dict()
 
     @measurement_settings.setter
     def measurement_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
+        if isinstance(settings_dict, PulsedMeasurementSettings):
+            self.set_measurement_settings(settings_dict.to_dict())
+        elif isinstance(settings_dict, dict):
             self.set_measurement_settings(settings_dict)
         return
 
@@ -678,7 +718,7 @@ class PulsedMeasurementLogic(LogicBase):
         self._measurement_information = info_dict.copy()
 
         # invoke settings if needed
-        if self._invoke_settings_from_sequence and self._measurement_information:
+        if self.__measurement_settings.invoke_settings and self._measurement_information:
             self._apply_invoked_settings()
             self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return
@@ -709,7 +749,7 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def timer_interval(self):
-        return float(self.__timer_interval)
+        return float(self.__execution_state.timer_interval_s)
 
     @timer_interval.setter
     def timer_interval(self, value):
@@ -719,7 +759,7 @@ class PulsedMeasurementLogic(LogicBase):
 
     @property
     def alternative_data_type(self):
-        return str(self._alternative_data_type)
+        return str(self.alternate_signal_settings.alternative_data_type)
 
     @alternative_data_type.setter
     def alternative_data_type(self, alt_data_type):
@@ -824,46 +864,41 @@ class PulsedMeasurementLogic(LogicBase):
         @return:
         """
         # Determine complete settings dictionary
-        if not isinstance(settings_dict, dict):
+        if isinstance(settings_dict, PulsedMeasurementSettings):
+            settings_dict = settings_dict.to_dict()
+            settings_dict.update(kwargs)
+        elif not isinstance(settings_dict, dict):
             settings_dict = kwargs
         else:
             settings_dict.update(kwargs)
 
-        # Check if invoke_settings flag has changed
+        # invoke_settings flag can change regardless of module state
         if 'invoke_settings' in settings_dict:
-            self._invoke_settings_from_sequence = bool(settings_dict.get('invoke_settings'))
-
-        # Invoke settings if measurement_information is present and flag is set
-        if self._invoke_settings_from_sequence:
+            self.__measurement_settings = replace(
+                self.__measurement_settings,
+                invoke_settings=_as_bool(settings_dict['invoke_settings'])
+            )
+        if self.__measurement_settings.invoke_settings:
             if self._measurement_information:
                 self._apply_invoked_settings()
         else:
-            # Apply settings that can be changed while a measurement is running
+            # units/labels can change while a measurement is running
             with self._threadlock:
+                units_labels = {}
                 if 'units' in settings_dict:
-                    self._data_units = settings_dict.get('units')
-                    # self.fc.set_units(self._data_units)
+                    units_labels['units'] = settings_dict['units']
                 if 'labels' in settings_dict:
-                    self._data_labels = list(settings_dict.get('labels'))
-
+                    units_labels['labels'] = settings_dict['labels']
+                if units_labels:
+                    self.__measurement_settings = self.__measurement_settings.update_from_dict(units_labels)
             if self.module_state() == 'idle':
-                # Get all other parameters if present
-                if 'controlled_variable' in settings_dict:
-                    self._controlled_variable = np.array(settings_dict.get('controlled_variable'),
-                                                         dtype=float)
-                if 'number_of_lasers' in settings_dict:
-                    self._number_of_lasers = int(settings_dict.get('number_of_lasers'))
-                    if self._fastcounter().is_gated():
-                        self.set_fast_counter_settings(number_of_gates=self._number_of_lasers)
-                if 'laser_ignore_list' in settings_dict:
-                    self._laser_ignore_list = sorted(settings_dict.get('laser_ignore_list'))
-                if 'alternating' in settings_dict:
-                    self._alternating = bool(settings_dict.get('alternating'))
-
-        # Perform sanity checks on settings
+                idle_only_keys = ('controlled_variable', 'number_of_lasers', 'laser_ignore_list', 'alternating')
+                idle_updates = {k: settings_dict[k] for k in idle_only_keys if k in settings_dict}
+                if idle_updates:
+                    self.__measurement_settings = self.__measurement_settings.update_from_dict(idle_updates)
+                if 'number_of_lasers' in idle_updates and self._fastcounter().is_gated():
+                    self.set_fast_counter_settings(number_of_gates=self.__measurement_settings.number_of_lasers)
         self._measurement_settings_sanity_check()
-
-        # emit update signal for master (GUI or other logic module)
         self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
         return self.measurement_settings
 
@@ -886,7 +921,7 @@ class PulsedMeasurementLogic(LogicBase):
         self.sigMeasurementStatusUpdated.emit(True, False)
 
         # Check if measurement settings need to be invoked
-        if self._invoke_settings_from_sequence:
+        if self.__measurement_settings.invoke_settings:
             if self._measurement_information:
                 self._apply_invoked_settings()
                 self.sigMeasurementSettingsUpdated.emit(self.measurement_settings)
@@ -912,34 +947,29 @@ class PulsedMeasurementLogic(LogicBase):
                 self._initialize_data_arrays()
 
                 # recall stashed raw data
-                if stashed_raw_data_tag in self._saved_raw_data:
-                    self._recalled_raw_data_tag = stashed_raw_data_tag
-                    self.log.info('Starting pulsed measurement with stashed raw data "{0}".'
-                                  ''.format(stashed_raw_data_tag))
-                else:
-                    self._recalled_raw_data_tag = None
+                if self._data_stash.recall(stashed_raw_data_tag) is not None:
+                     self.log.info('Starting pulsed measurement with stashed raw data "{0}".'
+                                     ''.format(stashed_raw_data_tag))
+                #On a miss, the recall method will return None,
+                #the log message will not be printed, and the active_tag is cleared internally
 
                 # start microwave source
-                if self.__use_ext_microwave:
+                if self.__microwave_settings.use_ext_microwave:
                     self.microwave_on()
                 # start fast counter
                 self.fast_counter_on()
                 # start pulse generator
                 self.pulse_generator_on()
 
+                # start the time and set the paused state to false
+                self.__execution_state.start()
+
                 # initialize analysis_timer
-                self.__elapsed_time = 0.0
-                self._elapsed_pause = 0
-                self.sigTimerUpdated.emit(self.__elapsed_time,
-                                          self.__elapsed_sweeps,
-                                          self.__timer_interval)
+                self.sigTimerUpdated.emit(self.measurement_data.elapsed_time,
+                                          self.measurement_data.elapsed_sweeps,
+                                          self.__execution_state.timer_interval_s)
 
-                # Set starting time and start timer (if present)
-                self.__start_time = time.time()
                 self.sigStartTimer.emit()
-
-                # Set measurement paused flag
-                self.__is_paused = False
             else:
                 self.log.warning('Unable to start pulsed measurement. Measurement already running.')
         return
@@ -964,18 +994,17 @@ class PulsedMeasurementLogic(LogicBase):
                 # Turn off pulse generator
                 self.pulse_generator_off()
                 # Turn off microwave source
-                if self.__use_ext_microwave:
+                if self.__microwave_settings.use_ext_microwave:
                     self.microwave_off()
 
                 # stash raw data if requested
                 if stash_raw_data_tag:
-                    self._saved_raw_data[stash_raw_data_tag] = (self.raw_data.copy(),
-                                                                {'elapsed_sweeps': self.__elapsed_sweeps,
-                                                                 'elapsed_time': self.__elapsed_time})
-                self._recalled_raw_data_tag = None
+                          self._data_stash.stash(stash_raw_data_tag, self.measurement_data.raw_data,
+                                                 self.measurement_data.elapsed_sweeps, self.measurement_data.elapsed_time)
+                self._data_stash.clear_active()
 
                 # Set measurement paused flag
-                self.__is_paused = False
+                self.__execution_state.is_paused = False
 
                 self.module_state.unlock()
                 self.sigMeasurementStatusUpdated.emit(False, False)
@@ -1008,12 +1037,11 @@ class PulsedMeasurementLogic(LogicBase):
 
                 self.fast_counter_pause()
                 self.pulse_generator_off()
-                if self.__use_ext_microwave:
+                if self.__microwave_settings.use_ext_microwave:
                     self.microwave_off()
 
                 # Set measurement paused flag
-                self.__is_paused = True
-                self._time_of_pause = time.time()
+                self.__execution_state.pause()
 
                 self.sigMeasurementStatusUpdated.emit(True, True)
             else:
@@ -1028,7 +1056,7 @@ class PulsedMeasurementLogic(LogicBase):
         """
         with self._threadlock:
             if self.module_state() == 'locked':
-                if self.__use_ext_microwave:
+                if self.__microwave_settings.use_ext_microwave:
                     self.microwave_on()
                 self.fast_counter_continue()
                 self.pulse_generator_on()
@@ -1038,8 +1066,7 @@ class PulsedMeasurementLogic(LogicBase):
                     self.sigStartTimer.emit()
 
                 # Set measurement paused flag
-                self.__is_paused = False
-                self.__start_time += time.time() - self._time_of_pause
+                self.__execution_state.unpause()
 
                 self.sigMeasurementStatusUpdated.emit(True, False)
             else:
@@ -1056,16 +1083,16 @@ class PulsedMeasurementLogic(LogicBase):
         @param int|float interval: Interval of the timer in s
         """
         with self._threadlock:
-            self.__timer_interval = interval
-            if self.__timer_interval > 0:
-                self.__analysis_timer.setInterval(int(1000. * self.__timer_interval))
-                if self.module_state() == 'locked' and not self.__is_paused:
+            self.__execution_state.timer_interval_s = interval
+            if self.__execution_state.timer_interval_s > 0:
+                self.__analysis_timer.setInterval(int(1000. * self.__execution_state.timer_interval_s))
+                if self.module_state() == 'locked' and not self.__execution_state.is_paused:
                     self.sigStartTimer.emit()
             else:
                 self.sigStopTimer.emit()
 
-            self.sigTimerUpdated.emit(self.__elapsed_time, self.__elapsed_sweeps,
-                                      self.__timer_interval)
+            self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
+                                      self.__execution_state.timer_interval_s)
         return
 
     @QtCore.Slot(str)
@@ -1076,18 +1103,18 @@ class PulsedMeasurementLogic(LogicBase):
         @return:
         """
         with self._threadlock:
-            if alt_data_type != self.alternative_data_type:
+            if alt_data_type != self.alternate_signal_settings.alternative_data_type:
                 self.do_fit('No Fit', True)
-            if alt_data_type == 'Delta' and not self._alternating:
-                if self._alternative_data_type == 'Delta':
-                    self._alternative_data_type = None
+            if alt_data_type == 'Delta' and not self.__measurement_settings.alternating:
+                if self.alternate_signal_settings.alternative_data_type == 'Delta':
+                    self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=None)
                 self.log.error('Can not set "Delta" as alternative data calculation if measurement is '
-                               'not alternating.\n'
-                               'Setting to previous type "{0}".'.format(self.alternative_data_type))
+                           'not alternating.\n'
+                           'Setting to previous type "{0}".'.format(self.alternate_signal_settings.alternative_data_type))
             elif alt_data_type == 'None':
-                self._alternative_data_type = None
+                self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=None)
             else:
-                self._alternative_data_type = alt_data_type
+                self.alternate_signal_settings = replace(self.alternate_signal_settings, alternative_data_type=alt_data_type)
 
             self._compute_alt_data()
             self.sigMeasurementDataUpdated.emit()
@@ -1115,7 +1142,7 @@ class PulsedMeasurementLogic(LogicBase):
         @return result_object: the lmfit result object
         """
         container = self.alt_fc if use_alternative_data else self.fc
-        data = self.signal_alt_data if use_alternative_data else self.signal_data
+        data = self.measurement_data.signal_alt_data if use_alternative_data else self.measurement_data.signal_data
         try:
             config, result = container.fit_data(fit_config, data[0], data[1])
             if result:
@@ -1133,88 +1160,65 @@ class PulsedMeasurementLogic(LogicBase):
         return result
 
     def _apply_invoked_settings(self):
-        """
-        """
         if not isinstance(self._measurement_information, dict) or not self._measurement_information:
             self.log.warning('Can\'t invoke measurement settings from sequence information '
-                             'since no measurement_information container is given.')
+                         'since no measurement_information container is given.')
             return
 
         # First try to set parameters that can be changed during a running measurement
+        units_labels = {}
         if 'units' in self._measurement_information:
-            with self._threadlock:
-                self._data_units = self._measurement_information.get('units')
-                # self.fc.set_units(self._data_units)
+            units_labels['units'] = self._measurement_information.get('units')
         if 'labels' in self._measurement_information:
+            units_labels['labels'] = self._measurement_information.get('labels')
+        if units_labels:
             with self._threadlock:
-                self._data_labels = list(self._measurement_information.get('labels'))
+                self.__measurement_settings = self.__measurement_settings.update_from_dict(units_labels)
 
-        # Check if a measurement is running and apply following settings if this is not the case
         if self.module_state() == 'locked':
             return
 
-        if 'number_of_lasers' in self._measurement_information:
-            self._number_of_lasers = int(self._measurement_information.get('number_of_lasers'))
-        else:
-            self.log.error('Unable to invoke setting for "number_of_lasers".\n'
+        required = ('number_of_lasers', 'laser_ignore_list', 'alternating', 'controlled_variable', 'counting_length')
+        for key in required:
+            if key not in self._measurement_information:
+                self.log.error(f'Unable to invoke setting for "{key}".\n'
                            'Measurement information container is incomplete/invalid.')
-            return
+                return
 
-        if 'laser_ignore_list' in self._measurement_information:
-            self._laser_ignore_list = sorted(self._measurement_information.get('laser_ignore_list'))
-        else:
-            self.log.error('Unable to invoke setting for "laser_ignore_list".\n'
-                           'Measurement information container is incomplete/invalid.')
-            return
+        self.__measurement_settings = self.__measurement_settings.update_from_dict({
+            'number_of_lasers': int(self._measurement_information['number_of_lasers']),
+            'laser_ignore_list': sorted(self._measurement_information['laser_ignore_list']),
+            'alternating': bool(self._measurement_information['alternating']),
+            'controlled_variable': self._measurement_information['controlled_variable'],
+        })
 
-        if 'alternating' in self._measurement_information:
-            self._alternating = bool(self._measurement_information.get('alternating'))
-        else:
-            self.log.error('Unable to invoke setting for "alternating".\n'
-                           'Measurement information container is incomplete/invalid.')
-            return
-
-        if 'controlled_variable' in self._measurement_information:
-            self._controlled_variable = np.array(
-                self._measurement_information.get('controlled_variable'), dtype=float)
-        else:
-            self.log.error('Unable to invoke setting for "controlled_variable".\n'
-                           'Measurement information container is incomplete/invalid.')
-            return
-
-        if 'counting_length' in self._measurement_information:
-            fast_counter_record_length = self._measurement_information.get('counting_length')
-        else:
-            self.log.error('Unable to invoke setting for "counting_length".\n'
-                           'Measurement information container is incomplete/invalid.')
-            return
-
+        fast_counter_record_length = self._measurement_information['counting_length']
         if self._fastcounter().is_gated():
-            self.set_fast_counter_settings(number_of_gates=self._number_of_lasers,
-                                           record_length=fast_counter_record_length)
+            self.set_fast_counter_settings(number_of_gates=self.__measurement_settings.number_of_lasers,
+                                       record_length=fast_counter_record_length)
         else:
             self.set_fast_counter_settings(record_length=fast_counter_record_length)
         return
 
     def _measurement_settings_sanity_check(self):
-        number_of_analyzed_lasers = self._number_of_lasers - len(self._laser_ignore_list)
-        if len(self._controlled_variable) < 1:
+        settings = self.__measurement_settings
+        number_of_analyzed_lasers = settings.number_of_lasers - len(settings.laser_ignore_list)
+        if len(settings.controlled_variable) < 1:
             self.log.error('Tried to set empty controlled variables array. This can not work.')
 
-        if self._alternating and (number_of_analyzed_lasers // 2) != len(self._controlled_variable):
+        if settings.alternating and (number_of_analyzed_lasers // 2) != len(settings.controlled_variable):
             self.log.error('Half of the number of laser pulses to analyze ({0}) does not match the '
-                           'number of controlled_variable ticks ({1:d}).'
-                           ''.format(number_of_analyzed_lasers // 2,
-                                     len(self._controlled_variable)))
-        elif not self._alternating and number_of_analyzed_lasers != len(self._controlled_variable):
+                       'number of controlled_variable ticks ({1:d}).'
+                       ''.format(number_of_analyzed_lasers // 2, len(settings.controlled_variable)))
+        elif not settings.alternating and number_of_analyzed_lasers != len(settings.controlled_variable):
             self.log.error('Number of laser pulses to analyze ({0:d}) does not match the number of '
-                           'controlled_variable ticks ({1:d}).'
-                           ''.format(number_of_analyzed_lasers, len(self._controlled_variable)))
+                       'controlled_variable ticks ({1:d}).'
+                       ''.format(number_of_analyzed_lasers, len(settings.controlled_variable)))
 
-        if self._fastcounter().is_gated() and self._number_of_lasers != self.__fast_counter_gates:
+        if self._fastcounter().is_gated() and settings.number_of_lasers != self.__fast_counter_settings.number_of_gates:
             self.log.error('Gated fast counter gate number ({0:d}) differs from number of laser pulses ({1:d})'
-                           'configured in measurement settings.'.format(self._number_of_lasers,
-                                                                        self.__fast_counter_gates))
+                       'configured in measurement settings.'.format(settings.number_of_lasers,
+                                                                    self.__fast_counter_settings.number_of_gates))
         return
 
     @QtCore.Slot()
@@ -1231,64 +1235,61 @@ class PulsedMeasurementLogic(LogicBase):
                 tmp_signal, tmp_error = self._analyze_laser_pulses()
 
                 # exclude laser pulses to ignore
-                if len(self._laser_ignore_list) > 0:
-                    # Convert relative negative indices into absolute positive indices
-                    while self._laser_ignore_list[0] < 0:
-                        neg_index = self._laser_ignore_list[0]
-                        self._laser_ignore_list[0] = len(tmp_signal) + neg_index
-                        self._laser_ignore_list.sort()
-
-                    tmp_signal = np.delete(tmp_signal, self._laser_ignore_list)
-                    tmp_error = np.delete(tmp_error, self._laser_ignore_list)
+                ignore_list = list(self.__measurement_settings.laser_ignore_list)
+                if ignore_list:
+                    ignore_list = sorted(idx if idx >= 0 else len(tmp_signal) + idx for idx in ignore_list)
+                    tmp_signal = np.delete(tmp_signal, ignore_list)
+                    tmp_error = np.delete(tmp_error, ignore_list)
+                    
 
                 # order data according to alternating flag
-                if self._alternating:
-                    if len(self.signal_data[0]) != len(tmp_signal[::2]):
+                if self.__measurement_settings.alternating:
+                    if len(self.measurement_data.signal_data[0]) != len(tmp_signal[::2]):
                         self.log.error('Length of controlled variable ({0}) does not match length of number of readout '
-                                       'pulses ({1}).'.format(len(self.signal_data[0]), len(tmp_signal[::2])))
+                                       'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal[::2])))
                         return
-                    self.signal_data[1] = tmp_signal[::2]
-                    self.signal_data[2] = tmp_signal[1::2]
-                    self.measurement_error[1] = tmp_error[::2]
-                    self.measurement_error[2] = tmp_error[1::2]
+                    self.measurement_data.signal_data[1] = tmp_signal[::2]
+                    self.measurement_data.signal_data[2] = tmp_signal[1::2]
+                    self.measurement_data.measurement_error[1] = tmp_error[::2]
+                    self.measurement_data.measurement_error[2] = tmp_error[1::2]
                 else:
-                    if len(self.signal_data[0]) != len(tmp_signal):
+                    if len(self.measurement_data.signal_data[0]) != len(tmp_signal):
                         self.log.error('Length of controlled variable ({0}) does not match length of number of readout '
-                                       'pulses ({1}).'.format(len(self.signal_data[0]), len(tmp_signal)))
+                                       'pulses ({1}).'.format(len(self.measurement_data.signal_data[0]), len(tmp_signal)))
                         return
-                    self.signal_data[1] = tmp_signal
-                    self.measurement_error[1] = tmp_error
+                    self.measurement_data.signal_data[1] = tmp_signal
+                    self.measurement_data.measurement_error[1] = tmp_error
 
                 # Compute alternative data array from signal
                 self._compute_alt_data()
 
             # emit signals
-            self.sigTimerUpdated.emit(self.__elapsed_time, self.__elapsed_sweeps,
-                                      self.__timer_interval)
+            self.sigTimerUpdated.emit(self.measurement_data.elapsed_time, self.measurement_data.elapsed_sweeps,
+                                      self.__execution_state.timer_interval_s)
             self.sigMeasurementDataUpdated.emit()
             return
 
     def _extract_laser_pulses(self):
         # Get counter raw data (including recalled raw data from previous measurement)
         fc_data, info_dict = self._get_raw_data()
-        self.raw_data = fc_data
-        self.__elapsed_sweeps = info_dict['elapsed_sweeps']
-        self.__elapsed_time = info_dict['elapsed_time']
+        self.measurement_data.raw_data = fc_data
+        self.measurement_data.elapsed_sweeps = info_dict['elapsed_sweeps']
+        self.measurement_data.elapsed_time = info_dict['elapsed_time']
 
         # extract laser pulses from raw data
-        return_dict = self._pulseextractor.extract_laser_pulses(self.raw_data)
-        self.laser_data = return_dict['laser_counts_arr']
+        return_dict = self._pulseextractor.extract_laser_pulses(self.measurement_data.raw_data)
+        self.measurement_data.laser_data = return_dict['laser_counts_arr']
         return
 
     def _analyze_laser_pulses(self):
         # analyze pulses and get data points for signal array. Also check if extraction
         # worked (non-zero array returned).
-        if self.laser_data.any():
+        if self.measurement_data.laser_data.any():
             tmp_signal, tmp_error = self._pulseanalyzer.analyse_laser_pulses(
-                self.laser_data)
+                self.measurement_data.laser_data)
         else:
-            tmp_signal = np.zeros(self.laser_data.shape[0])
-            tmp_error = np.zeros(self.laser_data.shape[0])
+            tmp_signal = np.zeros(self.measurement_data.laser_data.shape[0])
+            tmp_error = np.zeros(self.measurement_data.laser_data.shape[0])
         return tmp_signal, tmp_error
 
     def _get_raw_data(self):
@@ -1314,21 +1315,22 @@ class PulsedMeasurementLogic(LogicBase):
         if isinstance(info_dict, dict) and info_dict.get('elapsed_time') is not None:
             elapsed_time = info_dict['elapsed_time']
         else:
-            elapsed_time = time.time() - self.__start_time
+            elapsed_time = self.__execution_state.get_live_elapsed_time()
 
         # add old raw data from previous measurements if necessary
-        if self._saved_raw_data.get(self._recalled_raw_data_tag) is not None:
+        stashed_data = self._data_stash.get_active()
+        if stashed_data is not None:
             # self.log.info('Found old saved raw data with tag "{0}".'
             #               ''.format(self._recalled_raw_data_tag))
-            elapsed_sweeps += self._saved_raw_data[self._recalled_raw_data_tag][1]['elapsed_sweeps']
-            elapsed_time += self._saved_raw_data[self._recalled_raw_data_tag][1]['elapsed_time']
+            elapsed_sweeps += stashed_data['elapsed_sweeps']
+            elapsed_time += stashed_data['elapsed_time']
             if not fc_data.any():
                 self.log.warning('Only zeros received from fast counter!\n'
                                  'Using recalled raw data only.')
-                fc_data = self._saved_raw_data[self._recalled_raw_data_tag][0]
-            elif self._saved_raw_data[self._recalled_raw_data_tag][0].shape == fc_data.shape:
+                fc_data = stashed_data['data']
+            elif stashed_data['data'].shape == fc_data.shape:
                 self.log.debug('Recalled raw data has the same shape as current data.')
-                fc_data = self._saved_raw_data[self._recalled_raw_data_tag][0] + fc_data
+                fc_data = stashed_data['data'] + fc_data
             else:
                 self.log.warning('Recalled raw data has not the same shape as current data.'
                                  '\nDid NOT add recalled raw data to current time trace.')
@@ -1342,67 +1344,67 @@ class PulsedMeasurementLogic(LogicBase):
         """
         Initializing the signal, error, laser and raw data arrays.
         """
-        # Determine signal array dimensions
-        signal_dim = 3 if self._alternating else 2
+        settings = self.__measurement_settings
+        fc_settings = self.__fast_counter_settings
+        signal_dim = 3 if settings.alternating else 2
+        self.measurement_data.signal_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        self.measurement_data.signal_data[0] = settings.controlled_variable
 
-        self.signal_data = np.zeros((signal_dim, len(self._controlled_variable)), dtype=float)
-        self.signal_data[0] = self._controlled_variable
+        self.measurement_data.signal_alt_data = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        self.measurement_data.signal_alt_data[0] = settings.controlled_variable
 
-        self.signal_alt_data = np.zeros((signal_dim, len(self._controlled_variable)), dtype=float)
-        self.signal_alt_data[0] = self._controlled_variable
+        self.measurement_data.measurement_error = np.zeros((signal_dim, len(settings.controlled_variable)), dtype=float)
+        self.measurement_data.measurement_error[0] = settings.controlled_variable
 
-        self.measurement_error = np.zeros((signal_dim, len(self._controlled_variable)), dtype=float)
-        self.measurement_error[0] = self._controlled_variable
+        number_of_bins = int(fc_settings.record_length / fc_settings.bin_width)
+        laser_length = number_of_bins if fc_settings.number_of_gates > 0 else 500
+        self.measurement_data.laser_data = np.zeros((settings.number_of_lasers, laser_length), dtype='int64')
 
-        number_of_bins = int(self.__fast_counter_record_length / self.__fast_counter_binwidth)
-        laser_length = number_of_bins if self.__fast_counter_gates > 0 else 500
-        self.laser_data = np.zeros((self._number_of_lasers, laser_length), dtype='int64')
-
-        if self.__fast_counter_gates > 0:
-            self.raw_data = np.zeros((self._number_of_lasers, number_of_bins), dtype='int64')
+        if fc_settings.number_of_gates > 0:
+            self.measurement_data.raw_data = np.zeros((settings.number_of_lasers, number_of_bins), dtype='int64')
         else:
-            self.raw_data = np.zeros(number_of_bins, dtype='int64')
+            self.measurement_data.raw_data = np.zeros(number_of_bins, dtype='int64')
 
         self.sigMeasurementDataUpdated.emit()
         return
 
     ############################################################################
     def _get_raw_metadata(self):
-        return {'bin width (s)'               : self.__fast_counter_binwidth,
-                'record length (s)'           : self.__fast_counter_record_length,
-                'gated counting'              : self.fast_counter_settings['is_gated'],
-                'Number of laser pulses'      : self._number_of_lasers,
-                'alternating'                 : self._alternating,
-                'Controlled variable'         : list(self.signal_data[0]),
-                'Approx. measurement time (s)': self.__elapsed_time,
-                'Measurement sweeps'          : self.__elapsed_sweeps}
+        fc = self.__fast_counter_settings
+        ms = self.__measurement_settings
+        return {'bin width (s)'               : fc.bin_width,
+            'record length (s)'           : fc.record_length,
+            'gated counting'              : fc.is_gated,
+            'Number of laser pulses'      : ms.number_of_lasers,
+            'alternating'                 : ms.alternating,
+            'Controlled variable'         : list(self.measurement_data.signal_data[0]),
+            'Approx. measurement time (s)': self.measurement_data.elapsed_time,
+            'Measurement sweeps'          : self.measurement_data.elapsed_sweeps}
 
     def _get_laser_metadata(self):
-        return {'bin width (s)'        : self.__fast_counter_binwidth,
-                'record length (s)'    : self.__fast_counter_record_length,
-                'gated counting'       : self.fast_counter_settings['is_gated'],
-                'extraction parameters': self.extraction_settings}
+        fc = self.__fast_counter_settings
+        return {'bin width (s)'        : fc.bin_width,
+            'record length (s)'    : fc.record_length,
+            'gated counting'       : fc.is_gated,
+            'extraction parameters': self.extraction_settings}
 
     def _get_signal_metadata(self):
-        metadata = {'Approx. measurement time (s)': self.__elapsed_time,
-                    'Measurement sweeps'          : self.__elapsed_sweeps,
-                    'Number of laser pulses'      : self._number_of_lasers,
-                    'Laser ignore indices'        : self._laser_ignore_list,
-                    'alternating'                 : self._alternating,
-                    'analysis parameters'         : self.analysis_settings,
-                    'extraction parameters'       : self.extraction_settings,
-                    'fast counter settings'       : self.fast_counter_settings,
-                    # todo: save sequence belonging to signal, not last uploaded one
-                    'generation parameters'       : self.sampling_information.get('generation_parameters'),
-                    'generation method parameters': self.generation_method_parameters}
+        ms = self.__measurement_settings
+        metadata = {'Approx. measurement time (s)': self.measurement_data.elapsed_time,
+                'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
+                'Number of laser pulses'      : ms.number_of_lasers,
+                'Laser ignore indices'        : list(ms.laser_ignore_list),
+                'alternating'                 : ms.alternating,
+                'analysis parameters'         : self.analysis_settings,
+                'extraction parameters'       : self.extraction_settings,
+                'fast counter settings'       : self.fast_counter_settings,
+                'generation parameters'       : self.sampling_information.get('generation_parameters'),
+                'generation method parameters': self.generation_method_parameters}
         if self._fit_result:
-            export_dict = FitContainer.dict_result(self._fit_result)
-            metadata['fit result'] = export_dict
+            metadata['fit result'] = FitContainer.dict_result(self._fit_result)
         if self._fit_result_alt:
-            export_dict = FitContainer.dict_result(self._fit_result_alt)
-            metadata['fit result alt'] = export_dict
+            metadata['fit result alt'] = FitContainer.dict_result(self._fit_result_alt)
         return metadata
-
     @staticmethod
     def _get_patched_filename_nametag(file_name=None, nametag=None, suffix_str=''):
         """ Helper method to return either a full file name or a nametag to be used as arguments in
@@ -1425,10 +1427,10 @@ class PulsedMeasurementLogic(LogicBase):
 
         @return list: List of column header strings
         """
-        column_headers = [f'{self._data_labels[0]} ({self._data_units[0]})',
-                          f'{self._data_labels[1]} ({self._data_units[1]})']
+        labels, units = self.__measurement_settings.labels, self.__measurement_settings.units
+        column_headers = [f'{labels[0]} ({units[0]})', f'{labels[1]} ({units[1]})']
         if with_error:
-            column_headers.append(f'{self._data_labels[1]} ({self._data_units[1]})')
+            column_headers.append(f'{labels[1]} ({units[1]})')
         return column_headers
 
     def save_measurement_data(self, tag=None, notes=None, file_path=None, storage_cls=None,
@@ -1478,7 +1480,7 @@ class PulsedMeasurementLogic(LogicBase):
                                                                     '_raw_timetrace')
         # Save data to file
         data_storage.save_data(
-            self.raw_data.astype('int64')[:, np.newaxis] if self.raw_data.ndim == 1 else self.raw_data.astype('int64'),
+            self.measurement_data.raw_data.astype('int64')[:, np.newaxis] if self.measurement_data.raw_data.ndim == 1 else self.measurement_data.raw_data.astype('int64'),
             metadata=self._get_raw_metadata(),
             nametag=nametag,
             filename=save_filename,
@@ -1494,7 +1496,7 @@ class PulsedMeasurementLogic(LogicBase):
             save_filename, nametag = self._get_patched_filename_nametag(file_name,
                                                                         tag,
                                                                         '_laser_pulses')
-            data_storage.save_data(self.laser_data,
+            data_storage.save_data(self.measurement_data.laser_data,
                                    metadata=self._get_laser_metadata(),
                                    nametag=nametag,
                                    filename=save_filename,
@@ -1512,9 +1514,9 @@ class PulsedMeasurementLogic(LogicBase):
 
             # Format data to save
             if with_error:
-                data = np.vstack((self.signal_data, self.measurement_error[1:])).transpose()
+                data = np.vstack((self.measurement_data.signal_data, self.measurement_data.measurement_error[1:])).transpose()
             else:
-                data = self.signal_data.transpose()
+                data = self.measurement_data.signal_data.transpose()
 
             save_path, _, _ = data_storage.save_data(
                 data,
@@ -1535,7 +1537,6 @@ class PulsedMeasurementLogic(LogicBase):
     def _plot_pulsed_thumbnail(self, with_error=False):
 
         def _plot_fit(axis, use_alternative_data=False):
-
             fit_res = self._fit_result
             if use_alternative_data:
                 fit_res = self._fit_result_alt
@@ -1544,37 +1545,27 @@ class PulsedMeasurementLogic(LogicBase):
 
             label = 'fit'
             if use_alternative_data:
-                label = label='secondary fit'
+                label = 'secondary fit'
 
             x_axis_fit_scaled = fit_x / scaled_float.scale_val
             axis.plot(x_axis_fit_scaled, fit_y,
                      color=colors[2], marker='None', linewidth=1.5,
                      label=label)
 
-            # add then the fit result to the plot:
-
             # Parameters for the text plot:
-            # The position of the text annotation is controlled with the
-            # relative offset in x direction and the relative length factor
-            # rel_len_fac of the longest entry in one column
             rel_offset = 0.02
             rel_len_fac = 0.011
             entries_per_col = 24
 
             result_str = fit_res.result_str
-
-            # do reverse processing to get each entry in a list
             entry_list = result_str.split('\n')
-            # slice the entry_list in entries_per_col
             chunks = [entry_list[x:x + entries_per_col] for x in range(0, len(entry_list), entries_per_col)]
 
             is_first_column = True  # first entry should contain header or \n
 
             for column in chunks:
-
                 max_length = max(column, key=len)  # get the longest entry
                 column_text = ''
-
                 for entry in column:
                     column_text += entry + '\n'
 
@@ -1592,16 +1583,11 @@ class PulsedMeasurementLogic(LogicBase):
                          transform=axis.transAxes,
                          fontsize=12)
 
-                # the rel_offset in position of the text is a linear function
-                # which depends on the longest entry in the column
                 rel_offset += rel_len_fac * len(max_length)
-
                 is_first_column = False
 
         def _is_fit_available(use_alternative_data=False):
-
             fit = self._fit_result if not use_alternative_data else self._fit_result_alt
-
             if not fit:
                 return False
             else:
@@ -1612,57 +1598,58 @@ class PulsedMeasurementLogic(LogicBase):
                 self.log.warning("Latex character '$' in string; expect wrong text rendering."
                                  " Please use rich text html instead.")
             else:
-                # transform to math expression, use non-italic font
                 text_str = r"$\mathrm{" + text_str + "}$"
 
-            # handle subscript
             text_str = text_str.replace("<sub>","_{").replace("</sub>","}")
-            # handle white space
-            text_str = text_str.replace(" ", "\ ")
-
+            text_str = text_str.replace(" ", r"\ ")
             return text_str
 
         # Prepare the figure to save as a "data thumbnail"
         plt.style.use(QudiMatplotlibStyle.style)
 
         # extract the possible colors from the colorscheme:
-        # todo: still needed or set by core?
         prop_cycle = QudiMatplotlibStyle.style['axes.prop_cycle']
-        colors = {}
-        for i, color_setting in enumerate(prop_cycle):
-            colors[i] = color_setting['color']
+        colors = {i: color_setting['color'] for i, color_setting in enumerate(prop_cycle)}
+
+        # ------------------------------------------------------------------------
+        # OPTIMIZATION: Grab local references to avoid making RAM-heavy copies
+        # and to cleanly access our new dataclasses.
+        # ------------------------------------------------------------------------
+        data = self.measurement_data
+        settings = self.__measurement_settings
+        alt_type = self.alternative_data_type
 
         # scale the x_axis for plotting
-        max_val = np.max(self.signal_data[0])
+        max_val = np.max(data.signal_data[0])
         scaled_float = ScaledFloat(max_val)
         counts_prefix = scaled_float.scale
-        x_axis_scaled = self.signal_data[0] / scaled_float.scale_val
+        x_axis_scaled = data.signal_data[0] / scaled_float.scale_val
 
         # Create the figure object
-        if self._alternative_data_type and self._alternative_data_type != 'None':
+        if alt_type and alt_type != 'None':
             fig, (ax1, ax2) = plt.subplots(2, 1)
         else:
             fig, ax1 = plt.subplots()
 
         if with_error:
-            ax1.errorbar(x=x_axis_scaled, y=self.signal_data[1],
-                         yerr=self.measurement_error[1],
+            ax1.errorbar(x=x_axis_scaled, y=data.signal_data[1],
+                         yerr=data.measurement_error[1],
                          linestyle=':', linewidth=0.5, color=colors[0],
                          ecolor=colors[1], capsize=3, capthick=0.9,
                          elinewidth=1.2, label='data trace 1')
 
-            if self._alternating:
-                ax1.errorbar(x=x_axis_scaled, y=self.signal_data[2],
-                             yerr=self.measurement_error[2], fmt='-D',
+            if settings.alternating:
+                ax1.errorbar(x=x_axis_scaled, y=data.signal_data[2],
+                             yerr=data.measurement_error[2], fmt='-D',
                              linestyle=':', linewidth=0.5, color=colors[3],
                              ecolor=colors[4],  capsize=3, capthick=0.7,
                              elinewidth=1.2, label='data trace 2')
         else:
-            ax1.plot(x_axis_scaled, self.signal_data[1], color=colors[0],
+            ax1.plot(x_axis_scaled, data.signal_data[1], color=colors[0],
                      linestyle=':', linewidth=0.5, label='data trace 1')
 
-            if self._alternating:
-                ax1.plot(x_axis_scaled, self.signal_data[2], '-o',
+            if settings.alternating:
+                ax1.plot(x_axis_scaled, data.signal_data[2], '-o',
                          color=colors[3], linestyle=':', linewidth=0.5,
                          label='data trace 2')
 
@@ -1670,44 +1657,43 @@ class PulsedMeasurementLogic(LogicBase):
             _plot_fit(axis=ax1)
 
         # handle the save of the alternative data plot
-        if self._alternative_data_type and self._alternative_data_type != 'None':
+        if alt_type and alt_type != 'None':
 
             # scale the x_axis for plotting
-            max_val = np.max(self.signal_alt_data[0])
+            max_val = np.max(data.signal_alt_data[0])
             scaled_float = ScaledFloat(max_val)
             x_axis_prefix = scaled_float.scale
-            x_axis_ft_scaled = self.signal_alt_data[0] / scaled_float.scale_val
+            x_axis_ft_scaled = data.signal_alt_data[0] / scaled_float.scale_val
 
-            # since no ft units are provided, make a small work around:
-            if self._alternative_data_type == 'FFT':
-                if self._data_units[0] == 's':
+            if alt_type == 'FFT':
+                if settings.units[0] == 's':
                     inverse_cont_var = 'Hz'
-                elif self._data_units[0] == 'Hz':
+                elif settings.units[0] == 'Hz':
                     inverse_cont_var = 's'
                 else:
-                    inverse_cont_var = '(1/{0})'.format(self._data_units[0])
+                    inverse_cont_var = '(1/{0})'.format(settings.units[0])
                 x_axis_ft_label = 'FT {0} ({1}{2})'.format(
-                    self._data_labels[0], x_axis_prefix, inverse_cont_var)
-                y_axis_ft_label = 'FT({0}) (arb. u.)'.format(self._data_labels[1])
+                    settings.labels[0], x_axis_prefix, inverse_cont_var)
+                y_axis_ft_label = 'FT({0}) (arb. u.)'.format(settings.labels[1])
                 ft_label = 'FT of data trace 1'
             else:
-                if self._data_units[0]:
-                    x_axis_ft_label = '{0} ({1}{2})'.format(self._data_labels[0], x_axis_prefix,
-                                                            self._data_units[0])
+                if settings.units[0]:
+                    x_axis_ft_label = '{0} ({1}{2})'.format(settings.labels[0], x_axis_prefix,
+                                                            settings.units[0])
                 else:
-                    x_axis_ft_label = '{0}'.format(self._data_labels[0])
-                if self._data_units[1]:
-                    y_axis_ft_label = '{0} ({1})'.format(self._data_labels[1], self._data_units[1])
+                    x_axis_ft_label = '{0}'.format(settings.labels[0])
+                if settings.units[1]:
+                    y_axis_ft_label = '{0} ({1})'.format(settings.labels[1], settings.units[1])
                 else:
-                    y_axis_ft_label = '{0}'.format(self._data_labels[1])
+                    y_axis_ft_label = '{0}'.format(settings.labels[1])
 
-                ft_label = '{0} of data traces'.format(self._alternative_data_type)
+                ft_label = '{0} of data traces'.format(alt_type)
 
-            ax2.plot(x_axis_ft_scaled, self.signal_alt_data[1],
+            ax2.plot(x_axis_ft_scaled, data.signal_alt_data[1],
                      linestyle=':', linewidth=0.5, color=colors[0],
                      label=ft_label)
-            if self._alternating and len(self.signal_alt_data) > 2:
-                ax2.plot(x_axis_ft_scaled, self.signal_alt_data[2],
+            if settings.alternating and len(data.signal_alt_data) > 2:
+                ax2.plot(x_axis_ft_scaled, data.signal_alt_data[2],
                          linestyle=':', linewidth=0.5, color=colors[3],
                          label=ft_label.replace('1', '2'))
 
@@ -1722,50 +1708,42 @@ class PulsedMeasurementLogic(LogicBase):
             if _is_fit_available(use_alternative_data=True):
                 _plot_fit(axis=ax2, use_alternative_data=True)
 
-        data_label_tex = [_subscript_html_2_tex(self._data_labels[0]),
-                          _subscript_html_2_tex(self._data_labels[1])]
+        data_label_tex = [_subscript_html_2_tex(settings.labels[0]),
+                          _subscript_html_2_tex(settings.labels[1])]
 
         ax1.set_xlabel(
-            '{0} ({1}{2})'.format(data_label_tex[0], counts_prefix, self._data_units[0]))
-        if self._data_units[1]:
-            ax1.set_ylabel('{0} ({1})'.format(data_label_tex[1], self._data_units[1]))
+            '{0} ({1}{2})'.format(data_label_tex[0], counts_prefix, settings.units[0]))
+        
+        if settings.units[1]:
+            ax1.set_ylabel('{0} ({1})'.format(data_label_tex[1], settings.units[1]))
         else:
             ax1.set_ylabel('{0}'.format(data_label_tex[1]))
 
         fig.tight_layout()
         ax1.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
                    mode="expand", borderaxespad=0.)
-        # plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
-        #            mode="expand", borderaxespad=0.)
 
         return fig
 
     def _compute_alt_data(self):
-        """
-        Performing transformations on the measurement data (e.g. fourier transform).
-        """
-        if self._alternative_data_type == 'Delta' and len(self.signal_data) == 3:
-            self.signal_alt_data = np.empty((2, self.signal_data.shape[1]), dtype=float)
-            self.signal_alt_data[0] = self.signal_data[0]
-            self.signal_alt_data[1] = self.signal_data[1] - self.signal_data[2]
-        elif self._alternative_data_type == 'FFT' and self.signal_data.shape[1] >= 2:
-            fft_x, fft_y = compute_ft(x_val=self.signal_data[0],
-                                      y_val=self.signal_data[1],
-                                      zeropad_num=self.zeropad,
-                                      window=self.window,
-                                      base_corr=self.base_corr,
-                                      psd=self.psd)
-            self.signal_alt_data = np.empty((len(self.signal_data), len(fft_x)), dtype=float)
-            self.signal_alt_data[0] = fft_x
-            self.signal_alt_data[1] = fft_y
-            for dim in range(2, len(self.signal_data)):
-                dummy, self.signal_alt_data[dim] = compute_ft(x_val=self.signal_data[0],
-                                                              y_val=self.signal_data[dim],
-                                                              zeropad_num=self.zeropad,
-                                                              window=self.window,
-                                                              base_corr=self.base_corr,
-                                                              psd=self.psd)
+        alt = self.alternate_signal_settings
+        md = self.measurement_data
+        if alt.alternative_data_type == 'Delta' and len(md.signal_data) == 3:
+            md.signal_alt_data = np.empty((2, md.signal_data.shape[1]), dtype=float)
+            md.signal_alt_data[0] = md.signal_data[0]
+            md.signal_alt_data[1] = md.signal_data[1] - md.signal_data[2]
+        elif alt.alternative_data_type == 'FFT' and md.signal_data.shape[1] >= 2:
+            fft_x, fft_y = compute_ft(x_val=md.signal_data[0], y_val=md.signal_data[1],
+                                  zeropad_num=alt.zeropad, window=alt.window,
+                                  base_corr=alt.base_corr, psd=alt.psd)
+            md.signal_alt_data = np.empty((len(md.signal_data), len(fft_x)), dtype=float)
+            md.signal_alt_data[0] = fft_x
+            md.signal_alt_data[1] = fft_y
+            for dim in range(2, len(md.signal_data)):
+                dummy, md.signal_alt_data[dim] = compute_ft(x_val=md.signal_data[0], y_val=md.signal_data[dim],
+                                                        zeropad_num=alt.zeropad, window=alt.window,
+                                                        base_corr=alt.base_corr, psd=alt.psd)
         else:
-            self.signal_alt_data = np.zeros(self.signal_data.shape, dtype=float)
-            self.signal_alt_data[0] = self.signal_data[0]
+            md.signal_alt_data = np.zeros(md.signal_data.shape, dtype=float)
+            md.signal_alt_data[0] = md.signal_data[0]
         return

--- a/src/qudi/logic/pulsed/pulsed_measurement_logic.py
+++ b/src/qudi/logic/pulsed/pulsed_measurement_logic.py
@@ -65,6 +65,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     GenerationMethodParameters,
     MeasurementInformation,
     MetadataDictRepresentation,
+    to_plain_metadata,
     MicrowaveSettings,
     FastCounterSettings,
     ReadoutSettings,
@@ -1917,8 +1918,7 @@ class PulsedMeasurementLogic(LogicBase):
             'Measurement sweeps'          : self.measurement_data.elapsed_sweeps,
             'pulsed measurement settings' : self._get_master_settings_metadata(generator_settings)}
         metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
-        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
-                for key, value in metadata.items()}
+        return self._finalize_metadata(metadata)
 
     def _get_laser_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         fc = self._settings.fast_counter_settings
@@ -1928,8 +1928,7 @@ class PulsedMeasurementLogic(LogicBase):
             'extraction parameters': self.extraction_settings,
             'pulsed measurement settings': self._get_master_settings_metadata(generator_settings)}
         metadata.update(self._get_loaded_asset_metadata(ensembles=ensembles, blocks=blocks))
-        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
-                for key, value in metadata.items()}
+        return self._finalize_metadata(metadata)
 
     def _get_signal_metadata(self, generator_settings=None, ensembles=None, blocks=None):
         ms = self._settings.readout_settings
@@ -1963,8 +1962,30 @@ class PulsedMeasurementLogic(LogicBase):
             metadata['fit result'] = FitContainer.dict_result(self._fit_result)
         if self._fit_result_alt:
             metadata['fit result alt'] = FitContainer.dict_result(self._fit_result_alt)
-        return {key: (MetadataDictRepresentation(value) if isinstance(value, dict) else value)
-                for key, value in metadata.items()}
+        return self._finalize_metadata(metadata)
+
+    @staticmethod
+    def _finalize_metadata(metadata):
+        """Shared tail of _get_raw_metadata()/_get_laser_metadata()/_get_signal_metadata().
+
+        Two steps, in this order:
+
+        1. to_plain_metadata() converts every value into types whose repr() can be read back by
+           qudi.util.datastorage's eval()-based parser - see its docstring for the three reprs that
+           otherwise arrive as unparsed strings, and for the >1000-element array truncation it
+           avoids.
+        2. Dicts are wrapped in MetadataDictRepresentation so the header shows them pretty-printed
+           across several lines instead of one wall-of-text line.
+
+        Sanitizing first matters: the wrapper's repr() is what ends up in the file, so it has to be
+        holding already-plain values. The two are independent otherwise - line breaks never affected
+        whether a value parses back (a dict literal spanning lines is a perfectly valid eval
+        expression, and ConfigParser rejoins continuation lines before the parse).
+        """
+        return {
+            key: (MetadataDictRepresentation(plain) if isinstance(plain, dict) else plain)
+            for key, plain in ((key, to_plain_metadata(value)) for key, value in metadata.items())
+        }
 
     @staticmethod
     def _get_patched_filename_nametag(file_name=None, nametag=None, suffix_str=''):

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -222,8 +222,15 @@ class SamplingFunctions:
         """
         Helper method to check if an object is a valid sampling function class.
 
-        @param object obj: object to check
-        @return bool: True if obj is a valid sampling function class, False otherwise
+        Parameters
+        ----------
+        obj : object
+            Object to check.
+
+        Returns
+        -------
+        bool
+            True if obj is a valid sampling function class, False otherwise.
         """
         if inspect.isclass(obj):
             return SamplingBase in inspect.getmro(obj) and object not in obj.__bases__

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -274,3 +274,6 @@ class PulseEnvelope:
     def from_dict(cls, parameters: dict) -> "PulseEnvelope":
         return PulseEnvelope(parameters["type"], parameters["parameters"])
 
+    def to_dict(self) -> dict:
+        return {"type": self.type, "parameters": self.parameters}
+

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -70,6 +70,11 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     _DEFAULT_PULSE_GENERATOR_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters, MeasurementInformation
+from qudi.logic.pulsed.pulsed_data.settings_coercion import (
+    SettingsTypeError,
+    as_settings_dict,
+    coerce_settings,
+)
 
 SafeRepresenter.add_multi_representer(PulseEnvelope, dataclass_representer)
 SafeConstructor.add_constructor("!PulseEnvelope", pulse_envelope_constructor)
@@ -105,12 +110,22 @@ def _resolve_asset_closure(asset, saved_pulse_block_ensembles, saved_pulse_block
     Missing referenced names are logged as a combined warning and skipped rather than raising -
     a best-effort, partially-resolved snapshot is still useful for saving/inspection.
 
-    @param asset: the currently loaded PulseBlockEnsemble or PulseSequence, or None if nothing is
+    Parameters
+    ----------
+    asset
+        The currently loaded PulseBlockEnsemble or PulseSequence, or None if nothing is
         loaded.
-    @param dict saved_pulse_block_ensembles: SequenceGeneratorLogic._saved_pulse_block_ensembles
-    @param dict saved_pulse_blocks: SequenceGeneratorLogic._saved_pulse_blocks
-    @param log: logger to warn through (SequenceGeneratorLogic.log)
-    @return (ensembles, blocks): {name: independent copy}. `ensembles` is empty if `asset` is a
+    saved_pulse_block_ensembles : dict
+        SequenceGeneratorLogic._saved_pulse_block_ensembles
+    saved_pulse_blocks : dict
+        SequenceGeneratorLogic._saved_pulse_blocks
+    log
+        Logger to warn through (SequenceGeneratorLogic.log)
+
+    Returns
+    -------
+    ensembles, blocks
+        {name: independent copy}. `ensembles` is empty if `asset` is a
         bare PulseBlockEnsemble or None. `blocks` covers every PulseBlock referenced by
         `ensembles`, or referenced directly by `asset` if it is a bare PulseBlockEnsemble.
     """
@@ -483,11 +498,11 @@ class SequenceGeneratorLogic(LogicBase):
         return self._generator_settings.pulse_generator_settings.to_dict()
 
     @pulse_generator_settings.setter
-    def pulse_generator_settings(self, settings_dict):
-        if isinstance(settings_dict, PulseGeneratorSettings):
-            self.set_pulse_generator_settings(settings_dict.to_dict())
-        elif isinstance(settings_dict, dict):
-            self.set_pulse_generator_settings(settings_dict)
+    def pulse_generator_settings(self, settings):
+        if not isinstance(settings, (PulseGeneratorSettings, dict)):
+            raise SettingsTypeError(f'pulse_generator_settings expects PulseGeneratorSettings or '
+                                    f'dict, got {type(settings).__name__}')
+        self.set_pulse_generator_settings(settings)
         return
 
     @property
@@ -531,26 +546,35 @@ class SequenceGeneratorLogic(LogicBase):
         return LoadedAsset(name=return_name, asset_type=return_type)
 
     @QtCore.Slot(dict)
-    def set_pulse_generator_settings(self, settings_dict=None, **kwargs):
+    def set_pulse_generator_settings(self, settings=None, **kwargs):
         """
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accept a PulseGeneratorSettings instance or a settings dictionary as positional
+        argument, or keyword arguments. If both are present both are being used by updating the
+        settings_dict with kwargs. The keyword arguments take precedence over the items in
+        settings_dict if there are conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Unlike set_generation_parameters() this stays dict-based rather than coercing to a
+        PulseGeneratorSettings: each key below is negotiated with the hardware only if present,
+        and activation_config accepts several shapes (str/set/tuple) that the dataclass field
+        does not. Calling with no arguments is a refresh, not an empty update.
+
+        Parameters
+        ----------
+        settings : PulseGeneratorSettings or dict or None
+        kwargs
         """
+        try:
+            settings_dict = as_settings_dict(settings, kwargs, PulseGeneratorSettings)
+        except SettingsTypeError as err:
+            # Logged rather than raised: this is a queued cross-thread slot, where an escaping
+            # exception cannot reach the emitter and may take the whole application down.
+            self.log.error(f'Unable to apply new pulse generator settings. {err}')
+            self.sigGeneratorSettingsUpdated.emit(self.pulse_generator_settings)
+            return self.pulse_generator_settings
+
         # Check if pulse generator is running and do nothing if that is the case
         pulser_status, status_dict = self.pulsegenerator().get_status()
         if pulser_status == 0:
-            # Determine complete settings dictionary
-            if not isinstance(settings_dict, dict):
-                settings_dict = kwargs
-            else:
-                settings_dict.update(kwargs)
-
             # Set parameters if present
             if 'activation_config' in settings_dict:
                 activation_config = settings_dict['activation_config']
@@ -648,7 +672,7 @@ class SequenceGeneratorLogic(LogicBase):
 
             self._update_pulse_generator_settings(upload_speed=self.get_speed_write_load())
 
-        elif len(kwargs) != 0 or isinstance(settings_dict, dict):
+        elif settings_dict:
             # Only throw warning when arguments have been passed to this method
             self.log.warning(
                 'Pulse generator is not idle (status: {0:d}, "{1}").\nUnable to apply new settings.'.format(
@@ -692,7 +716,9 @@ class SequenceGeneratorLogic(LogicBase):
     def load_ensemble(self, ensemble):
         """
 
-        @param str|PulseBlockEnsemble ensemble:
+        Parameters
+        ----------
+        ensemble : str or PulseBlockEnsemble
         """
         # If str has been passed, get the ensemble object from saved ensembles
         if isinstance(ensemble, str):
@@ -753,7 +779,9 @@ class SequenceGeneratorLogic(LogicBase):
     def load_sequence(self, sequence):
         """
 
-        @param str|PulseSequence sequence:
+        Parameters
+        ----------
+        sequence : str or PulseSequence
         """
         # If str has been passed, get the sequence object from saved sequences
         if isinstance(sequence, str):
@@ -841,7 +869,10 @@ class SequenceGeneratorLogic(LogicBase):
     def _apply_activation_config(self, activation_config):
         """
 
-        @param set activation_config: A set of channels to set active (all others inactive)
+        Parameters
+        ----------
+        activation_config : set
+            A set of channels to set active (all others inactive)
         """
         channel_state = self.pulsegenerator().get_active_channels()
         for chnl in channel_state:
@@ -869,11 +900,11 @@ class SequenceGeneratorLogic(LogicBase):
         return self._generator_settings.generation_parameters.to_dict()
 
     @generation_parameters.setter
-    def generation_parameters(self, settings_dict):
-        if isinstance(settings_dict, GenerationParameters):
-            self.set_generation_parameters(settings_dict.to_dict())
-        elif isinstance(settings_dict, dict):
-            self.set_generation_parameters(settings_dict)
+    def generation_parameters(self, settings):
+        if not isinstance(settings, (GenerationParameters, dict)):
+            raise SettingsTypeError(f'generation_parameters expects GenerationParameters or dict, '
+                                    f'got {type(settings).__name__}')
+        self.set_generation_parameters(settings)
         return
 
     @property
@@ -889,79 +920,64 @@ class SequenceGeneratorLogic(LogicBase):
         return self._saved_pulse_sequences
 
     @QtCore.Slot(dict)
-    def set_generation_parameters(self, settings_dict=None, **kwargs):
+    def set_generation_parameters(self, settings=None, **kwargs):
         """
-        Either accept a settings dictionary as positional argument or keyword arguments.
-        If both are present both are being used by updating the settings_dict with kwargs.
-        The keyword arguments take precedence over the items in settings_dict if there are
-        conflicting names.
+        Either accepts a GenerationParameters instance or a settings dictionary as positional
+        argument, or keyword arguments. A dict/kwargs is a partial patch of the current
+        parameters, a GenerationParameters is a full replacement. If both a settings_dict and
+        kwargs are present, the keyword arguments take precedence for conflicting names.
 
-        @param settings_dict:
-        @param kwargs:
-        @return:
+        Parameters
+        ----------
+        settings : GenerationParameters or dict or None
+        kwargs
         """
         # Check if generation is in progress and do nothing if that is the case
         if self.module_state() != 'locked':
-            # Determine complete settings dictionary
-            if isinstance(settings_dict, GenerationParameters):
-                settings_dict = settings_dict.to_dict()
-                settings_dict.update(kwargs)
-            elif not isinstance(settings_dict, dict):
-                settings_dict = kwargs
-            else:
-                settings_dict.update(kwargs)
+            current = self._generator_settings.generation_parameters
+            # Warn about unknown keys before coercion. GenerationParameters has a fixed schema, so
+            # (unlike the old plain dict) it cannot store arbitrary additional settings, and
+            # update_from_dict() would drop them without a word.
+            known_keys = {f.name for f in fields(GenerationParameters)}
+            if isinstance(settings, dict):
+                settings = {k: v for k, v in settings.items()
+                            if k in known_keys or self._warn_unknown_generation_parameter(k)}
+            kwargs = {k: v for k, v in kwargs.items()
+                      if k in known_keys or self._warn_unknown_generation_parameter(k)}
 
-            # Discard unknown keys. GenerationParameters has a fixed schema, so (unlike the old
-            # plain dict) it cannot store arbitrary additional settings.
-            known_keys = self._generator_settings.generation_parameters.to_dict().keys()
-            for key in list(settings_dict):
-                if key not in known_keys:
-                    self.log.warning(
-                        'Setting by name "{0}" not present in generation_parameters.\n'
-                        'Ignoring it.'.format(key)
-                    )
-                    del settings_dict[key]
-            # Sanity checks
+            try:
+                requested = coerce_settings(settings, kwargs, current, GenerationParameters)
+            except SettingsTypeError as err:
+                # Logged rather than raised: this is a queued cross-thread slot, where an escaping
+                # exception cannot reach the emitter and may take the whole application down.
+                self.log.error(f'Unable to apply new sampling settings. {err}')
+                self.sigSamplingSettingsUpdated.emit(self.generation_parameters)
+                return self.generation_parameters
+
+            # Sanity checks. A channel that is not part of the activation config keeps its current
+            # value, so the rest of the requested parameters still apply. Only channels this call
+            # actually changes are checked - an already-invalid current value would otherwise log
+            # an error on every call while reverting to itself. Healing those is the job of the
+            # activation-config handler in set_pulse_generator_settings().
+            # Every *_channel field is checked, not just the four built-in ones, so a lab
+            # extension declaring its own channel parameter gets the same validation - matching
+            # the suffix-based healing loop in set_pulse_generator_settings().
             active_channels = self._generator_settings.pulse_generator_settings.activation_config.channels
-            if settings_dict.get('laser_channel'):
-                if settings_dict['laser_channel'] not in active_channels:
+            for field_name in (f.name for f in fields(GenerationParameters) if f.name.endswith('_channel')):
+                channel = getattr(requested, field_name)
+                if (isinstance(channel, str) and channel
+                        and channel != getattr(current, field_name)
+                        and channel not in active_channels):
                     self.log.error(
-                        'Unable to set laser channel "{0}".\nChannel to set is not part '
-                        'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['laser_channel'], active_channels)
+                        'Unable to set {0} channel "{1}".\nChannel to set is not part '
+                        'of the current channel activation config ({2}).'
+                        ''.format(field_name[:-len('_channel')], channel, active_channels)
                     )
-                    del settings_dict['laser_channel']
-            if settings_dict.get('sync_channel'):
-                if settings_dict['sync_channel'] not in active_channels:
-                    self.log.error(
-                        'Unable to set sync channel "{0}".\nChannel to set is not part '
-                        'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['sync_channel'], active_channels)
-                    )
-                    del settings_dict['sync_channel']
-            if settings_dict.get('gate_channel'):
-                if settings_dict['gate_channel'] not in active_channels:
-                    self.log.error(
-                        'Unable to set gate channel "{0}".\nChannel to set is not part '
-                        'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['gate_channel'], active_channels)
-                    )
-                    del settings_dict['gate_channel']
-            if settings_dict.get('microwave_channel'):
-                if settings_dict['microwave_channel'] not in active_channels:
-                    self.log.error(
-                        'Unable to set microwave channel "{0}".\nChannel to set is not '
-                        'part of the current channel activation config ({1}).'
-                        ''.format(settings_dict['microwave_channel'], active_channels)
-                    )
-                    del settings_dict['microwave_channel']
+                    requested = replace(requested, **{field_name: getattr(current, field_name)})
 
-            # update settings dict
+            # update settings
             self._generator_settings = replace(
-                self._generator_settings,
-                generation_parameters=self._generator_settings.generation_parameters.update_from_dict(
-                    settings_dict
-                ),
+                self._generator_settings, generation_parameters=requested
             )
         else:
             self.log.error(
@@ -971,10 +987,20 @@ class SequenceGeneratorLogic(LogicBase):
         self.sigSamplingSettingsUpdated.emit(self.generation_parameters)
         return self.generation_parameters
 
+    def _warn_unknown_generation_parameter(self, key):
+        """Log an ignored generation parameter name. Always returns False so it can be used as the
+        filtering half of a comprehension guard."""
+        self.log.warning('Setting by name "{0}" not present in generation_parameters.\n'
+                         'Ignoring it.'.format(key))
+        return False
+
     def save_block(self, block):
         """Saves a PulseBlock instance
 
-        @param PulseBlock block: PulseBlock instance to save
+        Parameters
+        ----------
+        block : PulseBlock
+            PulseBlock instance to save
         """
         self._saved_pulse_blocks[block.name] = block
         self._save_block_to_file(block)
@@ -984,8 +1010,13 @@ class SequenceGeneratorLogic(LogicBase):
     def get_block(self, name):
         """
 
-        @param str name:
-        @return PulseBlock:
+        Parameters
+        ----------
+        name : str
+
+        Returns
+        -------
+        PulseBlock
         """
         if name not in self._saved_pulse_blocks:
             self.log.warning('PulseBlock "{0}" could not be found in saved pulse blocks.\nReturning None.'.format(name))
@@ -994,7 +1025,10 @@ class SequenceGeneratorLogic(LogicBase):
     def delete_block(self, name):
         """Remove the serialized object "name" from the block list and HDD.
 
-        @param name: string, name of the PulseBlock object to be removed.
+        Parameters
+        ----------
+        name
+            String, name of the PulseBlock object to be removed.
         """
         # Delete from dict
         if name in self.saved_pulse_blocks:
@@ -1012,8 +1046,15 @@ class SequenceGeneratorLogic(LogicBase):
         """
         De-serializes a PulseBlock instance from file.
 
-        @param str block_name: The name of the PulseBlock instance to de-serialize
-        @return PulseBlock: The de-serialized PulseBlock instance
+        Parameters
+        ----------
+        block_name : str
+            The name of the PulseBlock instance to de-serialize
+
+        Returns
+        -------
+        PulseBlock
+            The de-serialized PulseBlock instance
         """
         block = None
         filepath = os.path.join(self._assets_storage_dir, '{0}.block'.format(block_name))
@@ -1054,7 +1095,10 @@ class SequenceGeneratorLogic(LogicBase):
         """
         Saves a single PulseBlock instance to file by serialization using pickle.
 
-        @param PulseBlock block: The PulseBlock instance to be saved
+        Parameters
+        ----------
+        block : PulseBlock
+            The PulseBlock instance to be saved
         """
         filename = '{0}.block'.format(block.name)
         try:
@@ -1075,7 +1119,10 @@ class SequenceGeneratorLogic(LogicBase):
     def save_ensemble(self, ensemble):
         """Saves a PulseBlockEnsemble instance
 
-        @param PulseBlockEnsemble ensemble: PulseBlockEnsemble instance to save
+        Parameters
+        ----------
+        ensemble : PulseBlockEnsemble
+            PulseBlockEnsemble instance to save
         """
         self._saved_pulse_block_ensembles[ensemble.name] = ensemble
         self._save_ensemble_to_file(ensemble)
@@ -1085,8 +1132,9 @@ class SequenceGeneratorLogic(LogicBase):
     def get_ensemble(self, name: str):
         """
 
-        @param name:
-        @return:
+        Parameters
+        ----------
+        name
         """
         if name not in self._saved_pulse_block_ensembles:
             self.log.warning(
@@ -1122,8 +1170,15 @@ class SequenceGeneratorLogic(LogicBase):
         """
         De-serializes a PulseBlockEnsemble instance from file.
 
-        @param str ensemble_name: The name of the PulseBlockEnsemble instance to de-serialize
-        @return PulseBlockEnsemble: The de-serialized PulseBlockEnsemble instance
+        Parameters
+        ----------
+        ensemble_name : str
+            The name of the PulseBlockEnsemble instance to de-serialize
+
+        Returns
+        -------
+        PulseBlockEnsemble
+            The de-serialized PulseBlockEnsemble instance
         """
         ensemble = None
         filepath = os.path.join(self._assets_storage_dir, '{0}.ensemble'.format(ensemble_name))
@@ -1171,7 +1226,10 @@ class SequenceGeneratorLogic(LogicBase):
         """
         Saves a single PulseBlockEnsemble instance to file by serialization using pickle.
 
-        @param PulseBlockEnsemble ensemble: The PulseBlockEnsemble instance to be saved
+        Parameters
+        ----------
+        ensemble : PulseBlockEnsemble
+            The PulseBlockEnsemble instance to be saved
         """
         filename = '{0}.ensemble'.format(ensemble.name)
         try:
@@ -1192,10 +1250,15 @@ class SequenceGeneratorLogic(LogicBase):
     def save_sequence(self, sequence):
         """Saves a PulseSequence instance
 
-        @param object sequence: a PulseSequence object, which is going to be
-                                serialized to file.
+        Parameters
+        ----------
+        sequence : object
+            A PulseSequence object, which is going to be serialized to file.
 
-        @return: str: name of the serialized object, if needed.
+        Returns
+        -------
+        str
+            Name of the serialized object, if needed.
         """
         self._saved_pulse_sequences[sequence.name] = sequence
         self._save_sequence_to_file(sequence)
@@ -1205,8 +1268,9 @@ class SequenceGeneratorLogic(LogicBase):
     def get_sequence(self, name: str):
         """
 
-        @param name:
-        @return:
+        Parameters
+        ----------
+        name
         """
         if name not in self._saved_pulse_sequences:
             self.log.warning(
@@ -1221,8 +1285,15 @@ class SequenceGeneratorLogic(LogicBase):
         pulsed_data/pulsed_measurement.py's PulseObjects) - see _resolve_asset_closure() for the
         full traversal/missing-reference contract.
 
-        @param asset: the currently loaded PulseBlockEnsemble or PulseSequence, or None.
-        @return (ensembles, blocks): {name: independent copy}, see _resolve_asset_closure().
+        Parameters
+        ----------
+        asset
+            The currently loaded PulseBlockEnsemble or PulseSequence, or None.
+
+        Returns
+        -------
+        ensembles, blocks
+            {name: independent copy}, see _resolve_asset_closure().
         """
         return _resolve_asset_closure(asset, self._saved_pulse_block_ensembles, self._saved_pulse_blocks, self.log)
 
@@ -1254,8 +1325,15 @@ class SequenceGeneratorLogic(LogicBase):
         """
         De-serializes a PulseSequence instance from file.
 
-        @param str sequence_name: The name of the PulseSequence instance to de-serialize
-        @return PulseSequence: The de-serialized PulseSequence instance
+        Parameters
+        ----------
+        sequence_name : str
+            The name of the PulseSequence instance to de-serialize
+
+        Returns
+        -------
+        PulseSequence
+            The de-serialized PulseSequence instance
         """
         filepath = os.path.join(self._assets_storage_dir, '{0}.sequence'.format(sequence_name))
         if os.path.exists(filepath):
@@ -1351,7 +1429,10 @@ class SequenceGeneratorLogic(LogicBase):
         """
         Saves a single PulseSequence instance to file by serialization using pickle.
 
-        @param PulseSequence sequence: The PulseSequence instance to be saved
+        Parameters
+        ----------
+        sequence : PulseSequence
+            The PulseSequence instance to be saved
         """
         filename = '{0}.sequence'.format(sequence.name)
         try:
@@ -1372,9 +1453,10 @@ class SequenceGeneratorLogic(LogicBase):
     def generate_predefined_sequence(self, predefined_sequence_name, kwargs_dict):
         """
 
-        @param predefined_sequence_name:
-        @param kwargs_dict:
-        @return:
+        Parameters
+        ----------
+        predefined_sequence_name
+        kwargs_dict
         """
         gen_method = self.generate_methods[predefined_sequence_name]
         gen_params = self.generate_method_params[predefined_sequence_name]
@@ -1473,8 +1555,15 @@ class SequenceGeneratorLogic(LogicBase):
         Will return information like length in seconds and bins (with currently set sampling rate)
         as well as number of laser pulses (with currently selected laser/gate channel)
 
-        @param PulseBlockEnsemble ensemble: The PulseBlockEnsemble instance to analyze
-        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
+        Parameters
+        ----------
+        ensemble : PulseBlockEnsemble
+            The PulseBlockEnsemble instance to analyze
+
+        Returns
+        -------
+        (float, int, int)
+            Length in seconds, length in bins, number of laser/gate pulses
         """
         # Return if the ensemble is empty
         if len(ensemble) == 0:
@@ -1492,8 +1581,15 @@ class SequenceGeneratorLogic(LogicBase):
         seconds and bins (with currently set sampling rate), number of laser pulses (with currently
         selected laser/gate channel)
 
-        @param PulseSequence sequence: The PulseSequence instance to analyze
-        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
+        Parameters
+        ----------
+        sequence : PulseSequence
+            The PulseSequence instance to analyze
+
+        Returns
+        -------
+        (float, int, int)
+            Length in seconds, length in bins, number of laser/gate pulses
         """
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
@@ -1531,19 +1627,26 @@ class SequenceGeneratorLogic(LogicBase):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param ensemble: A PulseBlockEnsemble object (see logic.pulse_objects.py) or the name of one
-        @return: number_of_samples (int): The total number of samples in a Waveform provided the
-                                              current sample_rate and PulseBlockEnsemble object.
-                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
-                                       the provided PulseBlockEnsemble.
-                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
-                                                               PulseBlockElement in chronological
-                                                               order (incl. repetitions).
-                 digital_rising_bins (dict): Dictionary with keys being the digital channel
-                                             descriptor string and items being arrays of
-                                             chronological low-to-high transition positions
-                                             (in timebins; incl. repetitions) for each digital
-                                             channel.
+        Parameters
+        ----------
+        ensemble
+            A PulseBlockEnsemble object (see logic.pulse_objects.py) or the name of one
+
+        Returns
+        -------
+        number_of_samples : int
+            The total number of samples in a Waveform provided the current sample_rate and
+            PulseBlockEnsemble object.
+        total_elements : int
+            The total number of PulseBlockElements (incl. repetitions) in the provided
+            PulseBlockEnsemble.
+        elements_length_bins : 1D numpy.ndarray[int]
+            Array of number of timebins for each PulseBlockElement in chronological order (incl.
+            repetitions).
+        digital_rising_bins : dict
+            Dictionary with keys being the digital channel descriptor string and items being
+            arrays of chronological low-to-high transition positions (in timebins; incl.
+            repetitions) for each digital channel.
         """
         if isinstance(ensemble, str):
             if ensemble not in self._saved_pulse_block_ensembles:
@@ -1688,19 +1791,26 @@ class SequenceGeneratorLogic(LogicBase):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param sequence: A PulseSequence object (see logic.pulse_objects.py) or the name of one
-        @return: number_of_samples (int): The total number of samples in a Waveform provided the
-                                              current sample_rate and PulseBlockEnsemble object.
-                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
-                                       the provided PulseBlockEnsemble.
-                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
-                                                               PulseBlockElement in chronological
-                                                               order (incl. repetitions).
-                 digital_rising_bins (dict): Dictionary with keys being the digital channel
-                                             descriptor string and items being arrays of
-                                             chronological low-to-high transition positions
-                                             (in timebins; incl. repetitions) for each digital
-                                             channel.
+        Parameters
+        ----------
+        sequence
+            A PulseSequence object (see logic.pulse_objects.py) or the name of one
+
+        Returns
+        -------
+        number_of_samples : int
+            The total number of samples in a Waveform provided the current sample_rate and
+            PulseBlockEnsemble object.
+        total_elements : int
+            The total number of PulseBlockElements (incl. repetitions) in the provided
+            PulseBlockEnsemble.
+        elements_length_bins : 1D numpy.ndarray[int]
+            Array of number of timebins for each PulseBlockElement in chronological order (incl.
+            repetitions).
+        digital_rising_bins : dict
+            Dictionary with keys being the digital channel descriptor string and items being
+            arrays of chronological low-to-high transition positions (in timebins; incl.
+            repetitions) for each digital channel.
         """
         if isinstance(sequence, str):
             if sequence not in self._saved_pulse_sequences:
@@ -1957,24 +2067,28 @@ class SequenceGeneratorLogic(LogicBase):
     ):
         """General sampling of a PulseBlockEnsemble object, which serves as the construction plan.
 
-        @param str|PulseBlockEnsemble ensemble: PulseBlockEnsemble instance or name of a saved
-                                                PulseBlockEnsemble to sample
-        @param int offset_bin: If many pulse ensembles are samples sequentially, then the
-                               offset_bin of the previous sampling can be passed to maintain
-                               rotating frame across pulse_block_ensembles
-        @param str name_tag: a name tag, which is used to keep the sampled files together, which
-                             where sampled from the same PulseBlockEnsemble object but where
-                             different offset_bins were used.
+        Parameters
+        ----------
+        ensemble : str or PulseBlockEnsemble
+            PulseBlockEnsemble instance or name of a saved PulseBlockEnsemble to sample
+        offset_bin : int
+            If many pulse ensembles are samples sequentially, then the offset_bin of the previous
+            sampling can be passed to maintain rotating frame across pulse_block_ensembles
+        name_tag : str
+            A name tag, which is used to keep the sampled files together, which where sampled
+            from the same PulseBlockEnsemble object but where different offset_bins were used.
 
-        @return tuple: of length 3 with
-                       (offset_bin, created_waveforms, ensemble_info).
-                        offset_bin:
-                            integer, which is used for maintaining the rotation frame
-                        created_waveforms:
-                            list, a list of created waveform names
-                        ensemble_info:
-                            EnsembleAnalysisResult, information about the ensemble returned by
-                            analyze_block_ensemble
+        Returns
+        -------
+        tuple
+            Of length 3 with (offset_bin, created_waveforms, ensemble_info).
+        offset_bin
+            Integer, which is used for maintaining the rotation frame
+        created_waveforms
+            List, a list of created waveform names
+        ensemble_info
+            EnsembleAnalysisResult, information about the ensemble returned by
+            analyze_block_ensemble
 
         This method is creating the actual samples (voltages and logic states) for each time step
         of the analog and digital channels specified in the PulseBlockEnsemble.
@@ -2303,7 +2417,10 @@ class SequenceGeneratorLogic(LogicBase):
     def sample_pulse_sequence(self, sequence: Union[str, PulseSequence]):
         """Samples the PulseSequence object, which serves as the construction plan.
 
-        @param str|PulseSequence sequence: Name or instance of the PulseSequence to be sampled.
+        Parameters
+        ----------
+        sequence : str or PulseSequence
+            Name or instance of the PulseSequence to be sampled.
 
         The sequence object is sampled by call subsequently the sampling routine for the
         PulseBlockEnsemble objects and passing if needed the rotating frame option.

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -44,7 +44,6 @@ from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, Puls
 from qudi.logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElement
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType, SamplingFunctions
 from qudi.interface.pulser_interface import PulserInterface, SequenceOption
-from qudi.util.benchmark import BenchmarkTool
 
 from qudi.util.yaml import SafeRepresenter, SafeConstructor
 from qudi.util.yaml_helpers import (
@@ -58,6 +57,7 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     AnalogLevels,
     DigitalLevels,
     PulseGeneratorSettings,
+    SequenceGeneratorSettings,
     EnsembleAnalysisResult,
     SequenceAnalysisResult,
     SamplingInformation,
@@ -66,6 +66,7 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     SequenceSamplingState,
     PulserBenchmarks,
 )
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters
 
 SafeRepresenter.add_multi_representer(PulseEnvelope, dataclass_representer)
 SafeConstructor.add_constructor("!PulseEnvelope", pulse_envelope_constructor)
@@ -76,6 +77,39 @@ SafeConstructor.add_constructor("!SamplingInformation", sampling_information_con
 def _dataclass_to_dict(obj, exclude=()):
     """Shallow-flattens a dataclass instance into a plain dict, one level deep."""
     return {f.name: getattr(obj, f.name) for f in fields(obj) if f.name not in exclude}
+
+
+def _default_generator_settings():
+    """Factory for the default SequenceGeneratorSettings, used both as the StatusVar default
+    and as the fallback when restoring a malformed/legacy status value."""
+    return SequenceGeneratorSettings(
+        generation_parameters=GenerationParameters(
+            laser_channel='d_ch1',
+            sync_channel='',
+            gate_channel='',
+            microwave_channel='a_ch1',
+            microwave_frequency=2.87e9,
+            microwave_amplitude=0.0,
+            rabi_period=100e-9,
+            laser_length=3e-6,
+            laser_delay=500e-9,
+            wait_time=1e-6,
+            analog_trigger_voltage=0.0,
+            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
+            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
+            pulse_envelope_order=1,
+        ),
+        pulse_generator_settings=PulseGeneratorSettings(
+            activation_config=ActivationConfig(name='', channels=set()),
+            sample_rate=0.0,
+            analog_levels=AnalogLevels(amplitude=dict(), offset=dict()),
+            digital_levels=DigitalLevels(low=dict(), high=dict()),
+            interleave=False,
+            flags=set(),
+            upload_speed=np.nan,
+        ),
+        pulser_benchmarks=PulserBenchmarks(),
+    )
 
 
 class SequenceGeneratorLogic(LogicBase):
@@ -123,43 +157,16 @@ class SequenceGeneratorLogic(LogicBase):
     _disable_bench_prompt = ConfigOption(name='disable_benchmark_prompt', default=False, missing='nothing')
 
     # status vars
-    # Global parameters describing the channel usage and common parameters used during pulsed object
-    # generation for predefined methods.
-    _generation_parameters = StatusVar(
-        default=GenerationParameters(
-            laser_channel='d_ch1',
-            sync_channel='',
-            gate_channel='',
-            microwave_channel='a_ch1',
-            microwave_frequency=2.87e9,
-            microwave_amplitude=0.0,
-            rabi_period=100e-9,
-            laser_length=3e-6,
-            laser_delay=500e-9,
-            wait_time=1e-6,
-            analog_trigger_voltage=0.0,
-            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
-            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
-            pulse_envelope_order=1,
-        ),
-        constructor=lambda x: GenerationParameters.from_dict(x)
+    # Bundles the generation parameters (channel usage and common parameters used during
+    # pulsed object generation for predefined methods), the pulse generator hardware settings
+    # (activation config, sample rate, levels, ...) mirrored locally to avoid repeated slow
+    # hardware reads, and the write/load speed benchmarks into a single settings object instead
+    # of independently stored/persisted attributes.
+    _generator_settings = StatusVar(
+        default=_default_generator_settings(),
+        constructor=lambda x: SequenceGeneratorSettings.from_dict(x)
         if isinstance(x, dict)
-        else GenerationParameters(
-            laser_channel='d_ch1',
-            sync_channel='',
-            gate_channel='',
-            microwave_channel='a_ch1',
-            microwave_frequency=2.87e9,
-            microwave_amplitude=0.0,
-            rabi_period=100e-9,
-            laser_length=3e-6,
-            laser_delay=500e-9,
-            wait_time=1e-6,
-            analog_trigger_voltage=0.0,
-            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
-            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
-            pulse_envelope_order=1,
-        ),
+        else _default_generator_settings(),
         representer=lambda obj: obj.to_dict(),
     )
 
@@ -168,11 +175,6 @@ class SequenceGeneratorLogic(LogicBase):
     # _saved_pulse_blocks = StatusVar(default=OrderedDict())
     # _saved_pulse_block_ensembles = StatusVar(default=OrderedDict())
     # _saved_pulse_sequences = StatusVar(default=OrderedDict())
-
-    _benchmark_write = BenchmarkTool()
-    _benchmark_write_state = StatusVar(representer=_benchmark_write.save, constructor=_benchmark_write.load_from_dict)
-    _benchmark_load = BenchmarkTool()
-    _benchmark_load_state = StatusVar(representer=_benchmark_load.save, constructor=_benchmark_load.load_from_dict)
 
     # define signals
     sigBlockDictUpdated = QtCore.Signal(dict)
@@ -191,23 +193,6 @@ class SequenceGeneratorLogic(LogicBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # current pulse generator settings that are frequently used by this logic.
-        # Save them here since reading them from device every time they are used may take some time.
-        self.__pulse_generator_settings = PulseGeneratorSettings(
-            activation_config=ActivationConfig(name='', channels=set()),
-            sample_rate=0.0,
-            analog_levels=AnalogLevels(amplitude=dict(), offset=dict()),
-            digital_levels=DigitalLevels(low=dict(), high=dict()),
-            interleave=False,
-            flags=set(),
-            upload_speed=np.nan,
-        )
-
-        # Bundles the write/load BenchmarkTool instances used to estimate pulser upload speed.
-        # Wraps the existing class-level BenchmarkTool instances (not new ones), since those are
-        # bound to the _benchmark_write_state/_benchmark_load_state StatusVar persistence.
-        self.__pulser_benchmarks = PulserBenchmarks(write=self._benchmark_write, load=self._benchmark_load)
 
         # A flag indicating if sampling of a sequence is in progress
         self.__sequence_generation_in_progress = False
@@ -356,8 +341,26 @@ class SequenceGeneratorLogic(LogicBase):
         return self._predefined_path_list
 
     @property
+    def generator_settings(self):
+        """The full SequenceGeneratorSettings object (generation_parameters,
+        pulse_generator_settings, pulser_benchmarks bundled together)."""
+        return self._generator_settings
+
+    def _update_pulse_generator_settings(self, **changes):
+        """Replace one or more fields of the nested PulseGeneratorSettings, preserving the
+        identity of every other field of self._generator_settings (including the shared
+        pulser_benchmarks object)."""
+        self._generator_settings = replace(
+            self._generator_settings,
+            pulse_generator_settings=replace(
+                self._generator_settings.pulse_generator_settings, **changes
+            ),
+        )
+        return
+
+    @property
     def pulse_generator_settings(self):
-        return self.__pulse_generator_settings.to_dict()
+        return self._generator_settings.pulse_generator_settings.to_dict()
 
     @pulse_generator_settings.setter
     def pulse_generator_settings(self, settings_dict):
@@ -381,13 +384,11 @@ class SequenceGeneratorLogic(LogicBase):
 
     @property
     def analog_channels(self):
-        channels = self.__pulse_generator_settings.activation_config.channels
-        return {chnl for chnl in channels if chnl.startswith('a_ch')}
+        return self._generator_settings.pulse_generator_settings.analog_channels
 
     @property
     def digital_channels(self):
-        channels = self.__pulse_generator_settings.activation_config.channels
-        return {chnl for chnl in channels if chnl.startswith('d_ch')}
+        return self._generator_settings.pulse_generator_settings.digital_channels
 
     @property
     def loaded_asset(self):
@@ -439,8 +440,7 @@ class SequenceGeneratorLogic(LogicBase):
                 if isinstance(activation_config, str):
                     if activation_config in available_configs.keys():
                         set_config = self._apply_activation_config(available_configs[activation_config])
-                        self.__pulse_generator_settings = replace(
-                            self.__pulse_generator_settings,
+                        self._update_pulse_generator_settings(
                             activation_config=ActivationConfig(name=activation_config, channels=set_config),
                         )
                     else:
@@ -453,8 +453,7 @@ class SequenceGeneratorLogic(LogicBase):
                     if activation_config in available_configs.values():
                         set_config = self._apply_activation_config(activation_config)
                         config_name = list(available_configs)[list(available_configs.values()).index(activation_config)]
-                        self.__pulse_generator_settings = replace(
-                            self.__pulse_generator_settings,
+                        self._update_pulse_generator_settings(
                             activation_config=ActivationConfig(name=config_name, channels=set_config),
                         )
                     else:
@@ -466,8 +465,7 @@ class SequenceGeneratorLogic(LogicBase):
                 elif isinstance(activation_config, tuple):
                     if activation_config in available_configs.items():
                         set_config = self._apply_activation_config(activation_config[1])
-                        self.__pulse_generator_settings = replace(
-                            self.__pulse_generator_settings,
+                        self._update_pulse_generator_settings(
                             activation_config=ActivationConfig(name=activation_config[0], channels=set_config),
                         )
                     else:
@@ -479,8 +477,7 @@ class SequenceGeneratorLogic(LogicBase):
                 # Check if the ultimately set config is part of the constraints
                 if set_config is not None and set_config not in available_configs.values():
                     self.log.error('Something went wrong while setting new activation config.')
-                    self.__pulse_generator_settings = replace(
-                        self.__pulse_generator_settings,
+                    self._update_pulse_generator_settings(
                         activation_config=ActivationConfig(name='', channels=set_config),
                     )
 
@@ -489,7 +486,7 @@ class SequenceGeneratorLogic(LogicBase):
                 changed_settings = dict()
                 ana_chnls = natural_sort(self.analog_channels)
                 digi_chnls = natural_sort(self.digital_channels)
-                active_channels = self.__pulse_generator_settings.activation_config.channels
+                active_channels = self._generator_settings.pulse_generator_settings.activation_config.channels
                 for name in [setting for setting in self.generation_parameters if setting.endswith('_channel')]:
                     channel = self.generation_parameters[name]
                     if isinstance(channel, str) and channel not in active_channels:
@@ -508,34 +505,28 @@ class SequenceGeneratorLogic(LogicBase):
                             changed_settings[name] = new_channel
 
             if 'sample_rate' in settings_dict:
-                self.__pulse_generator_settings = replace(
-                    self.__pulse_generator_settings,
+                self._update_pulse_generator_settings(
                     sample_rate=self.pulsegenerator().set_sample_rate(float(settings_dict['sample_rate'])),
                 )
 
             if 'analog_levels' in settings_dict:
                 amplitude, offset = self.pulsegenerator().set_analog_level(*settings_dict['analog_levels'])
-                self.__pulse_generator_settings = replace(
-                    self.__pulse_generator_settings,
+                self._update_pulse_generator_settings(
                     analog_levels=AnalogLevels(amplitude=amplitude, offset=offset),
                 )
 
             if 'digital_levels' in settings_dict:
                 low, high = self.pulsegenerator().set_digital_level(*settings_dict['digital_levels'])
-                self.__pulse_generator_settings = replace(
-                    self.__pulse_generator_settings,
+                self._update_pulse_generator_settings(
                     digital_levels=DigitalLevels(low=low, high=high),
                 )
 
             if 'interleave' in settings_dict:
-                self.__pulse_generator_settings = replace(
-                    self.__pulse_generator_settings,
+                self._update_pulse_generator_settings(
                     interleave=self.pulsegenerator().set_interleave(bool(settings_dict['interleave'])),
                 )
 
-            self.__pulse_generator_settings = replace(
-                self.__pulse_generator_settings, upload_speed=self.get_speed_write_load()
-            )
+            self._update_pulse_generator_settings(upload_speed=self.get_speed_write_load())
 
         elif len(kwargs) != 0 or isinstance(settings_dict, dict):
             # Only throw warning when arguments have been passed to this method
@@ -615,7 +606,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.log.error('Can´t load a waveform, because pulser running. Switch off the pulser and try again.')
                 return -1
 
-            t_est_upload = self._benchmark_load.estimate_time(ensemble.sampling_information.number_of_samples)
+            t_est_upload = self._generator_settings.pulser_benchmarks.load.estimate_time(ensemble.sampling_information.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -627,7 +618,7 @@ class SequenceGeneratorLogic(LogicBase):
             # Actually load the waveforms to the generic channels
             start_time = time.perf_counter()
             self.pulsegenerator().load_waveform(ensemble.sampling_information.waveforms)
-            self._benchmark_load.add_benchmark(
+            self._generator_settings.pulser_benchmarks.load.add_benchmark(
                 time.perf_counter() - start_time, ensemble.sampling_information.number_of_samples
             )
         else:
@@ -714,8 +705,7 @@ class SequenceGeneratorLogic(LogicBase):
         # Read sample rate, analog/digital levels, interleave flag and available flags from device
         amplitude, offset = self.pulsegenerator().get_analog_level()
         low, high = self.pulsegenerator().get_digital_level()
-        self.__pulse_generator_settings = replace(
-            self.__pulse_generator_settings,
+        self._update_pulse_generator_settings(
             activation_config=activation_config,
             sample_rate=float(self.pulsegenerator().get_sample_rate()),
             analog_levels=AnalogLevels(amplitude=amplitude, offset=offset),
@@ -756,7 +746,7 @@ class SequenceGeneratorLogic(LogicBase):
 
     @property
     def generation_parameters(self):
-        return self._generation_parameters.to_dict()
+        return self._generator_settings.generation_parameters.to_dict()
 
     @generation_parameters.setter
     def generation_parameters(self, settings_dict):
@@ -803,7 +793,7 @@ class SequenceGeneratorLogic(LogicBase):
 
             # Discard unknown keys. GenerationParameters has a fixed schema, so (unlike the old
             # plain dict) it cannot store arbitrary additional settings.
-            known_keys = self._generation_parameters.to_dict().keys()
+            known_keys = self._generator_settings.generation_parameters.to_dict().keys()
             for key in list(settings_dict):
                 if key not in known_keys:
                     self.log.warning(
@@ -812,7 +802,7 @@ class SequenceGeneratorLogic(LogicBase):
                     )
                     del settings_dict[key]
             # Sanity checks
-            active_channels = self.__pulse_generator_settings.activation_config.channels
+            active_channels = self._generator_settings.pulse_generator_settings.activation_config.channels
             if settings_dict.get('laser_channel'):
                 if settings_dict['laser_channel'] not in active_channels:
                     self.log.error(
@@ -847,7 +837,12 @@ class SequenceGeneratorLogic(LogicBase):
                     del settings_dict['microwave_channel']
 
             # update settings dict
-            self._generation_parameters = self._generation_parameters.update_from_dict(settings_dict)
+            self._generator_settings = replace(
+                self._generator_settings,
+                generation_parameters=self._generator_settings.generation_parameters.update_from_dict(
+                    settings_dict
+                ),
+            )
         else:
             self.log.error(
                 'Unable to apply new sampling settings.\nSequenceGeneratorLogic is busy generating a waveform/sequence.'
@@ -1284,7 +1279,7 @@ class SequenceGeneratorLogic(LogicBase):
             self.save_block(block)
         for ensemble in ensembles:
             ensemble.sampling_information = SamplingInformation()
-            ensemble.generation_method_parameters = kwargs_dict
+            ensemble.generation_method_parameters = GenerationMethodParameters(kwargs_dict)
             self.save_ensemble(ensemble)
 
         if self.pulse_generator_constraints.sequence_option == SequenceOption.FORCED and len(sequences) < 1:
@@ -1297,7 +1292,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         for sequence in sequences:
             sequence.sampling_information = SamplingInformation()
-            sequence.generation_method_parameters = kwargs_dict
+            sequence.generation_method_parameters = GenerationMethodParameters(kwargs_dict)
             self.save_sequence(sequence)
 
         created_name = gen_params.get('name') if 'name' not in kwargs_dict else kwargs_dict['name']
@@ -1355,7 +1350,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         info = self.analyze_block_ensemble(ensemble=ensemble)
         ens_bins = info.number_of_samples
-        ens_length = ens_bins / self.__pulse_generator_settings.sample_rate
+        ens_length = ens_bins / self._generator_settings.pulse_generator_settings.sample_rate
         ens_lasers = min(len(info.laser_rising_bins), len(info.laser_falling_bins))
         return AssetInfo(length_s=ens_length, length_bins=ens_bins, number_of_lasers=ens_lasers)
 
@@ -1378,7 +1373,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         info = self.analyze_sequence(sequence=sequence)
         length_bins = info.number_of_samples
-        length_s = length_bins / self.__pulse_generator_settings.sample_rate if sequence.is_finite else np.inf
+        length_s = length_bins / self._generator_settings.pulse_generator_settings.sample_rate if sequence.is_finite else np.inf
 
         if len(laser_channel) > 0 and laser_channel[0] == 'd' and sequence.is_finite:
             number_of_lasers = len(info.digital_rising_bins[laser_channel])
@@ -1508,7 +1503,7 @@ class SequenceGeneratorLogic(LogicBase):
                     current_end_time += element.init_length_s + rep_no * element.increment_s
 
                     # Nearest possible match including the discretization in bins
-                    current_end_bin = int(np.rint(current_end_time * self.__pulse_generator_settings.sample_rate))
+                    current_end_bin = int(np.rint(current_end_time * self._generator_settings.pulse_generator_settings.sample_rate))
 
                     # append current element length in discrete bins to temporary array
                     elements_length_bins.append(current_end_bin - current_start_bin)
@@ -1540,7 +1535,7 @@ class SequenceGeneratorLogic(LogicBase):
             analog_channels=analog_channels,
             digital_channels=digital_channels,
             channel_set=analog_channels.union(digital_channels),
-            generation_parameters=self.generation_parameters.copy(),
+            generation_parameters=self._generator_settings.generation_parameters,
             ideal_length=current_end_time,
             laser_rising_bins=laser_rising_bins,
             laser_falling_bins=laser_falling_bins,
@@ -1756,7 +1751,7 @@ class SequenceGeneratorLogic(LogicBase):
             digital_channels=digital_channels,
             analog_channels=analog_channels,
             channel_set=analog_channels.union(digital_channels),
-            generation_parameters=self.generation_parameters.copy(),
+            generation_parameters=self._generator_settings.generation_parameters,
             digital_rising_bins=digital_rising_bins,
             digital_falling_bins=digital_falling_bins,
             number_of_steps=len(sequence),
@@ -1776,7 +1771,7 @@ class SequenceGeneratorLogic(LogicBase):
     def _sampling_ensemble_sanity_check(self, ensemble):
         blocks_missing = set()
         channel_activation_mismatch = False
-        active_channels = self.__pulse_generator_settings.activation_config.channels
+        active_channels = self._generator_settings.pulse_generator_settings.activation_config.channels
         for block_name, reps in ensemble.block_list:
             block = self._saved_pulse_blocks.get(block_name)
             # Check if block is present
@@ -1922,7 +1917,7 @@ class SequenceGeneratorLogic(LogicBase):
                 extension_samples = granularity - ensemble_info.number_of_samples % granularity
                 target_total_samples = ensemble_info.number_of_samples + extension_samples
                 extension_seconds = (
-                    target_total_samples / self.__pulse_generator_settings.sample_rate
+                    target_total_samples / self._generator_settings.pulse_generator_settings.sample_rate
                 ) - ensemble_info.ideal_length
 
                 pb_element = PulseBlockElement(
@@ -2007,7 +2002,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.sigSampleEnsembleComplete.emit(None)
                 return -1, list(), dict()
 
-            t_est_upload = self._benchmark_write.estimate_time(ensemble_info.number_of_samples)
+            t_est_upload = self._generator_settings.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -2047,7 +2042,7 @@ class SequenceGeneratorLogic(LogicBase):
                             if pulse_function:
                                 time_arr = (
                                     offset_bin + np.arange(samples_to_add, dtype='float64')
-                                ) / self.__pulse_generator_settings.sample_rate
+                                ) / self._generator_settings.pulse_generator_settings.sample_rate
 
                             # Calculate respective part of the sample arrays
                             for chnl in digital_high:
@@ -2057,7 +2052,7 @@ class SequenceGeneratorLogic(LogicBase):
                             for chnl in pulse_function:
                                 analog_samples[chnl][array_write_index : array_write_index + samples_to_add] = (
                                     pulse_function[chnl].get_samples(time_arr)
-                                    / (self.__pulse_generator_settings.analog_levels.amplitude[chnl] / 2)
+                                    / (self._generator_settings.pulse_generator_settings.analog_levels.amplitude[chnl] / 2)
                                 )
 
                             # Free memory
@@ -2142,13 +2137,13 @@ class SequenceGeneratorLogic(LogicBase):
             )
             self.log.debug(
                 'Estimated {:.3f} s from current estimated write speed {:.2f} MSa/s from {} benchmarks'.format(
-                    self._benchmark_write.estimate_time(ensemble_info.number_of_samples),
-                    self._benchmark_write.estimate_speed() / 1e6,
-                    self._benchmark_write.n_benchmarks,
+                    self._generator_settings.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples),
+                    self._generator_settings.pulser_benchmarks.write.estimate_speed() / 1e6,
+                    self._generator_settings.pulser_benchmarks.write.n_benchmarks,
                 )
             )
 
-            self._benchmark_write.add_benchmark(time.time() - start_time, ensemble_info.number_of_samples)
+            self._generator_settings.pulser_benchmarks.write.add_benchmark(time.time() - start_time, ensemble_info.number_of_samples)
 
             if ensemble_info.number_of_samples == 0:
                 self.log.warning(
@@ -2394,7 +2389,7 @@ class SequenceGeneratorLogic(LogicBase):
                 granularity = constraints.waveform_length.step
                 return np.ceil(n_samples / granularity) * granularity
 
-            self.__pulser_benchmarks.reset()
+            self._generator_settings.pulser_benchmarks.reset()
 
             n_samples_min = constraints.waveform_length.min
             n_max_fix = max(10e6, n_samples_min)
@@ -2419,7 +2414,7 @@ class SequenceGeneratorLogic(LogicBase):
             while time.perf_counter() - t_start < t_goal and rescode == 0:
                 speed = self.get_speed_write_load()
                 t_left = t_goal - (time.perf_counter() - t_start)
-                if self.__pulser_benchmarks.write.sanity and self.__pulser_benchmarks.load.sanity:
+                if self._generator_settings.pulser_benchmarks.write.sanity and self._generator_settings.pulser_benchmarks.load.sanity:
                     n_samples = speed * t_left / time_fraction
                     n_samples = round_to_granularity(n_samples)
                 else:  # poor speed estimate so far
@@ -2436,8 +2431,8 @@ class SequenceGeneratorLogic(LogicBase):
                     "Running benchmark. Current speed (write/load/tot): "
                     "{:.3f} / {:.3f} / {:.3f} MSa/s): {} samples for"
                     " estimated {:.5f} s, {:.5f} s left".format(
-                        self._benchmark_write.estimate_speed() / 1e6,
-                        self._benchmark_load.estimate_speed() / 1e6,
+                        self._generator_settings.pulser_benchmarks.write.estimate_speed() / 1e6,
+                        self._generator_settings.pulser_benchmarks.load.estimate_speed() / 1e6,
                         speed / 1e6,
                         n_samples,
                         t_est,
@@ -2551,7 +2546,7 @@ class SequenceGeneratorLogic(LogicBase):
             )
 
         if not ignore_datapoint:
-            self._benchmark_write.add_benchmark(
+            self._generator_settings.pulser_benchmarks.write.add_benchmark(
                 time.perf_counter() - start_time, n_samples, is_persistent=persistent_datapoint
             )
 
@@ -2559,7 +2554,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         loaded_dict = self.pulsegenerator().load_waveform(wfm_list)
         if not ignore_datapoint:
-            self._benchmark_load.add_benchmark(
+            self._generator_settings.pulser_benchmarks.load.add_benchmark(
                 time.perf_counter() - start_time, n_samples, is_persistent=persistent_datapoint
             )
 
@@ -2573,14 +2568,14 @@ class SequenceGeneratorLogic(LogicBase):
         return 0, list(), dict()
 
     def has_valid_pg_benchmark(self):
-        return self.__pulser_benchmarks.has_valid_estimate(ignore=self._disable_bench_prompt)
+        return self._generator_settings.pulser_benchmarks.has_valid_estimate(ignore=self._disable_bench_prompt)
 
     def get_speed_write_load(self):
         """
         Get the estimated speed of the pulse generator for writing and loading a waveform.
         :return: speed (Sa/s)
         """
-        return self.__pulser_benchmarks.estimate_combined_speed()
+        return self._generator_settings.pulser_benchmarks.estimate_combined_speed()
     
     def _migrate_legacy_sampling_information(self, loaded_object):
         """

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -53,7 +53,8 @@ from qudi.util.yaml_helpers import (
     sampling_information_constructor,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
-    GenerationParameters,
+    generation_parameters_class,
+    rebuild_generation_parameters,
     ActivationConfig,
     AnalogLevels,
     DigitalLevels,
@@ -66,7 +67,6 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     LoadedAsset,
     SequenceSamplingState,
     PulserBenchmarks,
-    _DEFAULT_GENERATION_PARAMETERS,
     _DEFAULT_PULSE_GENERATOR_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters, MeasurementInformation
@@ -91,14 +91,16 @@ def _default_generator_settings():
     """Factory for the default SequenceGeneratorSettings, used both as the StatusVar default
     and as the fallback when restoring a malformed/legacy status value.
 
-    generation_parameters/pulse_generator_settings reuse the single shared default instances
-    defined in sequence_generator_logic_data.py (that file can't import back from this one, so
-    it owns these literals rather than duplicating them here) - SequenceGeneratorSettings.
-    from_dict() falls back to the exact same instances when a saved settings file is missing one
-    of these keys.
+    pulse_generator_settings reuses the shared default instance defined in
+    sequence_generator_logic_data.py (that file can't import back from this one, so it owns these
+    literals rather than duplicating them here) - SequenceGeneratorSettings.from_dict() falls back
+    to the same instance when a saved settings file is missing that key.
+
+    The generation parameters are built fresh from whichever class is currently in effect, since
+    rebuild_generation_parameters() may have replaced it since import.
     """
     return SequenceGeneratorSettings(
-        generation_parameters=_DEFAULT_GENERATION_PARAMETERS,
+        generation_parameters=generation_parameters_class()(),
         pulse_generator_settings=_DEFAULT_PULSE_GENERATOR_SETTINGS,
     )
 
@@ -346,6 +348,66 @@ class SequenceGeneratorLogic(LogicBase):
         if isinstance(nested, dict) and nested.get('pulser_benchmarks'):
             self.pulser_benchmarks = PulserBenchmarks.from_dict(nested['pulser_benchmarks'])
 
+    def _merge_generator_declared_parameters(self):
+        """Fold the predefined generators' declared generation parameters into the schema.
+
+        Runs during activation because that is the first moment the generator classes exist: the
+        import-time merge in sequence_generator_logic_data.py only sees what
+        generation_parameter_extensions.py declares, not what comes in via
+        additional_predefined_methods_path.
+
+        Anything the new fields had saved is read back from the status file here. The StatusVar
+        restore already ran against the previous schema and dropped those keys, so without this a
+        generator-declared parameter would reset to its default on every launch.
+        """
+        declared = self._pog.collect_generation_parameter_contributors()
+        if not declared:
+            return
+
+        previous_cls = generation_parameters_class()
+        merged_cls = rebuild_generation_parameters(declared)
+        if merged_cls is previous_cls:
+            # Either nothing new to add, or the merge was rejected and has already logged why.
+            return
+
+        values = self._generator_settings.generation_parameters.to_dict()
+        for key, value in self._saved_generation_parameters().items():
+            # Only the newly added fields: the live values above already went through the restore
+            # and any legacy migration, so they win over what is on disk.
+            if key not in values:
+                values[key] = value
+
+        self._generator_settings = replace(
+            self._generator_settings, generation_parameters=merged_cls.from_dict(values)
+        )
+        self.log.debug(
+            'Generation parameters declared by predefined generators: {0}.'.format(
+                ', '.join(name for cls in declared for name in cls._own_field_names())
+            )
+        )
+        self.sigSamplingSettingsUpdated.emit(self.generation_parameters)
+
+    def _saved_generation_parameters(self):
+        """The generation parameters as they sit in the status file, in either storage format.
+
+        Returns
+        -------
+        dict
+            Empty if the file is absent, unreadable or holds no generation parameters.
+        """
+        file_path = get_module_app_data_path(self.__class__.__name__, self.module_base, self.module_name)
+        try:
+            raw_status = yaml_load(file_path, ignore_missing=True)
+        except Exception:
+            self.log.exception('Failed to read status file while restoring generation parameters:')
+            return dict()
+
+        settings = raw_status.get('_generator_settings')
+        if isinstance(settings, dict) and isinstance(settings.get('generation_parameters'), dict):
+            return settings['generation_parameters']
+        legacy = raw_status.get('_generation_parameters')
+        return legacy if isinstance(legacy, dict) else dict()
+
     def on_activate(self):
         """Initialisation performed during activation of the module."""
         # Must run first - self._generator_settings has already been restored (or defaulted) by
@@ -411,6 +473,8 @@ class SequenceGeneratorLogic(LogicBase):
 
         # Get instance of PulseObjectGenerator which takes care of collecting all predefined methods
         self._pog = PulseObjectGenerator(sequencegeneratorlogic=self)
+        # Before activate_plugins(), so a plugin already sees the full parameter set.
+        self._merge_generator_declared_parameters()
         self._pog.activate_plugins()
 
         self.__sequence_generation_in_progress = False
@@ -910,7 +974,7 @@ class SequenceGeneratorLogic(LogicBase):
 
     @generation_parameters.setter
     def generation_parameters(self, settings):
-        if not isinstance(settings, (GenerationParameters, dict)):
+        if not isinstance(settings, (generation_parameters_class(), dict)):
             raise SettingsTypeError(f'generation_parameters expects GenerationParameters or dict, '
                                     f'got {type(settings).__name__}')
         self.set_generation_parameters(settings)
@@ -947,7 +1011,8 @@ class SequenceGeneratorLogic(LogicBase):
             # Warn about unknown keys before coercion. GenerationParameters has a fixed schema, so
             # (unlike the old plain dict) it cannot store arbitrary additional settings, and
             # update_from_dict() would drop them without a word.
-            known_keys = {f.name for f in fields(GenerationParameters)}
+            gen_params_cls = generation_parameters_class()
+            known_keys = {f.name for f in fields(gen_params_cls)}
             if isinstance(settings, dict):
                 settings = {k: v for k, v in settings.items()
                             if k in known_keys or self._warn_unknown_generation_parameter(k)}
@@ -955,7 +1020,7 @@ class SequenceGeneratorLogic(LogicBase):
                       if k in known_keys or self._warn_unknown_generation_parameter(k)}
 
             try:
-                requested = coerce_settings(settings, kwargs, current, GenerationParameters)
+                requested = coerce_settings(settings, kwargs, current, gen_params_cls)
             except SettingsTypeError as err:
                 # Logged rather than raised: this is a queued cross-thread slot, where an escaping
                 # exception cannot reach the emitter and may take the whole application down.
@@ -972,7 +1037,7 @@ class SequenceGeneratorLogic(LogicBase):
             # extension declaring its own channel parameter gets the same validation - matching
             # the suffix-based healing loop in set_pulse_generator_settings().
             active_channels = self._generator_settings.pulse_generator_settings.activation_config.channels
-            for field_name in (f.name for f in fields(GenerationParameters) if f.name.endswith('_channel')):
+            for field_name in (f.name for f in fields(gen_params_cls) if f.name.endswith('_channel')):
                 channel = getattr(requested, field_name)
                 if (isinstance(channel, str) and channel
                         and channel != getattr(current, field_name)
@@ -999,8 +1064,12 @@ class SequenceGeneratorLogic(LogicBase):
     def _warn_unknown_generation_parameter(self, key):
         """Log an ignored generation parameter name. Always returns False so it can be used as the
         filtering half of a comprehension guard."""
-        self.log.warning('Setting by name "{0}" not present in generation_parameters.\n'
-                         'Ignoring it.'.format(key))
+        self.log.warning(
+            'Setting by name "{0}" not present in generation_parameters. Ignoring it.\n'
+            'Generation parameters are a fixed schema, so a new one has to be declared: on the '
+            'generator class that needs it via generation_parameter_contributors, or in '
+            'generation_parameter_extensions.py if the whole setup shares it.'.format(key)
+        )
         return False
 
     def save_block(self, block):

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -146,7 +146,12 @@ def _resolve_asset_closure(asset, saved_pulse_block_ensembles, saved_pulse_block
     blocks = {}
     missing_blocks = set()
 
-    if isinstance(asset, PulseSequence):
+    # Tri-state on purpose: True/False come from PulseSequence.is_sequence and
+    # PulseBlockEnsemble.is_sequence, while None means "not a pulse asset at all" and keeps the
+    # error branch below reachable - a bare `asset.is_sequence` would raise AttributeError there.
+    asset_is_sequence = getattr(asset, 'is_sequence', None)
+
+    if asset_is_sequence is True:
         ensembles = {}
         missing_ensembles = set()
         for seq_step in asset.ensemble_list:
@@ -165,7 +170,7 @@ def _resolve_asset_closure(asset, saved_pulse_block_ensembles, saved_pulse_block
                 '"{0}" while building its closure (they may have been deleted from the library '
                 'since this sequence was generated): {1}'.format(asset.name, missing_ensembles)
             )
-    elif isinstance(asset, PulseBlockEnsemble):
+    elif asset_is_sequence is False:
         ensembles = {}
         _resolve_blocks(asset, missing_blocks, blocks)
     else:
@@ -270,6 +275,10 @@ class SequenceGeneratorLogic(LogicBase):
     sigAvailableSequencesUpdated = QtCore.Signal(list)
     sigBenchmarkComplete = QtCore.Signal()
 
+    #: (asset_name, produced_sequence). The bool reports whether the generate method returned any
+    #: PulseSequence, which is what decides between sample_sequence() and sample_ensemble()
+    #: downstream. It is NOT the same question as PulseSequence.is_sequence, which asks whether a
+    #: given object is a sequence.
     sigPredefinedSequenceGenerated = QtCore.Signal(object, bool)
 
     def __init__(self, *args, **kwargs):
@@ -1510,7 +1519,20 @@ class SequenceGeneratorLogic(LogicBase):
             self.save_sequence(sequence)
 
         created_name = gen_params.get('name') if 'name' not in kwargs_dict else kwargs_dict['name']
-        self.sigPredefinedSequenceGenerated.emit(created_name, len(sequences) > 0)
+        # Ask the created asset itself instead of inferring from "did this method return any
+        # sequences at all" - the downstream decision is sample_sequence() vs sample_ensemble() for
+        # this one name, so the object carrying that name is what actually answers it.
+        # Sequences are searched first because _add_default_sequence() names its PulseSequence
+        # after ensembles[0], so both lists can hold `created_name` - and the sequence is the one
+        # that gets loaded. Falls back to the old proxy if no object carries the name, e.g. a
+        # generate method that renames what it returns.
+        created_asset = next(
+            (asset for asset in (*sequences, *ensembles) if asset.name == created_name), None
+        )
+        produced_sequence = (
+            created_asset.is_sequence if created_asset is not None else len(sequences) > 0
+        )
+        self.sigPredefinedSequenceGenerated.emit(created_name, produced_sequence)
         return
 
     def _add_default_sequence(self, ensembles, sequences):

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -20,12 +20,13 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-from dataclasses import replace, fields
+from dataclasses import replace, fields, is_dataclass, MISSING
 from enum import Enum
 from typing import Optional, Union
 import numpy as np
 import os
 import pickle
+import shutil
 import time
 import copy
 import traceback
@@ -36,7 +37,7 @@ from PySide6 import QtCore
 from qudi.core.statusvariable import StatusVar
 from qudi.core.connector import Connector
 from qudi.core.configoption import ConfigOption
-from qudi.util.paths import get_home_dir
+from qudi.util.paths import get_home_dir, get_module_app_data_path
 from qudi.util.helpers import natural_sort
 from qudi.util.network import netobtain
 from qudi.core.module import LogicBase
@@ -45,7 +46,7 @@ from qudi.logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElem
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, SamplingFunctions
 from qudi.interface.pulser_interface import PulserInterface, SequenceOption
 
-from qudi.util.yaml import SafeRepresenter, SafeConstructor
+from qudi.util.yaml import SafeRepresenter, SafeConstructor, yaml_load
 from qudi.util.yaml_helpers import (
     dataclass_representer,
     pulse_envelope_constructor,
@@ -68,7 +69,7 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     _DEFAULT_GENERATION_PARAMETERS,
     _DEFAULT_PULSE_GENERATOR_SETTINGS,
 )
-from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters, MeasurementInformation
 
 SafeRepresenter.add_multi_representer(PulseEnvelope, dataclass_representer)
 SafeConstructor.add_constructor("!PulseEnvelope", pulse_envelope_constructor)
@@ -94,8 +95,75 @@ def _default_generator_settings():
     return SequenceGeneratorSettings(
         generation_parameters=_DEFAULT_GENERATION_PARAMETERS,
         pulse_generator_settings=_DEFAULT_PULSE_GENERATOR_SETTINGS,
-        pulser_benchmarks=PulserBenchmarks(),
     )
+
+
+def _resolve_asset_closure(asset, saved_pulse_block_ensembles, saved_pulse_blocks, log):
+    """Walk `asset`'s block/ensemble NAME references and return independent copies of everything
+    it points to - see PulseObjects (pulsed_data/pulsed_measurement.py) for why this exists.
+
+    Missing referenced names are logged as a combined warning and skipped rather than raising -
+    a best-effort, partially-resolved snapshot is still useful for saving/inspection.
+
+    @param asset: the currently loaded PulseBlockEnsemble or PulseSequence, or None if nothing is
+        loaded.
+    @param dict saved_pulse_block_ensembles: SequenceGeneratorLogic._saved_pulse_block_ensembles
+    @param dict saved_pulse_blocks: SequenceGeneratorLogic._saved_pulse_blocks
+    @param log: logger to warn through (SequenceGeneratorLogic.log)
+    @return (ensembles, blocks): {name: independent copy}. `ensembles` is empty if `asset` is a
+        bare PulseBlockEnsemble or None. `blocks` covers every PulseBlock referenced by
+        `ensembles`, or referenced directly by `asset` if it is a bare PulseBlockEnsemble.
+    """
+
+    def _resolve_blocks(ensemble, missing_out, blocks_out):
+        for block_name, _reps in ensemble.block_list:
+            if block_name in blocks_out or block_name in missing_out:
+                continue
+            block = saved_pulse_blocks.get(block_name)
+            if block is None:
+                missing_out.add(block_name)
+            else:
+                blocks_out[block_name] = block.copy()
+
+    if asset is None:
+        return {}, {}
+
+    blocks = {}
+    missing_blocks = set()
+
+    if isinstance(asset, PulseSequence):
+        ensembles = {}
+        missing_ensembles = set()
+        for seq_step in asset.ensemble_list:
+            name = seq_step.ensemble
+            if name in ensembles or name in missing_ensembles:
+                continue
+            ensemble = saved_pulse_block_ensembles.get(name)
+            if ensemble is None:
+                missing_ensembles.add(name)
+                continue
+            ensembles[name] = ensemble.copy()
+            _resolve_blocks(ensemble, missing_blocks, blocks)
+        if missing_ensembles:
+            log.warning(
+                'Could not resolve the following PulseBlockEnsemble(s) referenced by PulseSequence '
+                '"{0}" while building its closure (they may have been deleted from the library '
+                'since this sequence was generated): {1}'.format(asset.name, missing_ensembles)
+            )
+    elif isinstance(asset, PulseBlockEnsemble):
+        ensembles = {}
+        _resolve_blocks(asset, missing_blocks, blocks)
+    else:
+        log.error('Cannot resolve closure for unsupported loaded asset type "{0}".'.format(type(asset)))
+        return {}, {}
+
+    if missing_blocks:
+        log.warning(
+            'Could not resolve the following PulseBlock(s) referenced by "{0}" while building its '
+            'closure (they may have been deleted from the library since generation): {1}'
+            ''.format(asset.name, missing_blocks)
+        )
+    return ensembles, blocks
 
 
 class SequenceGeneratorLogic(LogicBase):
@@ -144,16 +212,28 @@ class SequenceGeneratorLogic(LogicBase):
 
     # status vars
     # Bundles the generation parameters (channel usage and common parameters used during
-    # pulsed object generation for predefined methods), the pulse generator hardware settings
+    # pulsed object generation for predefined methods) and the pulse generator hardware settings
     # (activation config, sample rate, levels, ...) mirrored locally to avoid repeated slow
-    # hardware reads, and the write/load speed benchmarks into a single settings object instead
-    # of independently stored/persisted attributes.
+    # hardware reads into a single settings object instead of independently stored/persisted
+    # attributes.
     _generator_settings = StatusVar(
         default=_default_generator_settings(),
         constructor=lambda x: SequenceGeneratorSettings.from_dict(x)
         if isinstance(x, dict)
         else _default_generator_settings(),
         representer=lambda obj: obj.to_dict(),
+    )
+
+    # pulser_benchmarks is deliberately an independent StatusVar, NOT part of
+    # SequenceGeneratorSettings/_generator_settings above - it's runtime telemetry (hardware
+    # upload/download speed statistics), not a measurement-defining setting. `value` here already
+    # *is* the live PulserBenchmarks object (a genuinely per-instance attribute, unlike the
+    # pre-refactor class-level singleton BenchmarkTool instances this replaces), so the
+    # representer/constructor need no `self` at all.
+    pulser_benchmarks = StatusVar(
+        default=None,
+        constructor=lambda value: PulserBenchmarks.from_dict(value) if isinstance(value, dict) else PulserBenchmarks(),
+        representer=lambda value: value.to_dict(),
     )
 
     # The created pulse objects (PulseBlock, PulseBlockEnsemble, PulseSequence) are saved in
@@ -192,8 +272,62 @@ class SequenceGeneratorLogic(LogicBase):
         self._saved_pulse_block_ensembles = dict()
         self._saved_pulse_sequences = dict()
 
+    def _migrate_legacy_settings_if_needed(self):
+        """One-time upgrade path for a status file saved by either the pre-refactor version of
+        this module (separate '_generation_parameters'/'_benchmark_write_state'/
+        '_benchmark_load_state' StatusVars instead of one '_generator_settings' key), or a later
+        format with pulser_benchmarks nested inside '_generator_settings' instead of its own
+        independent StatusVar. See PulsedMeasurementLogic._migrate_legacy_settings_if_needed()
+        for the full explanation - same mechanism here.
+        """
+        file_path = get_module_app_data_path(self.__class__.__name__, self.module_base, self.module_name)
+        try:
+            raw_status = yaml_load(file_path, ignore_missing=True)
+        except Exception:
+            self.log.exception('Failed to read status file while checking for legacy settings format:')
+            return
+
+        if '_generator_settings' not in raw_status and SequenceGeneratorSettings.LEGACY_STATUS_VAR_KEYS.intersection(raw_status):
+            self.log.warning(
+                'Found generator settings saved by a pre-refactor version of this module '
+                '(individually-keyed generation parameters/benchmark StatusVars instead of the '
+                'current consolidated format). Migrating them now instead of silently resetting to '
+                'defaults. The original file has been backed up to "{0}.legacy_backup".'.format(file_path)
+            )
+            try:
+                backup_path = file_path + '.legacy_backup'
+                if not os.path.exists(backup_path):
+                    shutil.copy2(file_path, backup_path)
+            except Exception:
+                self.log.exception(
+                    'Failed to back up legacy status file before migrating (continuing anyway):'
+                )
+
+            try:
+                self._generator_settings = SequenceGeneratorSettings.from_legacy_dict(raw_status)
+            except Exception:
+                self.log.exception('Failed to migrate legacy generator settings - keeping defaults:')
+
+            self.pulser_benchmarks = PulserBenchmarks.from_dict({
+                'write': raw_status.get('_benchmark_write_state'),
+                'load': raw_status.get('_benchmark_load_state'),
+            })
+            return
+
+        # A status file saved by this session's brief in-between "everything in one dataclass"
+        # format has pulser_benchmarks nested one level deeper (inside '_generator_settings') than
+        # either the pre-refactor or the current independent-StatusVar format expects - back-fill
+        # it so upgrading from that format doesn't silently reset the benchmark history either.
+        nested = raw_status.get('_generator_settings')
+        if isinstance(nested, dict) and nested.get('pulser_benchmarks'):
+            self.pulser_benchmarks = PulserBenchmarks.from_dict(nested['pulser_benchmarks'])
+
     def on_activate(self):
         """Initialisation performed during activation of the module."""
+        # Must run first - self._generator_settings has already been restored (or defaulted) by
+        # qudi-core's StatusVar machinery by this point; see this method's docstring for why.
+        self._migrate_legacy_settings_if_needed()
+
         if not os.path.exists(self._assets_storage_dir):
             os.makedirs(self._assets_storage_dir)
 
@@ -592,7 +726,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.log.error('Can´t load a waveform, because pulser running. Switch off the pulser and try again.')
                 return -1
 
-            t_est_upload = self._generator_settings.pulser_benchmarks.load.estimate_time(ensemble.sampling_information.number_of_samples)
+            t_est_upload = self.pulser_benchmarks.load.estimate_time(ensemble.sampling_information.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -604,7 +738,7 @@ class SequenceGeneratorLogic(LogicBase):
             # Actually load the waveforms to the generic channels
             start_time = time.perf_counter()
             self.pulsegenerator().load_waveform(ensemble.sampling_information.waveforms)
-            self._generator_settings.pulser_benchmarks.load.add_benchmark(
+            self.pulser_benchmarks.load.add_benchmark(
                 time.perf_counter() - start_time, ensemble.sampling_information.number_of_samples
             )
         else:
@@ -997,7 +1131,7 @@ class SequenceGeneratorLogic(LogicBase):
             try:
                 with open(filepath, 'rb') as file:
                     ensemble = pickle.load(file)
-                self._migrate_legacy_sampling_information(ensemble)   
+                self._migrate_legacy_info_containers(ensemble)
             except pickle.UnpicklingError:
                 self.log.error(
                     'Failed to de-serialize PulseBlockEnsemble "{0}" from file. Deleting broken file.'.format(
@@ -1080,6 +1214,18 @@ class SequenceGeneratorLogic(LogicBase):
             )
         return self._saved_pulse_sequences.get(name)
 
+    def resolve_asset_closure(self, asset):
+        """Independent copies of every PulseBlockEnsemble/PulseBlock `asset` (a loaded
+        PulseBlockEnsemble or PulseSequence, or None) actually references by name. Used by
+        PulsedMasterLogic to build a self-contained PulsedMeasurement.objects (see
+        pulsed_data/pulsed_measurement.py's PulseObjects) - see _resolve_asset_closure() for the
+        full traversal/missing-reference contract.
+
+        @param asset: the currently loaded PulseBlockEnsemble or PulseSequence, or None.
+        @return (ensembles, blocks): {name: independent copy}, see _resolve_asset_closure().
+        """
+        return _resolve_asset_closure(asset, self._saved_pulse_block_ensembles, self._saved_pulse_blocks, self.log)
+
     def delete_sequence(self, name):
         """
         Remove the sequence with 'name' from the sequence dict and all associated waveforms
@@ -1120,7 +1266,7 @@ class SequenceGeneratorLogic(LogicBase):
                 # Restored it here but a better way needs to be found.
                 for step in range(len(sequence)):
                     sequence[step].__dict__ = sequence[step]
-                self._migrate_legacy_sampling_information(sequence)
+                self._migrate_legacy_info_containers(sequence)
             except pickle.UnpicklingError:
                 self.log.error('Failed to de-serialize PulseSequence "{0}" from file.'.format(sequence_name))
                 os.remove(filepath)
@@ -1988,7 +2134,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.sigSampleEnsembleComplete.emit(None)
                 return -1, list(), dict()
 
-            t_est_upload = self._generator_settings.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples)
+            t_est_upload = self.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -2123,13 +2269,13 @@ class SequenceGeneratorLogic(LogicBase):
             )
             self.log.debug(
                 'Estimated {:.3f} s from current estimated write speed {:.2f} MSa/s from {} benchmarks'.format(
-                    self._generator_settings.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples),
-                    self._generator_settings.pulser_benchmarks.write.estimate_speed() / 1e6,
-                    self._generator_settings.pulser_benchmarks.write.n_benchmarks,
+                    self.pulser_benchmarks.write.estimate_time(ensemble_info.number_of_samples),
+                    self.pulser_benchmarks.write.estimate_speed() / 1e6,
+                    self.pulser_benchmarks.write.n_benchmarks,
                 )
             )
 
-            self._generator_settings.pulser_benchmarks.write.add_benchmark(time.time() - start_time, ensemble_info.number_of_samples)
+            self.pulser_benchmarks.write.add_benchmark(time.time() - start_time, ensemble_info.number_of_samples)
 
             if ensemble_info.number_of_samples == 0:
                 self.log.warning(
@@ -2148,7 +2294,7 @@ class SequenceGeneratorLogic(LogicBase):
                 try:
                     self.module_state.unlock()
                 except:
-                    pass
+                    self.log.exception('Failed to unlock module state after sampling error:')
             self.sigSampleEnsembleComplete.emit(None)
             return -1, list(), dict()
         return offset_bin, natural_sort(written_waveforms), ensemble_info
@@ -2309,7 +2455,7 @@ class SequenceGeneratorLogic(LogicBase):
             try:
                 self.module_state.unlock()
             except:
-                pass
+                self.log.exception('Failed to unlock module state after sampling error:')
             self.__sequence_generation_in_progress = False
             self.sigSampleSequenceComplete.emit(None)
             return -1, list(), dict()
@@ -2375,7 +2521,7 @@ class SequenceGeneratorLogic(LogicBase):
                 granularity = constraints.waveform_length.step
                 return np.ceil(n_samples / granularity) * granularity
 
-            self._generator_settings.pulser_benchmarks.reset()
+            self.pulser_benchmarks.reset()
 
             n_samples_min = constraints.waveform_length.min
             n_max_fix = max(10e6, n_samples_min)
@@ -2400,7 +2546,7 @@ class SequenceGeneratorLogic(LogicBase):
             while time.perf_counter() - t_start < t_goal and rescode == 0:
                 speed = self.get_speed_write_load()
                 t_left = t_goal - (time.perf_counter() - t_start)
-                if self._generator_settings.pulser_benchmarks.write.sanity and self._generator_settings.pulser_benchmarks.load.sanity:
+                if self.pulser_benchmarks.write.sanity and self.pulser_benchmarks.load.sanity:
                     n_samples = speed * t_left / time_fraction
                     n_samples = round_to_granularity(n_samples)
                 else:  # poor speed estimate so far
@@ -2417,8 +2563,8 @@ class SequenceGeneratorLogic(LogicBase):
                     "Running benchmark. Current speed (write/load/tot): "
                     "{:.3f} / {:.3f} / {:.3f} MSa/s): {} samples for"
                     " estimated {:.5f} s, {:.5f} s left".format(
-                        self._generator_settings.pulser_benchmarks.write.estimate_speed() / 1e6,
-                        self._generator_settings.pulser_benchmarks.load.estimate_speed() / 1e6,
+                        self.pulser_benchmarks.write.estimate_speed() / 1e6,
+                        self.pulser_benchmarks.load.estimate_speed() / 1e6,
                         speed / 1e6,
                         n_samples,
                         t_est,
@@ -2532,7 +2678,7 @@ class SequenceGeneratorLogic(LogicBase):
             )
 
         if not ignore_datapoint:
-            self._generator_settings.pulser_benchmarks.write.add_benchmark(
+            self.pulser_benchmarks.write.add_benchmark(
                 time.perf_counter() - start_time, n_samples, is_persistent=persistent_datapoint
             )
 
@@ -2540,7 +2686,7 @@ class SequenceGeneratorLogic(LogicBase):
 
         loaded_dict = self.pulsegenerator().load_waveform(wfm_list)
         if not ignore_datapoint:
-            self._generator_settings.pulser_benchmarks.load.add_benchmark(
+            self.pulser_benchmarks.load.add_benchmark(
                 time.perf_counter() - start_time, n_samples, is_persistent=persistent_datapoint
             )
 
@@ -2554,35 +2700,57 @@ class SequenceGeneratorLogic(LogicBase):
         return 0, list(), dict()
 
     def has_valid_pg_benchmark(self):
-        return self._generator_settings.pulser_benchmarks.has_valid_estimate(ignore=self._disable_bench_prompt)
+        return self.pulser_benchmarks.has_valid_estimate(ignore=self._disable_bench_prompt)
 
     def get_speed_write_load(self):
         """
         Get the estimated speed of the pulse generator for writing and loading a waveform.
         :return: speed (Sa/s)
         """
-        return self._generator_settings.pulser_benchmarks.estimate_combined_speed()
+        return self.pulser_benchmarks.estimate_combined_speed()
     
-    def _migrate_legacy_sampling_information(self, loaded_object):
+    def _migrate_legacy_info_containers(self, loaded_object):
+        """Normalizes sampling_information/measurement_information/generation_method_parameters
+        on an unpickled PulseBlockEnsemble/PulseSequence - see _migrate_legacy_info_container()
+        for the two failure modes this guards against (both confirmed on real saved assets)."""
+        self._migrate_legacy_info_container(loaded_object, 'sampling_information', SamplingInformation)
+        self._migrate_legacy_info_container(loaded_object, 'measurement_information', MeasurementInformation)
+        self._migrate_legacy_info_container(loaded_object, 'generation_method_parameters', GenerationMethodParameters)
+
+    def _migrate_legacy_info_container(self, loaded_object, attr_name, container_cls):
+        """Normalizes a single `attr_name` on an unpickled PulseBlockEnsemble/PulseSequence back
+        to a complete, current `container_cls` instance. pickle.load() bypasses __init__, so an
+        older saved file can come back as either: (a) `attr_name` pickled as a plain dict, from
+        before `container_cls` was used consistently - converted via `from_dict()`; or (b) the
+        right class but missing fields added since it was saved - backfilled in place with each
+        field's declared default, since to_dict()/from_dict() would hit the same AttributeError.
         """
-        Detects legacy dict-based sampling_information in unpickled objects 
-        and converts them to the SamplingInformation dataclass.
-        """
-        if not hasattr(loaded_object, 'sampling_information'):
+        if not hasattr(loaded_object, attr_name):
+            setattr(loaded_object, attr_name, container_cls())
             return
 
-        # If it's already the new dataclass, do nothing
-        if isinstance(loaded_object.sampling_information, SamplingInformation):
-            return
+        value = getattr(loaded_object, attr_name)
 
-        # If it's a legacy dictionary, convert it
-        if isinstance(loaded_object.sampling_information, dict):
-            if not loaded_object.sampling_information:
-                # Replace empty dict with an empty dataclass (evaluates to False due to __bool__)
-                loaded_object.sampling_information = SamplingInformation()
+        if isinstance(value, dict) and not isinstance(value, container_cls):
+            if not value:
+                setattr(loaded_object, attr_name, container_cls())
             else:
-                # Convert populated dict
-                self.log.debug(f'Migrating legacy sampling_information for {loaded_object.name}')
-                loaded_object.sampling_information = SamplingInformation.from_dict(
-                    loaded_object.sampling_information
+                self.log.debug('Migrating legacy {0} for {1}'.format(attr_name, loaded_object.name))
+                setattr(loaded_object, attr_name, container_cls.from_dict(value))
+            return
+
+        if is_dataclass(value):
+            backfilled = []
+            for f in fields(value):
+                if not hasattr(value, f.name):
+                    if f.default_factory is not MISSING:
+                        setattr(value, f.name, f.default_factory())
+                    elif f.default is not MISSING:
+                        setattr(value, f.name, f.default)
+                    backfilled.append(f.name)
+            if backfilled:
+                self.log.debug(
+                    'Backfilled missing field(s) {0} on legacy {1} for {2}'.format(
+                        backfilled, attr_name, loaded_object.name
+                    )
                 )

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -62,6 +62,7 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     SequenceAnalysisResult,
     SamplingInformation,
     AssetInfo,
+    LoadedAsset,
     SequenceSamplingState,
     PulserBenchmarks,
 )
@@ -397,16 +398,16 @@ class SequenceGeneratorLogic(LogicBase):
             return_name = self._strip_ch_extension(name_list[0])
             for name in name_list:
                 if self._strip_ch_extension(name) != return_name:
-                    return '', ''
+                    return LoadedAsset.empty()
         elif asset_type == 'sequence' and len(name_list) > 0:
             return_type = 'PulseSequence'
             return_name = self._strip_ch_extension(name_list[0])
             for name in name_list:
                 if self._strip_ch_extension(name) != return_name:
-                    return '', ''
+                    return LoadedAsset.empty()
         else:
-            return '', ''
-        return return_name, return_type
+            return LoadedAsset.empty()
+        return LoadedAsset(name=return_name, asset_type=return_type)
 
     @QtCore.Slot(dict)
     def set_pulse_generator_settings(self, settings_dict=None, **kwargs):

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
+from dataclasses import replace, fields
 from enum import Enum
 from typing import Optional, Union
 import numpy as np
@@ -46,10 +47,34 @@ from qudi.interface.pulser_interface import PulserInterface, SequenceOption
 from qudi.util.benchmark import BenchmarkTool
 
 from qudi.util.yaml import SafeRepresenter, SafeConstructor
-from qudi.util.yaml_helpers import dataclass_representer, pulse_envelope_constructor
+from qudi.util.yaml_helpers import (
+    dataclass_representer,
+    pulse_envelope_constructor,
+    sampling_information_constructor,
+)
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
+    GenerationParameters,
+    ActivationConfig,
+    AnalogLevels,
+    DigitalLevels,
+    PulseGeneratorSettings,
+    EnsembleAnalysisResult,
+    SequenceAnalysisResult,
+    SamplingInformation,
+    AssetInfo,
+    SequenceSamplingState,
+    PulserBenchmarks,
+)
 
 SafeRepresenter.add_multi_representer(PulseEnvelope, dataclass_representer)
 SafeConstructor.add_constructor("!PulseEnvelope", pulse_envelope_constructor)
+SafeRepresenter.add_multi_representer(SamplingInformation, dataclass_representer)
+SafeConstructor.add_constructor("!SamplingInformation", sampling_information_constructor)
+
+
+def _dataclass_to_dict(obj, exclude=()):
+    """Shallow-flattens a dataclass instance into a plain dict, one level deep."""
+    return {f.name: getattr(obj, f.name) for f in fields(obj) if f.name not in exclude}
 
 
 class SequenceGeneratorLogic(LogicBase):
@@ -100,22 +125,41 @@ class SequenceGeneratorLogic(LogicBase):
     # Global parameters describing the channel usage and common parameters used during pulsed object
     # generation for predefined methods.
     _generation_parameters = StatusVar(
-        default={
-            'laser_channel': 'd_ch1',
-            'sync_channel': '',
-            'gate_channel': '',
-            'microwave_channel': 'a_ch1',
-            'microwave_frequency': 2.87e9,
-            'microwave_amplitude': 0.0,
-            'rabi_period': 100e-9,
-            'laser_length': 3e-6,
-            'laser_delay': 500e-9,
-            'wait_time': 1e-6,
-            'analog_trigger_voltage': 0.0,
-            'optimal_control_assets_path': 'C:\\Software\\qudi_data\\optimal_control_assets',
-            'pulse_envelope': PulseEnvelope(PulseEnvelopeType.rectangle),
-            'pulse_envelope_order': 1,
-        }
+        default=GenerationParameters(
+            laser_channel='d_ch1',
+            sync_channel='',
+            gate_channel='',
+            microwave_channel='a_ch1',
+            microwave_frequency=2.87e9,
+            microwave_amplitude=0.0,
+            rabi_period=100e-9,
+            laser_length=3e-6,
+            laser_delay=500e-9,
+            wait_time=1e-6,
+            analog_trigger_voltage=0.0,
+            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
+            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
+            pulse_envelope_order=1,
+        ),
+        constructor=lambda x: GenerationParameters.from_dict(x)
+        if isinstance(x, dict)
+        else GenerationParameters(
+            laser_channel='d_ch1',
+            sync_channel='',
+            gate_channel='',
+            microwave_channel='a_ch1',
+            microwave_frequency=2.87e9,
+            microwave_amplitude=0.0,
+            rabi_period=100e-9,
+            laser_length=3e-6,
+            laser_delay=500e-9,
+            wait_time=1e-6,
+            analog_trigger_voltage=0.0,
+            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
+            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
+            pulse_envelope_order=1,
+        ),
+        representer=lambda obj: obj.to_dict(),
     )
 
     # The created pulse objects (PulseBlock, PulseBlockEnsemble, PulseSequence) are saved in
@@ -149,17 +193,20 @@ class SequenceGeneratorLogic(LogicBase):
 
         # current pulse generator settings that are frequently used by this logic.
         # Save them here since reading them from device every time they are used may take some time.
-        self.__activation_config = ('', set())  # Activation config name and set of active channels
-        self.__sample_rate = 0.0  # Sample rate in samples/s
-        self.__analog_levels = (dict(), dict())  # Tuple of two dict (<pp_amplitude>, <offset>)
-        # Dict keys are analog channel descriptors
-        self.__digital_levels = (dict(), dict())  # Tuple of two dict (<low_volt>, <high_volt>)
-        # Dict keys are digital channel descriptors
-        self.__interleave = False  # Flag to indicate use of interleave
-        # Set of available flags
-        self.__flags = set()
-        # upload speed from benchmark
-        self.__upload_speed = np.nan
+        self.__pulse_generator_settings = PulseGeneratorSettings(
+            activation_config=ActivationConfig(name='', channels=set()),
+            sample_rate=0.0,
+            analog_levels=AnalogLevels(amplitude=dict(), offset=dict()),
+            digital_levels=DigitalLevels(low=dict(), high=dict()),
+            interleave=False,
+            flags=set(),
+            upload_speed=np.nan,
+        )
+
+        # Bundles the write/load BenchmarkTool instances used to estimate pulser upload speed.
+        # Wraps the existing class-level BenchmarkTool instances (not new ones), since those are
+        # bound to the _benchmark_write_state/_benchmark_load_state StatusVar persistence.
+        self.__pulser_benchmarks = PulserBenchmarks(write=self._benchmark_write, load=self._benchmark_load)
 
         # A flag indicating if sampling of a sequence is in progress
         self.__sequence_generation_in_progress = False
@@ -309,19 +356,13 @@ class SequenceGeneratorLogic(LogicBase):
 
     @property
     def pulse_generator_settings(self):
-        settings_dict = dict()
-        settings_dict['activation_config'] = tuple(self.__activation_config)
-        settings_dict['sample_rate'] = float(self.__sample_rate)
-        settings_dict['analog_levels'] = tuple(self.__analog_levels)
-        settings_dict['digital_levels'] = tuple(self.__digital_levels)
-        settings_dict['interleave'] = bool(self.__interleave)
-        settings_dict['flags'] = set(self.__flags)
-        settings_dict['upload_speed'] = float(self.__upload_speed)
-        return settings_dict
+        return self.__pulse_generator_settings.to_dict()
 
     @pulse_generator_settings.setter
     def pulse_generator_settings(self, settings_dict):
-        if isinstance(settings_dict, dict):
+        if isinstance(settings_dict, PulseGeneratorSettings):
+            self.set_pulse_generator_settings(settings_dict.to_dict())
+        elif isinstance(settings_dict, dict):
             self.set_pulse_generator_settings(settings_dict)
         return
 
@@ -339,11 +380,13 @@ class SequenceGeneratorLogic(LogicBase):
 
     @property
     def analog_channels(self):
-        return {chnl for chnl in self.__activation_config[1] if chnl.startswith('a_ch')}
+        channels = self.__pulse_generator_settings.activation_config.channels
+        return {chnl for chnl in channels if chnl.startswith('a_ch')}
 
     @property
     def digital_channels(self):
-        return {chnl for chnl in self.__activation_config[1] if chnl.startswith('d_ch')}
+        channels = self.__pulse_generator_settings.activation_config.channels
+        return {chnl for chnl in channels if chnl.startswith('d_ch')}
 
     @property
     def loaded_asset(self):
@@ -395,7 +438,10 @@ class SequenceGeneratorLogic(LogicBase):
                 if isinstance(activation_config, str):
                     if activation_config in available_configs.keys():
                         set_config = self._apply_activation_config(available_configs[activation_config])
-                        self.__activation_config = (activation_config, set_config)
+                        self.__pulse_generator_settings = replace(
+                            self.__pulse_generator_settings,
+                            activation_config=ActivationConfig(name=activation_config, channels=set_config),
+                        )
                     else:
                         self.log.error(
                             'Unable to set activation config by name.\n"{0}" not found in pulser constraints.'.format(
@@ -406,7 +452,10 @@ class SequenceGeneratorLogic(LogicBase):
                     if activation_config in available_configs.values():
                         set_config = self._apply_activation_config(activation_config)
                         config_name = list(available_configs)[list(available_configs.values()).index(activation_config)]
-                        self.__activation_config = (config_name, set_config)
+                        self.__pulse_generator_settings = replace(
+                            self.__pulse_generator_settings,
+                            activation_config=ActivationConfig(name=config_name, channels=set_config),
+                        )
                     else:
                         self.log.error(
                             'Unable to set activation config "{0}".\nNot found in pulser constraints.'.format(
@@ -416,7 +465,10 @@ class SequenceGeneratorLogic(LogicBase):
                 elif isinstance(activation_config, tuple):
                     if activation_config in available_configs.items():
                         set_config = self._apply_activation_config(activation_config[1])
-                        self.__activation_config = (activation_config[0], set_config)
+                        self.__pulse_generator_settings = replace(
+                            self.__pulse_generator_settings,
+                            activation_config=ActivationConfig(name=activation_config[0], channels=set_config),
+                        )
                     else:
                         self.log.error(
                             'Unable to set activation config "{0}".\nNot found in pulser constraints.'.format(
@@ -426,16 +478,20 @@ class SequenceGeneratorLogic(LogicBase):
                 # Check if the ultimately set config is part of the constraints
                 if set_config is not None and set_config not in available_configs.values():
                     self.log.error('Something went wrong while setting new activation config.')
-                    self.__activation_config = ('', set_config)
+                    self.__pulse_generator_settings = replace(
+                        self.__pulse_generator_settings,
+                        activation_config=ActivationConfig(name='', channels=set_config),
+                    )
 
                 # search the generation_parameters for channel specifiers and adjust them if they
                 # are no longer valid
                 changed_settings = dict()
                 ana_chnls = natural_sort(self.analog_channels)
                 digi_chnls = natural_sort(self.digital_channels)
+                active_channels = self.__pulse_generator_settings.activation_config.channels
                 for name in [setting for setting in self.generation_parameters if setting.endswith('_channel')]:
                     channel = self.generation_parameters[name]
-                    if isinstance(channel, str) and channel not in self.__activation_config[1]:
+                    if isinstance(channel, str) and channel not in active_channels:
                         if channel.startswith('a'):
                             new_channel = ana_chnls[0] if ana_chnls else digi_chnls[0]
                         elif channel.startswith('d'):
@@ -451,18 +507,34 @@ class SequenceGeneratorLogic(LogicBase):
                             changed_settings[name] = new_channel
 
             if 'sample_rate' in settings_dict:
-                self.__sample_rate = self.pulsegenerator().set_sample_rate(float(settings_dict['sample_rate']))
+                self.__pulse_generator_settings = replace(
+                    self.__pulse_generator_settings,
+                    sample_rate=self.pulsegenerator().set_sample_rate(float(settings_dict['sample_rate'])),
+                )
 
             if 'analog_levels' in settings_dict:
-                self.__analog_levels = self.pulsegenerator().set_analog_level(*settings_dict['analog_levels'])
+                amplitude, offset = self.pulsegenerator().set_analog_level(*settings_dict['analog_levels'])
+                self.__pulse_generator_settings = replace(
+                    self.__pulse_generator_settings,
+                    analog_levels=AnalogLevels(amplitude=amplitude, offset=offset),
+                )
 
             if 'digital_levels' in settings_dict:
-                self.__digital_levels = self.pulsegenerator().set_digital_level(*settings_dict['digital_levels'])
+                low, high = self.pulsegenerator().set_digital_level(*settings_dict['digital_levels'])
+                self.__pulse_generator_settings = replace(
+                    self.__pulse_generator_settings,
+                    digital_levels=DigitalLevels(low=low, high=high),
+                )
 
             if 'interleave' in settings_dict:
-                self.__interleave = self.pulsegenerator().set_interleave(bool(settings_dict['interleave']))
+                self.__pulse_generator_settings = replace(
+                    self.__pulse_generator_settings,
+                    interleave=self.pulsegenerator().set_interleave(bool(settings_dict['interleave'])),
+                )
 
-            self.__upload_speed = self.get_speed_write_load()
+            self.__pulse_generator_settings = replace(
+                self.__pulse_generator_settings, upload_speed=self.get_speed_write_load()
+            )
 
         elif len(kwargs) != 0 or isinstance(settings_dict, dict):
             # Only throw warning when arguments have been passed to this method
@@ -492,11 +564,11 @@ class SequenceGeneratorLogic(LogicBase):
         # Delete all sampling information from all PulseBlockEnsembles and PulseSequences
         for seq_name in self.saved_pulse_sequences:
             seq = self.saved_pulse_sequences[seq_name]
-            seq.sampling_information = dict()
+            seq.sampling_information = SamplingInformation()
             self.save_sequence(seq)
         for ens_name in self.saved_pulse_block_ensembles:
             ens = self.saved_pulse_block_ensembles[ens_name]
-            ens.sampling_information = dict()
+            ens.sampling_information = SamplingInformation()
             self.save_ensemble(ens)
         self.sigAvailableWaveformsUpdated.emit(self.sampled_waveforms)
         self.sigAvailableSequencesUpdated.emit(self.sampled_sequences)
@@ -528,7 +600,7 @@ class SequenceGeneratorLogic(LogicBase):
         if ensemble.sampling_information:
             # Check if the corresponding waveforms are present in the pulse generator memory
             ready_waveforms = self.sampled_waveforms
-            for waveform in ensemble.sampling_information['waveforms']:
+            for waveform in ensemble.sampling_information.waveforms:
                 if waveform not in ready_waveforms:
                     self.log.error(
                         'Waveform "{0}" associated with PulseBlockEnsemble "{1}" not '
@@ -542,7 +614,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.log.error('Can´t load a waveform, because pulser running. Switch off the pulser and try again.')
                 return -1
 
-            t_est_upload = self._benchmark_load.estimate_time(ensemble.sampling_information['number_of_samples'])
+            t_est_upload = self._benchmark_load.estimate_time(ensemble.sampling_information.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -553,9 +625,9 @@ class SequenceGeneratorLogic(LogicBase):
 
             # Actually load the waveforms to the generic channels
             start_time = time.perf_counter()
-            self.pulsegenerator().load_waveform(ensemble.sampling_information['waveforms'])
+            self.pulsegenerator().load_waveform(ensemble.sampling_information.waveforms)
             self._benchmark_load.add_benchmark(
-                time.perf_counter() - start_time, ensemble.sampling_information['number_of_samples']
+                time.perf_counter() - start_time, ensemble.sampling_information.number_of_samples
             )
         else:
             self.log.error(
@@ -589,7 +661,7 @@ class SequenceGeneratorLogic(LogicBase):
         if sequence.sampling_information and sequence.name in self.sampled_sequences:
             # Check if the corresponding waveforms are present in the pulse generator memory
             ready_waveforms = self.sampled_waveforms
-            for waveform in sequence.sampling_information['waveforms']:
+            for waveform in sequence.sampling_information.waveforms:
                 if waveform not in ready_waveforms:
                     self.log.error(
                         'Waveform "{0}" associated with PulseSequence "{1}" not '
@@ -622,13 +694,13 @@ class SequenceGeneratorLogic(LogicBase):
         if current_config in avail_configs.values():
             # Read config found in constraints
             config_name = list(avail_configs)[list(avail_configs.values()).index(current_config)]
-            self.__activation_config = (config_name, current_config)
+            activation_config = ActivationConfig(name=config_name, channels=current_config)
         else:
             # Set first valid config if read config is not valid.
             config_to_set = list(avail_configs.items())[0]
             set_config = self._apply_activation_config(config_to_set[1])
             if set_config != config_to_set[1]:
-                self.__activation_config = ('', set_config)
+                activation_config = ActivationConfig(name='', channels=set_config)
                 self.log.error(
                     'Error during activation.\n'
                     'Unable to set activation_config that was taken from pulse '
@@ -636,22 +708,20 @@ class SequenceGeneratorLogic(LogicBase):
                     'Probably one or more activation_configs in constraints invalid.'
                 )
             else:
-                self.__activation_config = config_to_set
+                activation_config = ActivationConfig.from_tuple(*config_to_set)
 
-        # Read sample rate from device
-        self.__sample_rate = float(self.pulsegenerator().get_sample_rate())
-
-        # Read analog levels from device
-        self.__analog_levels = self.pulsegenerator().get_analog_level()
-
-        # Read digital levels from device
-        self.__digital_levels = self.pulsegenerator().get_digital_level()
-
-        # Read interleave flag from device
-        self.__interleave = self.pulsegenerator().get_interleave()
-
-        # Read available flags from device
-        self.__flags = set(self.pulsegenerator().get_constraints().flags)
+        # Read sample rate, analog/digital levels, interleave flag and available flags from device
+        amplitude, offset = self.pulsegenerator().get_analog_level()
+        low, high = self.pulsegenerator().get_digital_level()
+        self.__pulse_generator_settings = replace(
+            self.__pulse_generator_settings,
+            activation_config=activation_config,
+            sample_rate=float(self.pulsegenerator().get_sample_rate()),
+            analog_levels=AnalogLevels(amplitude=amplitude, offset=offset),
+            digital_levels=DigitalLevels(low=low, high=high),
+            interleave=self.pulsegenerator().get_interleave(),
+            flags=set(self.pulsegenerator().get_constraints().flags),
+        )
 
         # Notify new settings to listening module
         self.set_pulse_generator_settings()
@@ -685,11 +755,13 @@ class SequenceGeneratorLogic(LogicBase):
 
     @property
     def generation_parameters(self):
-        return self._generation_parameters.copy()
+        return self._generation_parameters.to_dict()
 
     @generation_parameters.setter
     def generation_parameters(self, settings_dict):
-        if isinstance(settings_dict, dict):
+        if isinstance(settings_dict, GenerationParameters):
+            self.set_generation_parameters(settings_dict.to_dict())
+        elif isinstance(settings_dict, dict):
             self.set_generation_parameters(settings_dict)
         return
 
@@ -720,55 +792,61 @@ class SequenceGeneratorLogic(LogicBase):
         # Check if generation is in progress and do nothing if that is the case
         if self.module_state() != 'locked':
             # Determine complete settings dictionary
-            if not isinstance(settings_dict, dict):
+            if isinstance(settings_dict, GenerationParameters):
+                settings_dict = settings_dict.to_dict()
+                settings_dict.update(kwargs)
+            elif not isinstance(settings_dict, dict):
                 settings_dict = kwargs
             else:
                 settings_dict.update(kwargs)
 
-            # Notify if new keys have been added
-            for key in settings_dict:
-                if key not in self._generation_parameters:
+            # Discard unknown keys. GenerationParameters has a fixed schema, so (unlike the old
+            # plain dict) it cannot store arbitrary additional settings.
+            known_keys = self._generation_parameters.to_dict().keys()
+            for key in list(settings_dict):
+                if key not in known_keys:
                     self.log.warning(
                         'Setting by name "{0}" not present in generation_parameters.\n'
-                        'Will add it but this could lead to unwanted effects.'
-                        ''.format(key)
+                        'Ignoring it.'.format(key)
                     )
+                    del settings_dict[key]
             # Sanity checks
+            active_channels = self.__pulse_generator_settings.activation_config.channels
             if settings_dict.get('laser_channel'):
-                if settings_dict['laser_channel'] not in self.__activation_config[1]:
+                if settings_dict['laser_channel'] not in active_channels:
                     self.log.error(
                         'Unable to set laser channel "{0}".\nChannel to set is not part '
                         'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['laser_channel'], self.__activation_config[1])
+                        ''.format(settings_dict['laser_channel'], active_channels)
                     )
                     del settings_dict['laser_channel']
             if settings_dict.get('sync_channel'):
-                if settings_dict['sync_channel'] not in self.__activation_config[1]:
+                if settings_dict['sync_channel'] not in active_channels:
                     self.log.error(
                         'Unable to set sync channel "{0}".\nChannel to set is not part '
                         'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['sync_channel'], self.__activation_config[1])
+                        ''.format(settings_dict['sync_channel'], active_channels)
                     )
                     del settings_dict['sync_channel']
             if settings_dict.get('gate_channel'):
-                if settings_dict['gate_channel'] not in self.__activation_config[1]:
+                if settings_dict['gate_channel'] not in active_channels:
                     self.log.error(
                         'Unable to set gate channel "{0}".\nChannel to set is not part '
                         'of the current channel activation config ({1}).'
-                        ''.format(settings_dict['gate_channel'], self.__activation_config[1])
+                        ''.format(settings_dict['gate_channel'], active_channels)
                     )
                     del settings_dict['gate_channel']
             if settings_dict.get('microwave_channel'):
-                if settings_dict['microwave_channel'] not in self.__activation_config[1]:
+                if settings_dict['microwave_channel'] not in active_channels:
                     self.log.error(
                         'Unable to set microwave channel "{0}".\nChannel to set is not '
                         'part of the current channel activation config ({1}).'
-                        ''.format(settings_dict['microwave_channel'], self.__activation_config[1])
+                        ''.format(settings_dict['microwave_channel'], active_channels)
                     )
                     del settings_dict['microwave_channel']
 
             # update settings dict
-            self._generation_parameters.update(settings_dict)
+            self._generation_parameters = self._generation_parameters.update_from_dict(settings_dict)
         else:
             self.log.error(
                 'Unable to apply new sampling settings.\nSequenceGeneratorLogic is busy generating a waveform/sequence.'
@@ -911,7 +989,7 @@ class SequenceGeneratorLogic(LogicBase):
         if name in self.saved_pulse_block_ensembles:
             # check if ensemble has already been sampled and delete associated waveforms
             if self.saved_pulse_block_ensembles[name].sampling_information:
-                self._delete_waveform(self.saved_pulse_block_ensembles[name].sampling_information['waveforms'])
+                self._delete_waveform(self.saved_pulse_block_ensembles[name].sampling_information.waveforms)
                 self.sigAvailableWaveformsUpdated.emit(self.sampled_waveforms)
             # delete PulseBlockEnsemble
             del self._saved_pulse_block_ensembles[name]
@@ -937,6 +1015,7 @@ class SequenceGeneratorLogic(LogicBase):
             try:
                 with open(filepath, 'rb') as file:
                     ensemble = pickle.load(file)
+                self._migrate_legacy_sampling_information(ensemble)   
             except pickle.UnpicklingError:
                 self.log.error(
                     'Failed to de-serialize PulseBlockEnsemble "{0}" from file. Deleting broken file.'.format(
@@ -963,10 +1042,10 @@ class SequenceGeneratorLogic(LogicBase):
         for ensemble_name in names:
             ensemble = self._load_ensemble_from_file(ensemble_name)
             if ensemble is not None:
-                if ensemble.sampling_information.get('waveforms'):
-                    waveform_set = set(ensemble.sampling_information['waveforms'])
+                if ensemble.sampling_information.waveforms:
+                    waveform_set = set(ensemble.sampling_information.waveforms)
                     if not sampled_waveforms.issuperset(waveform_set):
-                        ensemble.sampling_information = dict()
+                        ensemble.sampling_information = SamplingInformation()
                 self._saved_pulse_block_ensembles[ensemble_name] = ensemble
 
         self.sigEnsembleDictUpdated.emit(self.saved_pulse_block_ensembles)
@@ -1030,7 +1109,7 @@ class SequenceGeneratorLogic(LogicBase):
             if self.saved_pulse_sequences[name].sampling_information:
                 self._delete_sequence(name)
                 if self.saved_pulse_sequences[name].rotating_frame:
-                    self._delete_waveform(self.saved_pulse_sequences[name].sampling_information['waveforms'])
+                    self._delete_waveform(self.saved_pulse_sequences[name].sampling_information.waveforms)
                     self.sigAvailableWaveformsUpdated.emit(self.sampled_waveforms)
             # delete PulseSequence
             del self._saved_pulse_sequences[name]
@@ -1059,6 +1138,7 @@ class SequenceGeneratorLogic(LogicBase):
                 # Restored it here but a better way needs to be found.
                 for step in range(len(sequence)):
                     sequence[step].__dict__ = sequence[step]
+                self._migrate_legacy_sampling_information(sequence)
             except pickle.UnpicklingError:
                 self.log.error('Failed to de-serialize PulseSequence "{0}" from file.'.format(sequence_name))
                 os.remove(filepath)
@@ -1129,11 +1209,11 @@ class SequenceGeneratorLogic(LogicBase):
             sequence = self._load_sequence_from_file(sequence_name)
             if sequence is not None:
                 if sequence.name not in sampled_sequences:
-                    sequence.sampling_information = dict()
+                    sequence.sampling_information = SamplingInformation()
                 elif sequence.sampling_information:
-                    waveform_set = set(sequence.sampling_information['waveforms'])
+                    waveform_set = set(sequence.sampling_information.waveforms)
                     if not sampled_waveforms.issuperset(waveform_set):
-                        sequence.sampling_information = dict()
+                        sequence.sampling_information = SamplingInformation()
                 self._saved_pulse_sequences[sequence_name] = sequence
 
         self.sigSequenceDictUpdated.emit(self.saved_pulse_sequences)
@@ -1202,7 +1282,7 @@ class SequenceGeneratorLogic(LogicBase):
         for block in blocks:
             self.save_block(block)
         for ensemble in ensembles:
-            ensemble.sampling_information = dict()
+            ensemble.sampling_information = SamplingInformation()
             ensemble.generation_method_parameters = kwargs_dict
             self.save_ensemble(ensemble)
 
@@ -1215,7 +1295,7 @@ class SequenceGeneratorLogic(LogicBase):
                 )
 
         for sequence in sequences:
-            sequence.sampling_information = dict()
+            sequence.sampling_information = SamplingInformation()
             sequence.generation_method_parameters = kwargs_dict
             self.save_sequence(sequence)
 
@@ -1270,13 +1350,13 @@ class SequenceGeneratorLogic(LogicBase):
         """
         # Return if the ensemble is empty
         if len(ensemble) == 0:
-            return 0.0, 0, 0
+            return AssetInfo(length_s=0.0, length_bins=0, number_of_lasers=0)
 
-        info_dict = self.analyze_block_ensemble(ensemble=ensemble)
-        ens_bins = info_dict['number_of_samples']
-        ens_length = ens_bins / self.__sample_rate
-        ens_lasers = min(len(info_dict['laser_rising_bins']), len(info_dict['laser_falling_bins']))
-        return ens_length, ens_bins, ens_lasers
+        info = self.analyze_block_ensemble(ensemble=ensemble)
+        ens_bins = info.number_of_samples
+        ens_length = ens_bins / self.__pulse_generator_settings.sample_rate
+        ens_lasers = min(len(info.laser_rising_bins), len(info.laser_falling_bins))
+        return AssetInfo(length_s=ens_length, length_bins=ens_bins, number_of_lasers=ens_lasers)
 
     def get_sequence_info(self, sequence):
         """
@@ -1295,18 +1375,18 @@ class SequenceGeneratorLogic(LogicBase):
             else self.generation_parameters['laser_channel']
         )
 
-        info_dict = self.analyze_sequence(sequence=sequence)
-        length_bins = info_dict['number_of_samples']
-        length_s = length_bins / self.__sample_rate if sequence.is_finite else np.inf
+        info = self.analyze_sequence(sequence=sequence)
+        length_bins = info.number_of_samples
+        length_s = length_bins / self.__pulse_generator_settings.sample_rate if sequence.is_finite else np.inf
 
         if len(laser_channel) > 0 and laser_channel[0] == 'd' and sequence.is_finite:
-            number_of_lasers = len(info_dict['digital_rising_bins'][laser_channel])
+            number_of_lasers = len(info.digital_rising_bins[laser_channel])
         elif sequence.is_finite:
             self.log.debug('Analog or no laser channel used. Given laser_channel: "{0}"'.format(laser_channel))
-            number_of_lasers = min(len(info_dict['laser_rising_bins']), len(info_dict['laser_falling_bins']))
+            number_of_lasers = min(len(info.laser_rising_bins), len(info.laser_falling_bins))
         else:
             number_of_lasers = -1
-        return length_s, length_bins, number_of_lasers
+        return AssetInfo(length_s=length_s, length_bins=length_bins, number_of_lasers=number_of_lasers)
 
     def analyze_block_ensemble(self, ensemble):
         """
@@ -1340,18 +1420,18 @@ class SequenceGeneratorLogic(LogicBase):
         if isinstance(ensemble, str):
             if ensemble not in self._saved_pulse_block_ensembles:
                 self.log.error(
-                    'No saved PulseBlockEnsemble instance by the name "{0}" found. Returning empty dict.'.format(
+                    'No saved PulseBlockEnsemble instance by the name "{0}" found. Returning None.'.format(
                         ensemble
                     )
                 )
-                return dict()
+                return None
             ensemble = self.get_ensemble(ensemble)
         elif not isinstance(ensemble, PulseBlockEnsemble):
             self.log.error(
                 'Ensemble to analyze must either be of type PulseBlockEnsemble or the '
-                'name of the ensemble. Returning empty dict'
+                'name of the ensemble. Returning None'
             )
-            return dict()
+            return None
 
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
@@ -1427,7 +1507,7 @@ class SequenceGeneratorLogic(LogicBase):
                     current_end_time += element.init_length_s + rep_no * element.increment_s
 
                     # Nearest possible match including the discretization in bins
-                    current_end_bin = int(np.rint(current_end_time * self.__sample_rate))
+                    current_end_bin = int(np.rint(current_end_time * self.__pulse_generator_settings.sample_rate))
 
                     # append current element length in discrete bins to temporary array
                     elements_length_bins.append(current_end_bin - current_start_bin)
@@ -1450,20 +1530,20 @@ class SequenceGeneratorLogic(LogicBase):
             laser_rising_bins = np.array(sorted(set(laser_rising_bins)), dtype='int64')
             laser_falling_bins = np.array(sorted(set(laser_falling_bins)), dtype='int64')
 
-        return_dict = dict()
-        return_dict['number_of_samples'] = np.sum(elements_length_bins)
-        return_dict['number_of_elements'] = len(elements_length_bins)
-        return_dict['elements_length_bins'] = elements_length_bins
-        return_dict['digital_rising_bins'] = digital_rising_bins
-        return_dict['digital_falling_bins'] = digital_falling_bins
-        return_dict['analog_channels'] = analog_channels
-        return_dict['digital_channels'] = digital_channels
-        return_dict['channel_set'] = analog_channels.union(digital_channels)
-        return_dict['generation_parameters'] = self.generation_parameters.copy()
-        return_dict['ideal_length'] = current_end_time
-        return_dict['laser_rising_bins'] = laser_rising_bins
-        return_dict['laser_falling_bins'] = laser_falling_bins
-        return return_dict
+        return EnsembleAnalysisResult(
+            number_of_samples=np.sum(elements_length_bins),
+            number_of_elements=len(elements_length_bins),
+            elements_length_bins=elements_length_bins,
+            digital_rising_bins=digital_rising_bins,
+            digital_falling_bins=digital_falling_bins,
+            analog_channels=analog_channels,
+            digital_channels=digital_channels,
+            channel_set=analog_channels.union(digital_channels),
+            generation_parameters=self.generation_parameters.copy(),
+            ideal_length=current_end_time,
+            laser_rising_bins=laser_rising_bins,
+            laser_falling_bins=laser_falling_bins,
+        )
 
     def analyze_sequence(self, sequence: Union[str, PulseSequence]):
         """
@@ -1497,16 +1577,16 @@ class SequenceGeneratorLogic(LogicBase):
         if isinstance(sequence, str):
             if sequence not in self._saved_pulse_sequences:
                 self.log.error(
-                    'No saved PulseSequence instance by the name "{0}" found. Returning empty dict.'.format(sequence)
+                    'No saved PulseSequence instance by the name "{0}" found. Returning None.'.format(sequence)
                 )
-                return dict()
+                return None
             sequence = self.get_sequence(sequence)
         elif not isinstance(sequence, PulseSequence):
             self.log.error(
                 'Sequence to analyze must either be of type PulseSequence or the name '
-                'of the sequence. Returning empty dict'
+                'of the sequence. Returning None'
             )
-            return dict()
+            return None
 
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
@@ -1558,11 +1638,11 @@ class SequenceGeneratorLogic(LogicBase):
             # Get the PulseBlockEnsemble instance associated with this sequence step
             ensemble = self.get_ensemble(seq_step.ensemble)
             # Get information about the current PulseBlockEnsemble instance
-            info_dict = self.analyze_block_ensemble(ensemble=ensemble)
+            info = self.analyze_block_ensemble(ensemble=ensemble)
             # Set tmp helper variables
             ensemble_name_set.add(ensemble.name)
             reps = seq_step.repetitions + 1
-            ens_bins = info_dict['number_of_samples']
+            ens_bins = info.number_of_samples
             # Keep track of channel states at sequence step boundaries
             prev_step_digital_state = step_last_digital_state.copy()
             prev_step_laser_on_state = step_last_laser_on_state
@@ -1574,9 +1654,9 @@ class SequenceGeneratorLogic(LogicBase):
             step_last_laser_on_state = tmp_block[-1].laser_on
             # Calculate sequence step information
             step_length_bins[step_no] = ens_bins * reps if is_finite else -1
-            number_of_step_elements[step_no] = info_dict['number_of_elements'] * reps if is_finite else -1
-            ideal_step_length[step_no] = info_dict['ideal_length'] * reps if is_finite else np.inf
-            step_elements_length_bins.append([seq_step.repetitions, info_dict['elements_length_bins']])
+            number_of_step_elements[step_no] = info.number_of_elements * reps if is_finite else -1
+            ideal_step_length[step_no] = info.ideal_length * reps if is_finite else np.inf
+            step_elements_length_bins.append([seq_step.repetitions, info.elements_length_bins])
 
             # Get the digital channel rising/falling bin positions and concatenate them according
             # to sequence step repetition count considering bin offsets.
@@ -1591,8 +1671,8 @@ class SequenceGeneratorLogic(LogicBase):
                     # Pay special attention to transitions from one sequence step to another.
                     for iteration in range(reps):
                         bin_offset = iteration * ens_bins + starting_bin
-                        rising_bins = info_dict['digital_rising_bins'][chnl] + bin_offset
-                        falling_bins = info_dict['digital_falling_bins'][chnl] + bin_offset
+                        rising_bins = info.digital_rising_bins[chnl] + bin_offset
+                        falling_bins = info.digital_falling_bins[chnl] + bin_offset
                         if iteration == 0 and prev_step_digital_state[chnl] != step_last_digital_state[chnl]:
                             if prev_step_digital_state[chnl] and not step_first_digital_state[chnl]:
                                 falling_bins = np.append(bin_offset, falling_bins)
@@ -1612,8 +1692,8 @@ class SequenceGeneratorLogic(LogicBase):
                 if not laser_channel.startswith('d'):
                     for iteration in range(reps):
                         bin_offset = iteration * ens_bins + starting_bin
-                        rising_bins = info_dict['laser_rising_bins'] + bin_offset
-                        falling_bins = info_dict['laser_falling_bins'] + bin_offset
+                        rising_bins = info.laser_rising_bins + bin_offset
+                        falling_bins = info.laser_falling_bins + bin_offset
                         if iteration == 0 and prev_step_laser_on_state != step_last_laser_on_state:
                             if prev_step_laser_on_state and not step_first_laser_on_state:
                                 falling_bins = np.append(bin_offset, falling_bins)
@@ -1671,31 +1751,31 @@ class SequenceGeneratorLogic(LogicBase):
                 'starts and ends with an active laser pulse'.format(sequence.name)
             )
 
-        return_dict = dict()
-        return_dict['digital_channels'] = digital_channels
-        return_dict['analog_channels'] = analog_channels
-        return_dict['channel_set'] = analog_channels.union(digital_channels)
-        return_dict['generation_parameters'] = self.generation_parameters.copy()
-        return_dict['digital_rising_bins'] = digital_rising_bins
-        return_dict['digital_falling_bins'] = digital_falling_bins
-        return_dict['number_of_steps'] = len(sequence)
-        return_dict['number_of_samples'] = np.sum(step_length_bins)
-        return_dict['number_of_samples_per_step'] = step_length_bins
-        return_dict['number_of_ensembles'] = len(ensemble_name_set)
-        return_dict['ensemble_names'] = ensemble_name_set
-        return_dict['number_of_elements'] = np.sum(number_of_step_elements)
-        return_dict['number_of_elements_per_step'] = number_of_step_elements
-        return_dict['elements_length_bins_per_step'] = step_elements_length_bins
-        return_dict['ideal_length_per_step'] = ideal_step_length
-        return_dict['ideal_length'] = np.sum(ideal_step_length)
-        return_dict['laser_rising_bins'] = laser_rising_bins
-        return_dict['laser_falling_bins'] = laser_falling_bins
-
-        return return_dict
+        return SequenceAnalysisResult(
+            digital_channels=digital_channels,
+            analog_channels=analog_channels,
+            channel_set=analog_channels.union(digital_channels),
+            generation_parameters=self.generation_parameters.copy(),
+            digital_rising_bins=digital_rising_bins,
+            digital_falling_bins=digital_falling_bins,
+            number_of_steps=len(sequence),
+            number_of_samples=np.sum(step_length_bins),
+            number_of_samples_per_step=step_length_bins,
+            number_of_ensembles=len(ensemble_name_set),
+            ensemble_names=ensemble_name_set,
+            number_of_elements=np.sum(number_of_step_elements),
+            number_of_elements_per_step=number_of_step_elements,
+            elements_length_bins_per_step=step_elements_length_bins,
+            ideal_length_per_step=ideal_step_length,
+            ideal_length=np.sum(ideal_step_length),
+            laser_rising_bins=laser_rising_bins,
+            laser_falling_bins=laser_falling_bins,
+        )
 
     def _sampling_ensemble_sanity_check(self, ensemble):
         blocks_missing = set()
         channel_activation_mismatch = False
+        active_channels = self.__pulse_generator_settings.activation_config.channels
         for block_name, reps in ensemble.block_list:
             block = self._saved_pulse_blocks.get(block_name)
             # Check if block is present
@@ -1703,7 +1783,7 @@ class SequenceGeneratorLogic(LogicBase):
                 blocks_missing.add(block_name)
                 continue
             # Check for matching channel activation
-            if block.channel_set != self.__activation_config[1]:
+            if block.channel_set != active_channels:
                 channel_activation_mismatch = True
 
         # print error messages
@@ -1717,7 +1797,7 @@ class SequenceGeneratorLogic(LogicBase):
             self.log.error(
                 'Sampling of PulseBlockEnsemble "{0}" failed!\nMismatch of activation '
                 'config in logic ({1}) and used channels in PulseBlockEnsemble.'
-                ''.format(ensemble.name, self.__activation_config[1])
+                ''.format(ensemble.name, active_channels)
             )
 
         # Return error code
@@ -1765,7 +1845,8 @@ class SequenceGeneratorLogic(LogicBase):
                         created_waveforms:
                             list, a list of created waveform names
                         ensemble_info:
-                            dict, information about the ensemble returned by analyze_block_ensemble
+                            EnsembleAnalysisResult, information about the ensemble returned by
+                            analyze_block_ensemble
 
         This method is creating the actual samples (voltages and logic states) for each time step
         of the analog and digital channels specified in the PulseBlockEnsemble.
@@ -1827,19 +1908,21 @@ class SequenceGeneratorLogic(LogicBase):
             granularity = self.pulse_generator_constraints.waveform_length.step
             self.log.debug(
                 'length: {0}, mod {1}'.format(
-                    ensemble_info['number_of_samples'], ensemble_info['number_of_samples'] % granularity
+                    ensemble_info.number_of_samples, ensemble_info.number_of_samples % granularity
                 )
             )
-            if ensemble_info['number_of_samples'] % granularity != 0:
+            if ensemble_info.number_of_samples % granularity != 0:
                 self.log.warn(
                     'Length {0} does not fulfil step constraint {1}.'.format(
-                        ensemble_info['number_of_samples'], granularity
+                        ensemble_info.number_of_samples, granularity
                     )
                 )
                 # TODO: take care of rounding errors!
-                extension_samples = granularity - ensemble_info['number_of_samples'] % granularity
-                target_total_samples = ensemble_info['number_of_samples'] + extension_samples
-                extension_seconds = (target_total_samples / self.__sample_rate) - ensemble_info['ideal_length']
+                extension_samples = granularity - ensemble_info.number_of_samples % granularity
+                target_total_samples = ensemble_info.number_of_samples + extension_samples
+                extension_seconds = (
+                    target_total_samples / self.__pulse_generator_settings.sample_rate
+                ) - ensemble_info.ideal_length
 
                 pb_element = PulseBlockElement(
                     init_length_s=extension_seconds,
@@ -1862,40 +1945,40 @@ class SequenceGeneratorLogic(LogicBase):
 
                 # get important parameters from the ensemble
                 ensemble_info = self.analyze_block_ensemble(ensemble)
-                if ensemble_info['number_of_samples'] != target_total_samples:
+                if ensemble_info.number_of_samples != target_total_samples:
                     self.log.error(
                         'Expanding the PulseBlockEnsemble to match the waveform granularity '
                         'has failed.\nTarget number of samples was {0:d}.\nfinal number of '
                         'samples is {1:d}.\nThis is probably due to a rounding error in '
                         'SequenceGeneratorLogic.sample_pulse_block_ensemble.'
-                        ''.format(target_total_samples, ensemble_info['number_of_samples'])
+                        ''.format(target_total_samples, ensemble_info.number_of_samples)
                     )
                 else:
                     self.log.warn(
                         'Extending waveform {0} by {2} bins. New length {1}.'.format(
-                            ensemble.name, ensemble_info['number_of_samples'], extension_samples
+                            ensemble.name, ensemble_info.number_of_samples, extension_samples
                         )
                     )
 
             # Calculate the byte size per sample.
             # One analog sample per channel is 4 bytes (np.float32) and one digital sample per channel
             # is 1 byte (np.bool).
-            bytes_per_sample = len(ensemble_info['analog_channels']) * 4 + len(ensemble_info['digital_channels'])
+            bytes_per_sample = len(ensemble_info.analog_channels) * 4 + len(ensemble_info.digital_channels)
 
             # Calculate the bytes estimate for the entire ensemble
-            bytes_per_ensemble = bytes_per_sample * ensemble_info['number_of_samples']
+            bytes_per_ensemble = bytes_per_sample * ensemble_info.number_of_samples
 
             # Determine the size of the sample arrays to be written as a whole.
             if bytes_per_ensemble <= self._overhead_bytes or self._overhead_bytes == 0:
-                array_length = ensemble_info['number_of_samples']
+                array_length = ensemble_info.number_of_samples
             else:
                 array_length = self._overhead_bytes // bytes_per_sample
 
             n_max_samples = self.pulsegenerator().get_constraints().waveform_length.max
-            if n_max_samples > 0.0 and ensemble_info['number_of_samples'] > n_max_samples:
+            if n_max_samples > 0.0 and ensemble_info.number_of_samples > n_max_samples:
                 self.log.error(
                     "Tried to write more samples ({:d}) than device supports ({:d}).".format(
-                        ensemble_info['number_of_samples'], n_max_samples
+                        ensemble_info.number_of_samples, n_max_samples
                     )
                 )
                 if not self.__sequence_generation_in_progress:
@@ -1907,9 +1990,9 @@ class SequenceGeneratorLogic(LogicBase):
             analog_samples = dict()
             digital_samples = dict()
             try:
-                for chnl in ensemble_info['analog_channels']:
+                for chnl in ensemble_info.analog_channels:
                     analog_samples[chnl] = np.empty(array_length, dtype='float32')
-                for chnl in ensemble_info['digital_channels']:
+                for chnl in ensemble_info.digital_channels:
                     digital_samples[chnl] = np.empty(array_length, dtype=bool)
             except MemoryError:
                 self.log.error(
@@ -1923,7 +2006,7 @@ class SequenceGeneratorLogic(LogicBase):
                 self.sigSampleEnsembleComplete.emit(None)
                 return -1, list(), dict()
 
-            t_est_upload = self._benchmark_write.estimate_time(ensemble_info['number_of_samples'])
+            t_est_upload = self._benchmark_write.estimate_time(ensemble_info.number_of_samples)
             if t_est_upload > self._info_on_estimated_upload_time:
                 now = datetime.datetime.now()
                 self.log.info(
@@ -1949,7 +2032,7 @@ class SequenceGeneratorLogic(LogicBase):
                     for element in block.element_list:
                         digital_high = element.digital_high
                         pulse_function = element.pulse_function
-                        element_length_bins = ensemble_info['elements_length_bins'][element_count]
+                        element_length_bins = ensemble_info.elements_length_bins[element_count]
 
                         # Indicator on how many samples of this element have been written already
                         element_samples_written = 0
@@ -1963,7 +2046,7 @@ class SequenceGeneratorLogic(LogicBase):
                             if pulse_function:
                                 time_arr = (
                                     offset_bin + np.arange(samples_to_add, dtype='float64')
-                                ) / self.__sample_rate
+                                ) / self.__pulse_generator_settings.sample_rate
 
                             # Calculate respective part of the sample arrays
                             for chnl in digital_high:
@@ -1972,7 +2055,8 @@ class SequenceGeneratorLogic(LogicBase):
                                 )
                             for chnl in pulse_function:
                                 analog_samples[chnl][array_write_index : array_write_index + samples_to_add] = (
-                                    pulse_function[chnl].get_samples(time_arr) / (self.__analog_levels[0][chnl] / 2)
+                                    pulse_function[chnl].get_samples(time_arr)
+                                    / (self.__pulse_generator_settings.analog_levels.amplitude[chnl] / 2)
                                 )
 
                             # Free memory
@@ -1993,14 +2077,14 @@ class SequenceGeneratorLogic(LogicBase):
 
                                 # Set first/last chunk flags
                                 is_first_chunk = array_write_index == processed_samples
-                                is_last_chunk = processed_samples == ensemble_info['number_of_samples']
+                                is_last_chunk = processed_samples == ensemble_info.number_of_samples
                                 written_samples, wfm_list = self.pulsegenerator().write_waveform(
                                     name=waveform_name,
                                     analog_samples=analog_samples,
                                     digital_samples=digital_samples,
                                     is_first_chunk=is_first_chunk,
                                     is_last_chunk=is_last_chunk,
-                                    total_number_of_samples=ensemble_info['number_of_samples'],
+                                    total_number_of_samples=ensemble_info.number_of_samples,
                                 )
 
                                 # Update written waveforms set
@@ -2027,13 +2111,13 @@ class SequenceGeneratorLogic(LogicBase):
                                 # check if the temporary write array needs to be truncated for the next
                                 # part. (because it is the last part of the ensemble to write which can
                                 # be shorter than the previous chunks)
-                                if array_length > ensemble_info['number_of_samples'] - processed_samples:
-                                    array_length = ensemble_info['number_of_samples'] - processed_samples
+                                if array_length > ensemble_info.number_of_samples - processed_samples:
+                                    array_length = ensemble_info.number_of_samples - processed_samples
                                     analog_samples = dict()
                                     digital_samples = dict()
-                                    for chnl in ensemble_info['analog_channels']:
+                                    for chnl in ensemble_info.analog_channels:
                                         analog_samples[chnl] = np.empty(array_length, dtype='float32')
-                                    for chnl in ensemble_info['digital_channels']:
+                                    for chnl in ensemble_info.digital_channels:
                                         digital_samples[chnl] = np.empty(array_length, dtype=bool)
 
                         # Increment element index
@@ -2044,10 +2128,10 @@ class SequenceGeneratorLogic(LogicBase):
             # This step is only performed if the resulting waveforms are named by the PulseBlockEnsemble
             # and not by a sequence nametag
             if waveform_name == ensemble.name:
-                ensemble.sampling_information = dict()
-                ensemble.sampling_information.update(ensemble_info)
-                ensemble.sampling_information['pulse_generator_settings'] = self.pulse_generator_settings
-                ensemble.sampling_information['waveforms'] = natural_sort(written_waveforms)
+                info_dict = _dataclass_to_dict(ensemble_info)
+                info_dict['pulse_generator_settings'] = self.pulse_generator_settings
+                info_dict['waveforms'] = natural_sort(written_waveforms)
+                ensemble.sampling_information = SamplingInformation.from_dict(info_dict)
                 self.save_ensemble(ensemble)
 
             self.log.info(
@@ -2057,15 +2141,15 @@ class SequenceGeneratorLogic(LogicBase):
             )
             self.log.debug(
                 'Estimated {:.3f} s from current estimated write speed {:.2f} MSa/s from {} benchmarks'.format(
-                    self._benchmark_write.estimate_time(ensemble_info['number_of_samples']),
+                    self._benchmark_write.estimate_time(ensemble_info.number_of_samples),
                     self._benchmark_write.estimate_speed() / 1e6,
                     self._benchmark_write.n_benchmarks,
                 )
             )
 
-            self._benchmark_write.add_benchmark(time.time() - start_time, ensemble_info['number_of_samples'])
+            self._benchmark_write.add_benchmark(time.time() - start_time, ensemble_info.number_of_samples)
 
-            if ensemble_info['number_of_samples'] == 0:
+            if ensemble_info.number_of_samples == 0:
                 self.log.warning(
                     'Empty waveform (0 samples) created from PulseBlockEnsemble "{0}".'.format(ensemble.name)
                 )
@@ -2138,45 +2222,38 @@ class SequenceGeneratorLogic(LogicBase):
                 self.pulsegenerator().delete_sequence(sequence.name)
 
             # Make sure the PulseSequence is contained in the saved sequences dict
-            sequence.sampling_information = dict()
+            sequence.sampling_information = SamplingInformation()
             self.save_sequence(sequence)
 
             # Take current time
             start_time = time.time()
 
-            # Produce a set of created waveforms
-            written_waveforms = set()
-            # Keep track of generated PulseBlockEnsembles and their corresponding ensemble_info dict
-            generated_ensembles = dict()
-
-            # Create a list in the process with each element holding the created waveform names as a
-            # tuple and the corresponding sequence parameters as defined in the PulseSequence object
-            # Example: [(('waveform1', 'waveform2'), seq_param_dict1),
-            #           (('waveform3', 'waveform4'), seq_param_dict2)]
-            sequence_param_dict_list = list()
+            # Bookkeeping for this sampling run only - created fresh here and discarded once the
+            # run finishes (successfully or not), it is not persisted.
+            state = SequenceSamplingState()
+            state.start()
 
             # if all the Pulse_Block_Ensembles should be in the rotating frame, then each ensemble
             # will be created in general with a different offset_bin. Therefore, in order to keep track
             # of the sampled Pulse_Block_Ensembles one has to introduce a running number as an
             # additional name tag, so keep the sampled files separate.
-            offset_bin = 0  # that will be used for phase preservation
             for step_index, seq_step in enumerate(sequence):
                 if sequence.rotating_frame:
                     # to make something like 001
                     name_tag = seq_step.ensemble + '_' + str(step_index).zfill(3)
                 else:
                     name_tag = seq_step.ensemble
-                    offset_bin = 0  # Keep the offset at 0
+                    state.offset_bin = 0  # Keep the offset at 0
 
                 # Only sample ensembles if they have not already been sampled
                 if (
                     sequence.rotating_frame
                     or not self.get_ensemble(name_tag).sampling_information
-                    or self.get_ensemble(name_tag).sampling_information['pulse_generator_settings']
+                    or self.get_ensemble(name_tag).sampling_information.pulse_generator_settings
                     != self.pulse_generator_settings
                 ):
-                    offset_bin, waveform_list, ensemble_info = self.sample_pulse_block_ensemble(
-                        ensemble=seq_step.ensemble, offset_bin=offset_bin, name_tag=name_tag
+                    state.offset_bin, waveform_list, ensemble_info = self.sample_pulse_block_ensemble(
+                        ensemble=seq_step.ensemble, offset_bin=state.offset_bin, name_tag=name_tag
                     )
 
                     if len(waveform_list) == 0:
@@ -2191,38 +2268,42 @@ class SequenceGeneratorLogic(LogicBase):
                         return
 
                     # Add to generated ensembles
-                    ensemble_info['waveforms'] = waveform_list
-                    generated_ensembles[name_tag] = ensemble_info
-
-                    # Add created waveform names to the set
-                    written_waveforms.update(waveform_list)
+                    state.record_ensemble(name_tag, _dataclass_to_dict(ensemble_info), waveform_list)
                 else:
                     self.log.debug('Waveform already sampled: {0}'.format(name_tag))
-                    ensemble_info = self.get_ensemble(name_tag).sampling_information.copy()
-                    del ensemble_info['pulse_generator_settings']
-                    generated_ensembles[name_tag] = ensemble_info
+                    existing = self.get_ensemble(name_tag).sampling_information
+                    existing_info = _dataclass_to_dict(
+                        existing,
+                        exclude=(
+                            'pulse_generator_settings',
+                            'waveforms',
+                            'step_waveform_list',
+                            'ensemble_info',
+                            '_legacy_data',
+                        ),
+                    )
+                    existing_info.update(existing._legacy_data)
+                    state.record_ensemble(name_tag, existing_info, existing.waveforms)
 
-                    # Add created waveform names to the set
-                    written_waveforms.update(ensemble_info['waveforms'])
-
-                # Append written sequence step to sequence_param_dict_list
-                sequence_param_dict_list.append((tuple(generated_ensembles[name_tag]['waveforms']), seq_step))
+                # Append written sequence step to step_results
+                state.record_step(name_tag, seq_step)
 
             # pass the whole information to the sequence creation method:
-            steps_written = self.pulsegenerator().write_sequence(sequence.name, sequence_param_dict_list)
-            if steps_written != len(sequence_param_dict_list):
+            steps_written = self.pulsegenerator().write_sequence(sequence.name, state.step_results)
+            if steps_written != len(state.step_results):
                 self.log.error(
                     'Writing PulseSequence "{0}" to the device memory failed.\n'
                     'Returned number of sequence steps ({1:d}) does not match desired '
-                    'number of steps ({2:d}).'.format(sequence.name, steps_written, len(sequence_param_dict_list))
+                    'number of steps ({2:d}).'.format(sequence.name, steps_written, len(state.step_results))
                 )
 
             # get important parameters from the sequence and save them to the sequence object
-            sequence.sampling_information.update(self.analyze_sequence(sequence))
-            sequence.sampling_information['ensemble_info'] = generated_ensembles
-            sequence.sampling_information['pulse_generator_settings'] = self.pulse_generator_settings
-            sequence.sampling_information['waveforms'] = natural_sort(written_waveforms)
-            sequence.sampling_information['step_waveform_list'] = [step[0] for step in sequence_param_dict_list]
+            info_dict = _dataclass_to_dict(self.analyze_sequence(sequence))
+            info_dict['ensemble_info'] = state.generated_ensembles
+            info_dict['pulse_generator_settings'] = self.pulse_generator_settings
+            info_dict['waveforms'] = natural_sort(state.written_waveforms)
+            info_dict['step_waveform_list'] = [step[0] for step in state.step_results]
+            sequence.sampling_information = SamplingInformation.from_dict(info_dict)
             self.save_sequence(sequence)
 
             self.log.info(
@@ -2234,6 +2315,7 @@ class SequenceGeneratorLogic(LogicBase):
             # unlock module
             self.module_state.unlock()
             self.__sequence_generation_in_progress = False
+            state.finish()
             self.sigAvailableSequencesUpdated.emit(self.sampled_sequences)
             self.sigSampleSequenceComplete.emit(sequence)
             return
@@ -2269,7 +2351,7 @@ class SequenceGeneratorLogic(LogicBase):
         # ensembles
         if nametag in self.saved_pulse_block_ensembles:
             ensemble = self.saved_pulse_block_ensembles[nametag]
-            ensemble.sampling_information = dict()
+            ensemble.sampling_information = SamplingInformation()
             self.save_ensemble(ensemble)
         return
 
@@ -2311,8 +2393,7 @@ class SequenceGeneratorLogic(LogicBase):
                 granularity = constraints.waveform_length.step
                 return np.ceil(n_samples / granularity) * granularity
 
-            self._benchmark_write.reset()
-            self._benchmark_load.reset()
+            self.__pulser_benchmarks.reset()
 
             n_samples_min = constraints.waveform_length.min
             n_max_fix = max(10e6, n_samples_min)
@@ -2337,7 +2418,7 @@ class SequenceGeneratorLogic(LogicBase):
             while time.perf_counter() - t_start < t_goal and rescode == 0:
                 speed = self.get_speed_write_load()
                 t_left = t_goal - (time.perf_counter() - t_start)
-                if self._benchmark_write.sanity and self._benchmark_load.sanity:
+                if self.__pulser_benchmarks.write.sanity and self.__pulser_benchmarks.load.sanity:
                     n_samples = speed * t_left / time_fraction
                     n_samples = round_to_granularity(n_samples)
                 else:  # poor speed estimate so far
@@ -2491,27 +2572,35 @@ class SequenceGeneratorLogic(LogicBase):
         return 0, list(), dict()
 
     def has_valid_pg_benchmark(self):
-        is_valid = not np.isnan(self.get_speed_write_load())
-        ignore = self._disable_bench_prompt
-        if ignore:
-            return True
-        return is_valid
+        return self.__pulser_benchmarks.has_valid_estimate(ignore=self._disable_bench_prompt)
 
     def get_speed_write_load(self):
         """
         Get the estimated speed of the pulse generator for writing and loading a waveform.
         :return: speed (Sa/s)
         """
+        return self.__pulser_benchmarks.estimate_combined_speed()
+    
+    def _migrate_legacy_sampling_information(self, loaded_object):
+        """
+        Detects legacy dict-based sampling_information in unpickled objects 
+        and converts them to the SamplingInformation dataclass.
+        """
+        if not hasattr(loaded_object, 'sampling_information'):
+            return
 
-        if self._benchmark_write.sanity or self._benchmark_load.sanity:
-            # any single speed may be negative and sane, if independent on time (Sa/upload time slope close to zero)
-            # both at the same time is unlikely
-            speed_combined = 1 / (
-                1 / self._benchmark_write.estimate_speed(check_sanity=False)
-                + 1 / self._benchmark_load.estimate_speed(check_sanity=False)
-            )
-            if speed_combined < 0:
-                return np.nan
-            return speed_combined
+        # If it's already the new dataclass, do nothing
+        if isinstance(loaded_object.sampling_information, SamplingInformation):
+            return
 
-        return np.nan
+        # If it's a legacy dictionary, convert it
+        if isinstance(loaded_object.sampling_information, dict):
+            if not loaded_object.sampling_information:
+                # Replace empty dict with an empty dataclass (evaluates to False due to __bool__)
+                loaded_object.sampling_information = SamplingInformation()
+            else:
+                # Convert populated dict
+                self.log.debug(f'Migrating legacy sampling_information for {loaded_object.name}')
+                loaded_object.sampling_information = SamplingInformation.from_dict(
+                    loaded_object.sampling_information
+                )

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -42,7 +42,7 @@ from qudi.util.network import netobtain
 from qudi.core.module import LogicBase
 from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from qudi.logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElement
-from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType, SamplingFunctions
+from qudi.logic.pulsed.sampling_functions import PulseEnvelope, SamplingFunctions
 from qudi.interface.pulser_interface import PulserInterface, SequenceOption
 
 from qudi.util.yaml import SafeRepresenter, SafeConstructor
@@ -65,6 +65,8 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     LoadedAsset,
     SequenceSamplingState,
     PulserBenchmarks,
+    _DEFAULT_GENERATION_PARAMETERS,
+    _DEFAULT_PULSE_GENERATOR_SETTINGS,
 )
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import GenerationMethodParameters
 
@@ -81,33 +83,17 @@ def _dataclass_to_dict(obj, exclude=()):
 
 def _default_generator_settings():
     """Factory for the default SequenceGeneratorSettings, used both as the StatusVar default
-    and as the fallback when restoring a malformed/legacy status value."""
+    and as the fallback when restoring a malformed/legacy status value.
+
+    generation_parameters/pulse_generator_settings reuse the single shared default instances
+    defined in sequence_generator_logic_data.py (that file can't import back from this one, so
+    it owns these literals rather than duplicating them here) - SequenceGeneratorSettings.
+    from_dict() falls back to the exact same instances when a saved settings file is missing one
+    of these keys.
+    """
     return SequenceGeneratorSettings(
-        generation_parameters=GenerationParameters(
-            laser_channel='d_ch1',
-            sync_channel='',
-            gate_channel='',
-            microwave_channel='a_ch1',
-            microwave_frequency=2.87e9,
-            microwave_amplitude=0.0,
-            rabi_period=100e-9,
-            laser_length=3e-6,
-            laser_delay=500e-9,
-            wait_time=1e-6,
-            analog_trigger_voltage=0.0,
-            optimal_control_assets_path='C:\\Software\\qudi_data\\optimal_control_assets',
-            pulse_envelope=PulseEnvelope(PulseEnvelopeType.rectangle),
-            pulse_envelope_order=1,
-        ),
-        pulse_generator_settings=PulseGeneratorSettings(
-            activation_config=ActivationConfig(name='', channels=set()),
-            sample_rate=0.0,
-            analog_levels=AnalogLevels(amplitude=dict(), offset=dict()),
-            digital_levels=DigitalLevels(low=dict(), high=dict()),
-            interleave=False,
-            flags=set(),
-            upload_speed=np.nan,
-        ),
+        generation_parameters=_DEFAULT_GENERATION_PARAMETERS,
+        pulse_generator_settings=_DEFAULT_PULSE_GENERATOR_SETTINGS,
         pulser_benchmarks=PulserBenchmarks(),
     )
 

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -1861,7 +1861,6 @@ class SequenceGeneratorLogic(LogicBase):
             analog_channels=analog_channels,
             digital_channels=digital_channels,
             channel_set=analog_channels.union(digital_channels),
-            generation_parameters=self._generator_settings.generation_parameters,
             ideal_length=current_end_time,
             laser_rising_bins=laser_rising_bins,
             laser_falling_bins=laser_falling_bins,
@@ -2084,7 +2083,6 @@ class SequenceGeneratorLogic(LogicBase):
             digital_channels=digital_channels,
             analog_channels=analog_channels,
             channel_set=analog_channels.union(digital_channels),
-            generation_parameters=self._generator_settings.generation_parameters,
             digital_rising_bins=digital_rising_bins,
             digital_falling_bins=digital_falling_bins,
             number_of_steps=len(sequence),
@@ -2618,7 +2616,17 @@ class SequenceGeneratorLogic(LogicBase):
                             '_legacy_data',
                         ),
                     )
-                    existing_info.update(existing._legacy_data)
+                    # _legacy_data is the untyped back door, and what lands here goes on to nest
+                    # inside SamplingInformation.ensemble_info - a declared dict field, so
+                    # from_dict()'s key filtering does not reach into it. Filter here too, or a
+                    # rejected key could ride back in one level down.
+                    existing_info.update(
+                        {
+                            key: value
+                            for key, value in existing._legacy_data.items()
+                            if key not in type(existing)._REJECTED_KEYS
+                        }
+                    )
                     state.record_ensemble(name_tag, existing_info, existing.waveforms)
 
                 # Append written sequence step to step_results
@@ -2962,3 +2970,18 @@ class SequenceGeneratorLogic(LogicBase):
                         backfilled, attr_name, loaded_object.name
                     )
                 )
+            # from_dict() refuses these, but pickle.load() bypasses it and restores _legacy_data
+            # verbatim - so an asset saved before a key was rejected still carries it. Drop it
+            # here instead, on the one path every unpickled asset goes through.
+            rejected = getattr(type(value), '_REJECTED_KEYS', frozenset())
+            legacy_data = getattr(value, '_legacy_data', None)
+            if rejected and isinstance(legacy_data, dict):
+                dropped = [key for key in legacy_data if key in rejected]
+                for key in dropped:
+                    del legacy_data[key]
+                if dropped:
+                    self.log.debug(
+                        'Dropped stale key(s) {0} from legacy {1} for {2}'.format(
+                            dropped, attr_name, loaded_object.name
+                        )
+                    )

--- a/src/qudi/util/yaml_helpers.py
+++ b/src/qudi/util/yaml_helpers.py
@@ -22,6 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 from dataclasses import fields
 
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
 
 def dataclass_representer(representer, data):
     tag = f'!{data.__class__.__name__}'
@@ -32,3 +33,8 @@ def dataclass_representer(representer, data):
 def pulse_envelope_constructor(loader, node):
     data = loader.construct_mapping(node, deep=True)
     return PulseEnvelope.from_dict(data)
+
+
+def sampling_information_constructor(loader, node):
+    data = loader.construct_mapping(node, deep=True)
+    return SamplingInformation.from_dict(data)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,18 @@
+import pickle
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import SamplingInformation
+
+# 1. Provide the path to one of your legacy .ensemble files
+file_path = r"C:\Users\BM\saved_pulsed_assets\rabi.ensemble"
+
+with open(file_path, 'rb') as f:
+    ensemble = pickle.load(f)
+
+print(f"Current type of sampling_information: {type(ensemble.sampling_information)}")
+
+# 2. If it's a dict, manually run your migration logic to see if it works
+if isinstance(ensemble.sampling_information, dict):
+    new_info = SamplingInformation.from_dict(ensemble.sampling_information)
+    print("Migration successful! New type:")
+    print(type(new_info))
+else:
+    print("Already a dataclass.")

--- a/tests/test_pulsed_measurement.py
+++ b/tests/test_pulsed_measurement.py
@@ -1,0 +1,176 @@
+from dataclasses import replace
+
+import numpy as np
+
+from qudi.logic.pulsed.pulse_objects import PulseBlockEnsemble, PulseSequence
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    GenerationMethodParameters,
+    MeasurementInformation,
+    PulsedMeasurementData,
+    PulsedMeasurementSettings,
+)
+from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
+    SamplingInformation,
+    SequenceGeneratorSettings,
+)
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, Settings
+from qudi.logic.pulsed.pulsed_measurement_logic import _default_measurement_settings
+from qudi.logic.pulsed.sequence_generator_logic import _default_generator_settings
+
+
+def _sample_data():
+    return PulsedMeasurementData(
+        raw_data=np.array([1, 2, 3], dtype=np.int64),
+        laser_data=np.array([[1, 2], [3, 4]], dtype=np.int64),
+        signal_data=np.array([[0.0, 1.0], [0.5, 0.6]], dtype=float),
+        signal_alt_data=np.zeros((2, 2), dtype=float),
+        measurement_error=np.zeros((2, 2), dtype=float),
+        elapsed_time=12.5,
+        elapsed_sweeps=3,
+    )
+
+
+def test_pulsed_measurement_round_trip_with_generator_settings():
+    measurement = PulsedMeasurement(
+        settings=Settings(
+            measurement_settings=_default_measurement_settings(),
+            generator_settings=_default_generator_settings(),
+        ),
+        data=PulsedData(measurement_data=_sample_data()),
+    )
+
+    restored = PulsedMeasurement.from_dict(measurement.to_dict())
+
+    # PulsedMeasurementSettings/ReadoutSettings has no custom __eq__, so comparing it directly
+    # would hit the numpy ambiguous-truth-value issue documented elsewhere in this codebase -
+    # spot-check a couple of fields via a class that IS safely comparable instead.
+    assert (
+        restored.settings.generator_settings.generation_parameters
+        == _default_generator_settings().generation_parameters
+    )
+    assert restored.settings.measurement_settings.timer_interval_s == 5.0
+    assert restored.settings.measurement_settings.fit_configs == _default_measurement_settings().fit_configs
+    assert restored.data.measurement_data.elapsed_sweeps == 3
+    assert restored.data.measurement_data.elapsed_time == 12.5
+    assert np.array_equal(restored.data.measurement_data.raw_data, measurement.data.measurement_data.raw_data)
+    # fit_result/fit_result_alt are intentionally never restored by from_dict() - see PulsedData's
+    # class docstring for why (lmfit.model.ModelResult has no reconstruction path).
+    assert restored.data.fit_result is None
+    assert restored.data.fit_result_alt is None
+    # sequence is intentionally never part of to_dict()/from_dict() - see PulsedMeasurement's
+    # class docstring for why.
+    assert restored.sequence is None
+
+
+def test_pulsed_measurement_round_trip_without_generator_settings_or_data():
+    measurement = PulsedMeasurement(settings=Settings(measurement_settings=_default_measurement_settings()))
+
+    restored = PulsedMeasurement.from_dict(measurement.to_dict())
+
+    assert restored.settings.generator_settings is None
+    assert restored.data is None
+
+
+def test_pulsed_measurement_settings_fit_configs_round_trip():
+    custom_configs = (
+        {'name': 'Custom Fit', 'model': 'Sine', 'estimator': 'default', 'custom_parameters': None},
+    )
+    settings = replace(_default_measurement_settings(), fit_configs=custom_configs)
+
+    restored = PulsedMeasurementSettings.from_dict(settings.to_dict())
+
+    assert restored.fit_configs == custom_configs
+
+
+def test_pulsed_measurement_data_copy_is_independent():
+    data = _sample_data()
+    copy = data.copy()
+
+    copy.raw_data[0] = 999
+    copy.elapsed_sweeps = 100
+
+    assert data.raw_data[0] == 1
+    assert data.elapsed_sweeps == 3
+
+
+def test_pulse_block_ensemble_copy_is_independent():
+    ensemble = PulseBlockEnsemble(name='original', block_list=[('block1', 3)], rotating_frame=True)
+    ensemble.measurement_information = MeasurementInformation(
+        number_of_lasers=2,
+        controlled_variable=np.array([0.0, 1.0]),
+        laser_ignore_list=[],
+        alternating=False,
+        counting_length=1e-6,
+    )
+    ensemble.generation_method_parameters = GenerationMethodParameters({'xy8_order': 8})
+
+    copy = ensemble.copy()
+    copy.block_list.append(('block2', 1))
+    copy.generation_method_parameters['xy8_order'] = 16
+    copy.measurement_information.number_of_lasers = 99
+
+    assert ensemble.block_list == [('block1', 3)]
+    assert ensemble.generation_method_parameters['xy8_order'] == 8
+    assert ensemble.measurement_information.number_of_lasers == 2
+
+
+def test_pulse_sequence_copy_is_independent():
+    # ensemble_list entries are SequenceStep, a mutable dict subclass - this is the exact case
+    # a naive shallow list() copy would get wrong (see PulseSequence.copy()'s docstring).
+    sequence = PulseSequence(name='original', ensemble_list=[('ensemble1', {'repetitions': 2})], rotating_frame=True)
+    sequence.generation_method_parameters = GenerationMethodParameters({'order': 4})
+
+    copy = sequence.copy()
+    copy.ensemble_list[0]['repetitions'] = 99
+    copy.generation_method_parameters['order'] = 8
+
+    assert sequence.ensemble_list[0]['repetitions'] == 2
+    assert sequence.generation_method_parameters['order'] == 4
+
+
+def test_pulsed_measurement_settings_from_dict_tolerates_missing_keys():
+    # Simulates loading an older saved settings file that predates a field being added to
+    # PulsedMeasurementSettings (e.g. before fit_configs existed) - from_dict() must degrade to
+    # that field's own default rather than raising KeyError.
+    full_dict = _default_measurement_settings().to_dict()
+    del full_dict['fit_configs']
+    del full_dict['microwave_settings']
+
+    restored = PulsedMeasurementSettings.from_dict(full_dict)
+
+    assert restored.fit_configs == ()
+    assert restored.microwave_settings.power == -30.0
+    assert restored.microwave_settings.frequency == 2870e6
+    # Fields that WERE present still round-trip correctly - this isn't a blanket "ignore
+    # everything" fallback, only missing keys are defaulted.
+    assert restored.timer_interval_s == _default_measurement_settings().timer_interval_s
+
+
+def test_sequence_generator_settings_from_dict_tolerates_missing_keys():
+    full_dict = _default_generator_settings().to_dict()
+    del full_dict['generation_parameters']
+    del full_dict['pulser_benchmarks']
+
+    restored = SequenceGeneratorSettings.from_dict(full_dict)
+
+    assert restored.generation_parameters == _default_generator_settings().generation_parameters
+    assert restored.pulser_benchmarks.write.n_benchmarks == 0
+
+
+def test_sampling_information_laser_bins_are_real_fields_not_legacy():
+    info = SamplingInformation.from_dict({
+        'laser_rising_bins': [10, 20, 30],
+        'laser_falling_bins': [15, 25, 35],
+    })
+
+    # Real dataclass fields, not routed through the _legacy_data catch-all - this is what
+    # basic_extraction_methods.py's ungated_gated_conv_deriv() reads via
+    # sampling_information['laser_rising_bins'].
+    assert 'laser_rising_bins' in info._field_names()
+    assert 'laser_falling_bins' not in info._legacy_data
+    assert list(info['laser_rising_bins']) == [10, 20, 30]
+    assert list(info['laser_falling_bins']) == [15, 25, 35]
+
+    restored = SamplingInformation.from_dict(info.to_dict())
+    assert list(restored.laser_rising_bins) == [10, 20, 30]
+    assert list(restored.laser_falling_bins) == [15, 25, 35]

--- a/tests/test_pulsed_measurement.py
+++ b/tests/test_pulsed_measurement.py
@@ -222,10 +222,11 @@ def test_pulsed_measurement_settings_migrates_legacy_status_dict():
     assert migrated.readout_settings.laser_ignore_list == [0, 1]
     assert migrated.readout_settings.units == ('s', 'a.u.')
     assert migrated.readout_settings.labels == ('Time', 'Contrast')
-    assert migrated.alternate_signal_settings.zeropad == 2
-    assert migrated.alternate_signal_settings.psd is True
-    assert migrated.alternate_signal_settings.window == 'hann'
-    assert migrated.alternate_signal_settings.base_corr is False
+    assert migrated.alternate_signal_settings.method is None
+    assert migrated.alternate_signal_settings.parameters['zeropad'] == 2
+    assert migrated.alternate_signal_settings.parameters['psd'] is True
+    assert migrated.alternate_signal_settings.parameters['window'] == 'hann'
+    assert migrated.alternate_signal_settings.parameters['base_corr'] is False
     assert migrated.extraction_parameters == {'method': 'gated_conv_deriv', 'conv_std_dev': 15.0}
     assert migrated.analysis_parameters == {'method': 'mean_norm'}
     # timer_interval_s/fit_configs are no longer fields of PulsedMeasurementSettings (see its

--- a/tests/test_pulsed_measurement.py
+++ b/tests/test_pulsed_measurement.py
@@ -1,8 +1,9 @@
-from dataclasses import replace
+import dataclasses
+import pickle
 
 import numpy as np
 
-from qudi.logic.pulsed.pulse_objects import PulseBlockEnsemble, PulseSequence
+from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockElement, PulseBlockEnsemble, PulseSequence
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     GenerationMethodParameters,
     MeasurementInformation,
@@ -13,9 +14,10 @@ from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     SamplingInformation,
     SequenceGeneratorSettings,
 )
-from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, Settings
-from qudi.logic.pulsed.pulsed_measurement_logic import _default_measurement_settings
-from qudi.logic.pulsed.sequence_generator_logic import _default_generator_settings
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement import PulsedMeasurement, PulsedData, PulseObjects, Settings
+from qudi.logic.pulsed.pulsed_measurement_logic import PulsedMeasurementLogic, _default_measurement_settings
+from qudi.logic.pulsed.sequence_generator_logic import _default_generator_settings, _resolve_asset_closure
+from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType
 
 
 def _sample_data():
@@ -48,8 +50,6 @@ def test_pulsed_measurement_round_trip_with_generator_settings():
         restored.settings.generator_settings.generation_parameters
         == _default_generator_settings().generation_parameters
     )
-    assert restored.settings.measurement_settings.timer_interval_s == 5.0
-    assert restored.settings.measurement_settings.fit_configs == _default_measurement_settings().fit_configs
     assert restored.data.measurement_data.elapsed_sweeps == 3
     assert restored.data.measurement_data.elapsed_time == 12.5
     assert np.array_equal(restored.data.measurement_data.raw_data, measurement.data.measurement_data.raw_data)
@@ -57,9 +57,11 @@ def test_pulsed_measurement_round_trip_with_generator_settings():
     # class docstring for why (lmfit.model.ModelResult has no reconstruction path).
     assert restored.data.fit_result is None
     assert restored.data.fit_result_alt is None
-    # sequence is intentionally never part of to_dict()/from_dict() - see PulsedMeasurement's
-    # class docstring for why.
-    assert restored.sequence is None
+    # Nothing was loaded when this snapshot was built, so objects.sequence/.ensembles/.blocks all
+    # default to empty - see PulseObjects.
+    assert restored.objects.sequence is None
+    assert restored.objects.ensembles == {}
+    assert restored.objects.blocks == {}
 
 
 def test_pulsed_measurement_round_trip_without_generator_settings_or_data():
@@ -69,17 +71,6 @@ def test_pulsed_measurement_round_trip_without_generator_settings_or_data():
 
     assert restored.settings.generator_settings is None
     assert restored.data is None
-
-
-def test_pulsed_measurement_settings_fit_configs_round_trip():
-    custom_configs = (
-        {'name': 'Custom Fit', 'model': 'Sine', 'estimator': 'default', 'custom_parameters': None},
-    )
-    settings = replace(_default_measurement_settings(), fit_configs=custom_configs)
-
-    restored = PulsedMeasurementSettings.from_dict(settings.to_dict())
-
-    assert restored.fit_configs == custom_configs
 
 
 def test_pulsed_measurement_data_copy_is_independent():
@@ -130,31 +121,24 @@ def test_pulse_sequence_copy_is_independent():
 
 def test_pulsed_measurement_settings_from_dict_tolerates_missing_keys():
     # Simulates loading an older saved settings file that predates a field being added to
-    # PulsedMeasurementSettings (e.g. before fit_configs existed) - from_dict() must degrade to
-    # that field's own default rather than raising KeyError.
+    # PulsedMeasurementSettings - from_dict() must degrade to that field's own default rather
+    # than raising KeyError.
     full_dict = _default_measurement_settings().to_dict()
-    del full_dict['fit_configs']
     del full_dict['microwave_settings']
 
     restored = PulsedMeasurementSettings.from_dict(full_dict)
 
-    assert restored.fit_configs == ()
     assert restored.microwave_settings.power == -30.0
     assert restored.microwave_settings.frequency == 2870e6
-    # Fields that WERE present still round-trip correctly - this isn't a blanket "ignore
-    # everything" fallback, only missing keys are defaulted.
-    assert restored.timer_interval_s == _default_measurement_settings().timer_interval_s
 
 
 def test_sequence_generator_settings_from_dict_tolerates_missing_keys():
     full_dict = _default_generator_settings().to_dict()
     del full_dict['generation_parameters']
-    del full_dict['pulser_benchmarks']
 
     restored = SequenceGeneratorSettings.from_dict(full_dict)
 
     assert restored.generation_parameters == _default_generator_settings().generation_parameters
-    assert restored.pulser_benchmarks.write.n_benchmarks == 0
 
 
 def test_sampling_information_laser_bins_are_real_fields_not_legacy():
@@ -174,3 +158,297 @@ def test_sampling_information_laser_bins_are_real_fields_not_legacy():
     restored = SamplingInformation.from_dict(info.to_dict())
     assert list(restored.laser_rising_bins) == [10, 20, 30]
     assert list(restored.laser_falling_bins) == [15, 25, 35]
+
+
+def test_legacy_status_var_keys_not_dataclass_fields():
+    # LEGACY_STATUS_VAR_KEYS is a plain class attribute used only for legacy-format detection
+    # (see PulsedMeasurementLogic/SequenceGeneratorLogic._migrate_legacy_settings_if_needed()) -
+    # it must never be picked up as a real dataclass field (that would require it to be passed
+    # to every constructor call and would show up in to_dict()/from_dict()).
+    assert 'LEGACY_STATUS_VAR_KEYS' not in {f.name for f in dataclasses.fields(PulsedMeasurementSettings)}
+    assert 'LEGACY_STATUS_VAR_KEYS' not in {f.name for f in dataclasses.fields(SequenceGeneratorSettings)}
+
+
+def test_pulsed_measurement_settings_migrates_legacy_status_dict():
+    # Simulates a real status file saved by the pre-refactor PulsedMeasurementLogic: ~20
+    # individually-keyed StatusVars (some Python-name-mangled) at the top level, instead of one
+    # '_settings' key - see PulsedMeasurementSettings.from_legacy_dict()'s docstring.
+    legacy_raw = {
+        '_PulsedMeasurementLogic__microwave_power': -13.0,
+        '_PulsedMeasurementLogic__microwave_freq': 2.5e9,
+        '_PulsedMeasurementLogic__use_ext_microwave': True,
+        '_PulsedMeasurementLogic__fast_counter_record_length': 5e-6,
+        '_PulsedMeasurementLogic__fast_counter_binwidth': 2e-9,
+        '_PulsedMeasurementLogic__fast_counter_gates': 4,
+        '_PulsedMeasurementLogic__timer_interval': 3,
+        '_invoke_settings_from_sequence': True,
+        '_number_of_lasers': 20,
+        '_controlled_variable': list(range(20)),
+        '_alternating': True,
+        '_laser_ignore_list': [0, 1],
+        '_data_units': ('s', 'a.u.'),
+        '_data_labels': ('Time', 'Contrast'),
+        'extraction_parameters': {'method': 'gated_conv_deriv', 'conv_std_dev': 15.0},
+        'analysis_parameters': {'method': 'mean_norm'},
+        'fit_configs': ({'name': 'Custom', 'model': 'Sine', 'estimator': 'default', 'custom_parameters': None},),
+        '_alternative_data_type': None,
+        'zeropad': 2,
+        'psd': True,
+        'window': 'hann',
+        'base_corr': False,
+    }
+
+    # A file with no '_settings' key but recognizable legacy keys must be detected as legacy -
+    # this is the exact condition used in PulsedMeasurementLogic._migrate_legacy_settings_if_needed().
+    assert '_settings' not in legacy_raw
+    assert PulsedMeasurementSettings.LEGACY_STATUS_VAR_KEYS.intersection(legacy_raw)
+
+    migrated = PulsedMeasurementSettings.from_legacy_dict(legacy_raw)
+
+    assert migrated.microwave_settings.power == -13.0
+    assert migrated.microwave_settings.frequency == 2.5e9
+    assert migrated.microwave_settings.use_ext_microwave is True
+    assert migrated.fast_counter_settings.bin_width == 2e-9
+    assert migrated.fast_counter_settings.record_length == 5e-6
+    assert migrated.fast_counter_settings.number_of_gates == 4
+    # is_gated is never persisted in the legacy format (it was always a live hardware query) -
+    # left at False here; PulsedMeasurementLogic.on_activate() re-syncs it from real hardware
+    # immediately afterwards via set_fast_counter_settings().
+    assert migrated.fast_counter_settings.is_gated is False
+    assert migrated.readout_settings.invoke_settings is True
+    assert migrated.readout_settings.number_of_lasers == 20
+    assert np.array_equal(migrated.readout_settings.controlled_variable, np.arange(20, dtype=float))
+    assert migrated.readout_settings.alternating is True
+    assert migrated.readout_settings.laser_ignore_list == [0, 1]
+    assert migrated.readout_settings.units == ('s', 'a.u.')
+    assert migrated.readout_settings.labels == ('Time', 'Contrast')
+    assert migrated.alternate_signal_settings.zeropad == 2
+    assert migrated.alternate_signal_settings.psd is True
+    assert migrated.alternate_signal_settings.window == 'hann'
+    assert migrated.alternate_signal_settings.base_corr is False
+    assert migrated.extraction_parameters == {'method': 'gated_conv_deriv', 'conv_std_dev': 15.0}
+    assert migrated.analysis_parameters == {'method': 'mean_norm'}
+    # timer_interval_s/fit_configs are no longer fields of PulsedMeasurementSettings (see its
+    # class docstring) - PulsedMeasurementLogic._migrate_legacy_settings_if_needed() migrates
+    # these two directly from the same raw dict into its own independent StatusVars instead,
+    # which requires a real logic instance and so isn't covered at this dataclass-level test.
+
+    # An empty dict (brand new install, file doesn't exist yet) must never be flagged as legacy.
+    assert not PulsedMeasurementSettings.LEGACY_STATUS_VAR_KEYS.intersection({})
+    # A dict that already has the new '_settings' key must never be re-migrated.
+    assert '_settings' in {'_settings': {}}
+
+
+def test_sequence_generator_settings_migrates_legacy_status_dict():
+    # Simulates a real status file saved by the pre-refactor SequenceGeneratorLogic: 3 separate
+    # StatusVars (_generation_parameters, _benchmark_write_state, _benchmark_load_state) instead
+    # of one '_generator_settings' key. pulse_envelope is a real PulseEnvelope instance here
+    # because qudi's registered YAML constructor for '!PulseEnvelope' already reconstructs it
+    # during yaml_load(), before this code ever sees the dict - see
+    # SequenceGeneratorSettings.from_legacy_dict()'s docstring.
+    legacy_raw = {
+        '_generation_parameters': {
+            'laser_channel': 'd_ch2',
+            'sync_channel': '',
+            'gate_channel': '',
+            'microwave_channel': 'a_ch1',
+            'microwave_frequency': 2.9e9,
+            'microwave_amplitude': 0.25,
+            'rabi_period': 80e-9,
+            'laser_length': 2e-6,
+            'laser_delay': 4e-7,
+            'wait_time': 8e-7,
+            'analog_trigger_voltage': 0.0,
+            'optimal_control_assets_path': 'C:\\some\\path',
+            'pulse_envelope': PulseEnvelope(PulseEnvelopeType.rectangle),
+            'pulse_envelope_order': 1,
+        },
+        '_benchmark_write_state': {
+            '_n_save_datapoints': 20,
+            '_datapoints': [(1.0, 100), (2.0, 200)],
+            '_datapoints_fixed': [],
+        },
+        '_benchmark_load_state': {
+            '_n_save_datapoints': 20,
+            '_datapoints': [],
+            '_datapoints_fixed': [],
+        },
+    }
+
+    assert '_generator_settings' not in legacy_raw
+    assert SequenceGeneratorSettings.LEGACY_STATUS_VAR_KEYS.intersection(legacy_raw)
+
+    migrated = SequenceGeneratorSettings.from_legacy_dict(legacy_raw)
+
+    assert migrated.generation_parameters.laser_channel == 'd_ch2'
+    assert migrated.generation_parameters.microwave_frequency == 2.9e9
+    assert migrated.generation_parameters.microwave_amplitude == 0.25
+    assert migrated.generation_parameters.rabi_period == 80e-9
+    assert migrated.generation_parameters.optimal_control_assets_path == 'C:\\some\\path'
+    # pulser_benchmarks is no longer a field of SequenceGeneratorSettings (see its class
+    # docstring) - SequenceGeneratorLogic._migrate_legacy_settings_if_needed() migrates it
+    # directly from the same raw dict into its own independent StatusVar instead, which requires
+    # a real logic instance and so isn't covered at this dataclass-level test.
+    # pulse_generator_settings is deliberately never migrated - the old format never persisted it
+    # either (SequenceGeneratorLogic.on_activate() always re-derives it fresh from hardware via
+    # _read_settings_from_device(), for both old and new code).
+    assert migrated.pulse_generator_settings == _default_generator_settings().pulse_generator_settings
+
+
+def test_measurement_snapshot_pickle_round_trip(tmp_path):
+    # Exercises PulsedMeasurementLogic.load_measurement_snapshot() against a real file on disk,
+    # mirroring what save_measurement_data(save_measurement_snapshot=True) produces (see that
+    # method's pickle.dump() of get_pulsed_measurement()'s return value).
+    data = _sample_data()
+    snapshot = PulsedMeasurement(
+        settings=Settings(
+            measurement_settings=_default_measurement_settings(),
+            generator_settings=_default_generator_settings(),
+        ),
+        data=PulsedData(measurement_data=data),
+    )
+
+    file_path = tmp_path / 'test.pulsedmeasurement'
+    with open(file_path, 'wb') as snapshot_file:
+        pickle.dump(snapshot, snapshot_file)
+
+    restored = PulsedMeasurementLogic.load_measurement_snapshot(str(file_path))
+
+    assert isinstance(restored, PulsedMeasurement)
+    assert restored.data.measurement_data.elapsed_sweeps == 3
+    assert restored.data.measurement_data.elapsed_time == 12.5
+    assert np.array_equal(restored.data.measurement_data.raw_data, data.raw_data)
+    assert (
+        restored.settings.generator_settings.generation_parameters
+        == _default_generator_settings().generation_parameters
+    )
+    assert restored.objects.sequence is None
+
+
+def test_pulse_block_copy_is_independent():
+    block = PulseBlock(name='original', element_list=[PulseBlockElement(init_length_s=1e-6)])
+
+    copy = block.copy()
+    copy.element_list[0].init_length_s = 999.0
+    copy.element_list.append(PulseBlockElement(init_length_s=2e-6))
+
+    assert len(block.element_list) == 1
+    assert block.element_list[0].init_length_s == 1e-6
+
+
+def _build_closure_fixtures():
+    """3 blocks, 2 ensembles (blk_2 shared between them), 1 sequence referencing both ensembles
+    (ens_a referenced twice, with different repetitions) - used by the closure-resolution tests
+    below."""
+    blk_1 = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    blk_2 = PulseBlock(name='blk_2', element_list=[PulseBlockElement(init_length_s=5e-7)])
+    blk_3 = PulseBlock(name='blk_3', element_list=[PulseBlockElement(init_length_s=2e-6)])
+    ens_a = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 2), ('blk_2', 0)])
+    ens_b = PulseBlockEnsemble(name='ens_b', block_list=[('blk_2', 0), ('blk_3', 0)])
+    sequence = PulseSequence(name='seq_main', ensemble_list=[
+        ('ens_a', {'repetitions': 0, 'go_to': -1}),
+        ('ens_b', {'repetitions': 5, 'go_to': -1}),
+        ('ens_a', {'repetitions': 2, 'go_to': -1}),
+    ])
+    saved_blocks = {'blk_1': blk_1, 'blk_2': blk_2, 'blk_3': blk_3}
+    saved_ensembles = {'ens_a': ens_a, 'ens_b': ens_b}
+    return sequence, ens_a, saved_ensembles, saved_blocks
+
+
+def test_resolve_asset_closure_skips_missing_references():
+    sequence, ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def __init__(self):
+            self.warnings = []
+
+        def warning(self, msg):
+            self.warnings.append(msg)
+
+    # Case A: a referenced ensemble name is missing from the registry.
+    log = _FakeLog()
+    incomplete_ensembles = {'ens_a': saved_ensembles['ens_a']}  # 'ens_b' missing
+    ensembles, blocks = _resolve_asset_closure(sequence, incomplete_ensembles, saved_blocks, log)
+    assert set(ensembles) == {'ens_a'}
+    assert 'ens_b' not in ensembles
+    assert len(log.warnings) == 1
+
+    # Case B: a referenced block name is missing from the registry.
+    log = _FakeLog()
+    incomplete_blocks = {'blk_1': saved_blocks['blk_1']}  # 'blk_2' missing
+    ensembles, blocks = _resolve_asset_closure(ens_a, saved_ensembles, incomplete_blocks, log)
+    assert set(blocks) == {'blk_1'}
+    assert 'blk_2' not in blocks
+    assert len(log.warnings) == 1
+
+    # None input.
+    log = _FakeLog()
+    assert _resolve_asset_closure(None, saved_ensembles, saved_blocks, log) == ({}, {})
+    assert log.warnings == []
+
+
+def test_pulsed_measurement_closure_round_trip():
+    sequence, _ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def warning(self, msg):
+            pass
+
+    ensembles, blocks = _resolve_asset_closure(sequence, saved_ensembles, saved_blocks, _FakeLog())
+
+    measurement = PulsedMeasurement(
+        settings=Settings(measurement_settings=_default_measurement_settings()),
+        objects=PulseObjects(sequence=sequence.copy(), ensembles=ensembles, blocks=blocks),
+    )
+
+    as_dict = measurement.to_dict()
+    assert as_dict['objects']['sequence']['type'] == 'PulseSequence'
+    assert len(as_dict['objects']['ensembles']) == 2
+    assert len(as_dict['objects']['blocks']) == 3  # blk_2 shared between ens_a/ens_b, deduped
+    assert len(as_dict['objects']['elements']) == 3  # one element per block
+
+    restored = PulsedMeasurement.from_dict(as_dict)
+    assert isinstance(restored.objects.sequence, PulseSequence)
+    assert restored.objects.sequence.name == 'seq_main'
+    assert restored.objects.sequence.ensemble_list == sequence.ensemble_list
+    assert set(restored.objects.ensembles) == {'ens_a', 'ens_b'}
+    assert restored.objects.ensembles['ens_a'].block_list == [('blk_1', 2), ('blk_2', 0)]
+    assert set(restored.objects.blocks) == {'blk_1', 'blk_2', 'blk_3'}
+    assert restored.objects.blocks['blk_1'].element_list[0] == blocks['blk_1'].element_list[0]
+
+
+def test_pulsed_measurement_bare_ensemble_closure_round_trip():
+    _sequence, ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def warning(self, msg):
+            pass
+
+    # Loaded asset is a bare PulseBlockEnsemble, not wrapped in a PulseSequence.
+    ensembles, blocks = _resolve_asset_closure(ens_a, saved_ensembles, saved_blocks, _FakeLog())
+    assert ensembles == {}  # nothing one level up to resolve for a bare ensemble
+    assert set(blocks) == {'blk_1', 'blk_2'}
+
+    measurement = PulsedMeasurement(
+        settings=Settings(measurement_settings=_default_measurement_settings()),
+        objects=PulseObjects(sequence=ens_a.copy(), ensembles=ensembles, blocks=blocks),
+    )
+
+    restored = PulsedMeasurement.from_dict(measurement.to_dict())
+    assert isinstance(restored.objects.sequence, PulseBlockEnsemble)
+    assert restored.objects.sequence.name == 'ens_a'
+    assert restored.objects.ensembles == {}
+    assert set(restored.objects.blocks) == {'blk_1', 'blk_2'}
+
+
+def test_pulse_objects_elements_property_reflects_blocks_live():
+    blk_1 = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    objects = PulseObjects(blocks={'blk_1': blk_1})
+
+    assert len(objects.elements) == 1
+
+    # Mutating the underlying block after construction is immediately reflected - elements is a
+    # computed property, not an independently stored/cached field, so it can never drift out of
+    # sync with `blocks`.
+    blk_1.element_list.append(PulseBlockElement(init_length_s=2e-6))
+    assert len(objects.elements) == 2

--- a/tests/test_pulsed_measurement.py
+++ b/tests/test_pulsed_measurement.py
@@ -1,7 +1,11 @@
 import dataclasses
+import math
 import pickle
+import types
 
 import numpy as np
+
+from qudi.util.datastorage import TextDataStorage
 
 from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockElement, PulseBlockEnsemble, PulseSequence
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
@@ -9,6 +13,7 @@ from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
     MeasurementInformation,
     PulsedMeasurementData,
     PulsedMeasurementSettings,
+    to_plain_metadata,
 )
 from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
     SamplingInformation,
@@ -57,9 +62,11 @@ def test_pulsed_measurement_round_trip_with_generator_settings():
     # class docstring for why (lmfit.model.ModelResult has no reconstruction path).
     assert restored.data.fit_result is None
     assert restored.data.fit_result_alt is None
-    # Nothing was loaded when this snapshot was built, so objects.sequence/.ensembles/.blocks all
-    # default to empty - see PulseObjects.
-    assert restored.objects.sequence is None
+    # Nothing was loaded when this snapshot was built, so objects.loaded_asset/.ensembles/.blocks
+    # all default to empty - see PulseObjects.
+    assert restored.objects.loaded_asset is None
+    assert restored.objects.loaded_sequence is None
+    assert restored.objects.loaded_ensemble is None
     assert restored.objects.ensembles == {}
     assert restored.objects.blocks == {}
 
@@ -323,7 +330,78 @@ def test_measurement_snapshot_pickle_round_trip(tmp_path):
         restored.settings.generator_settings.generation_parameters
         == _default_generator_settings().generation_parameters
     )
-    assert restored.objects.sequence is None
+    assert restored.objects.loaded_asset is None
+
+
+def _snapshot_with(objects):
+    return PulsedMeasurement(
+        settings=Settings(
+            measurement_settings=_default_measurement_settings(),
+            generator_settings=_default_generator_settings(),
+        ),
+        data=PulsedData(measurement_data=_sample_data()),
+        objects=objects,
+    )
+
+
+def _save_and_load_snapshot(tmp_path, snapshot, name):
+    """Mirrors save_measurement_data(save_measurement_snapshot=True) -> load_measurement_snapshot()."""
+    file_path = tmp_path / f'{name}.pulsedmeasurement'
+    with open(file_path, 'wb') as snapshot_file:
+        pickle.dump(snapshot, snapshot_file)
+    return PulsedMeasurementLogic.load_measurement_snapshot(str(file_path))
+
+
+def test_measurement_snapshot_round_trips_a_loaded_sequence(tmp_path):
+    sequence, _ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def warning(self, msg):
+            pass
+
+    ensembles, blocks = _resolve_asset_closure(sequence, saved_ensembles, saved_blocks, _FakeLog())
+    restored = _save_and_load_snapshot(
+        tmp_path,
+        _snapshot_with(PulseObjects(loaded_asset=sequence.copy(), ensembles=ensembles, blocks=blocks)),
+        'seq',
+    )
+
+    assert isinstance(restored.objects.loaded_asset, PulseSequence)
+    assert restored.objects.loaded_sequence is restored.objects.loaded_asset
+    assert restored.objects.loaded_ensemble is None
+    assert restored.objects.loaded_asset.name == 'seq_main'
+    assert set(restored.objects.ensembles) == {'ens_a', 'ens_b'}
+    assert set(restored.objects.blocks) == {'blk_1', 'blk_2', 'blk_3'}
+    assert restored.data.measurement_data.elapsed_sweeps == 3
+    assert restored.data.measurement_data.elapsed_time == 12.5
+
+    # The pickle path stays lossless: the 'nan' string conversion is a save-header concern only
+    # (see to_plain_metadata()), and must never leak into a snapshot.
+    upload_speed = restored.settings.generator_settings.pulse_generator_settings.upload_speed
+    assert isinstance(upload_speed, float) and math.isnan(upload_speed)
+
+
+def test_measurement_snapshot_round_trips_a_loaded_ensemble(tmp_path):
+    _sequence, ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def warning(self, msg):
+            pass
+
+    ensembles, blocks = _resolve_asset_closure(ens_a, saved_ensembles, saved_blocks, _FakeLog())
+    restored = _save_and_load_snapshot(
+        tmp_path,
+        _snapshot_with(PulseObjects(loaded_asset=ens_a.copy(), ensembles=ensembles, blocks=blocks)),
+        'ens',
+    )
+
+    assert isinstance(restored.objects.loaded_asset, PulseBlockEnsemble)
+    assert restored.objects.loaded_ensemble is restored.objects.loaded_asset
+    assert restored.objects.loaded_sequence is None
+    assert restored.objects.loaded_asset.name == 'ens_a'
+    assert restored.objects.ensembles == {}  # nothing one level up for a bare ensemble
+    assert set(restored.objects.blocks) == {'blk_1', 'blk_2'}
+    assert restored.data.measurement_data.elapsed_sweeps == 3
 
 
 def test_pulse_block_copy_is_independent():
@@ -399,19 +477,23 @@ def test_pulsed_measurement_closure_round_trip():
 
     measurement = PulsedMeasurement(
         settings=Settings(measurement_settings=_default_measurement_settings()),
-        objects=PulseObjects(sequence=sequence.copy(), ensembles=ensembles, blocks=blocks),
+        objects=PulseObjects(loaded_asset=sequence.copy(), ensembles=ensembles, blocks=blocks),
     )
 
     as_dict = measurement.to_dict()
-    assert as_dict['objects']['sequence']['type'] == 'PulseSequence'
+    # A PulseSequence is loaded, so it is written under 'loaded_sequence' - never 'loaded_ensemble'
+    # - and 'ensembles' is shown, because for a sequence they mean something.
+    assert as_dict['objects']['loaded_sequence']['type'] == 'PulseSequence'
+    assert 'loaded_ensemble' not in as_dict['objects']
     assert len(as_dict['objects']['ensembles']) == 2
     assert len(as_dict['objects']['blocks']) == 3  # blk_2 shared between ens_a/ens_b, deduped
-    assert len(as_dict['objects']['elements']) == 3  # one element per block
 
     restored = PulsedMeasurement.from_dict(as_dict)
-    assert isinstance(restored.objects.sequence, PulseSequence)
-    assert restored.objects.sequence.name == 'seq_main'
-    assert restored.objects.sequence.ensemble_list == sequence.ensemble_list
+    assert isinstance(restored.objects.loaded_asset, PulseSequence)
+    assert restored.objects.loaded_sequence is restored.objects.loaded_asset
+    assert restored.objects.loaded_ensemble is None
+    assert restored.objects.loaded_asset.name == 'seq_main'
+    assert restored.objects.loaded_asset.ensemble_list == sequence.ensemble_list
     assert set(restored.objects.ensembles) == {'ens_a', 'ens_b'}
     assert restored.objects.ensembles['ens_a'].block_list == [('blk_1', 2), ('blk_2', 0)]
     assert set(restored.objects.blocks) == {'blk_1', 'blk_2', 'blk_3'}
@@ -432,12 +514,22 @@ def test_pulsed_measurement_bare_ensemble_closure_round_trip():
 
     measurement = PulsedMeasurement(
         settings=Settings(measurement_settings=_default_measurement_settings()),
-        objects=PulseObjects(sequence=ens_a.copy(), ensembles=ensembles, blocks=blocks),
+        objects=PulseObjects(loaded_asset=ens_a.copy(), ensembles=ensembles, blocks=blocks),
     )
 
-    restored = PulsedMeasurement.from_dict(measurement.to_dict())
-    assert isinstance(restored.objects.sequence, PulseBlockEnsemble)
-    assert restored.objects.sequence.name == 'ens_a'
+    as_dict = measurement.to_dict()
+    # A bare ensemble is written under 'loaded_ensemble', and 'ensembles' is left out entirely
+    # rather than written as an empty dict - an empty 'ensembles' beside an ensemble is exactly
+    # the reading that used to confuse people.
+    assert as_dict['objects']['loaded_ensemble']['type'] == 'PulseBlockEnsemble'
+    assert 'loaded_sequence' not in as_dict['objects']
+    assert 'ensembles' not in as_dict['objects']
+
+    restored = PulsedMeasurement.from_dict(as_dict)
+    assert isinstance(restored.objects.loaded_asset, PulseBlockEnsemble)
+    assert restored.objects.loaded_ensemble is restored.objects.loaded_asset
+    assert restored.objects.loaded_sequence is None
+    assert restored.objects.loaded_asset.name == 'ens_a'
     assert restored.objects.ensembles == {}
     assert set(restored.objects.blocks) == {'blk_1', 'blk_2'}
 
@@ -453,3 +545,361 @@ def test_pulse_objects_elements_property_reflects_blocks_live():
     # sync with `blocks`.
     blk_1.element_list.append(PulseBlockElement(init_length_s=2e-6))
     assert len(objects.elements) == 2
+
+
+def test_pulse_objects_reads_pre_split_sequence_key():
+    """Files written before the loaded_sequence/loaded_ensemble split put both kinds under one
+    'sequence' key, told apart only by the 'type' tag inside it. from_dict() still reads those."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ensemble = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    sequence = PulseSequence(name='seq_main', ensemble_list=[{'ensemble': 'ens_a'}])
+
+    legacy_ensemble = {
+        'blocks': {'blk_1': blk.get_dict_representation()},
+        'ensembles': {},
+        'sequence': dict({'type': 'PulseBlockEnsemble'}, **ensemble.get_dict_representation()),
+    }
+    restored = PulseObjects.from_dict(legacy_ensemble)
+    assert isinstance(restored.loaded_asset, PulseBlockEnsemble)
+    assert restored.loaded_ensemble is restored.loaded_asset
+    assert restored.loaded_sequence is None
+
+    legacy_sequence = {
+        'blocks': {'blk_1': blk.get_dict_representation()},
+        'ensembles': {'ens_a': ensemble.get_dict_representation()},
+        'sequence': dict({'type': 'PulseSequence'}, **sequence.get_dict_representation()),
+    }
+    restored = PulseObjects.from_dict(legacy_sequence)
+    assert isinstance(restored.loaded_asset, PulseSequence)
+    assert restored.loaded_sequence is restored.loaded_asset
+    assert restored.loaded_ensemble is None
+    assert set(restored.ensembles) == {'ens_a'}
+
+
+def test_pulse_objects_unpickles_pre_rename_snapshot():
+    """A '.pulsedmeasurement' snapshot pickled before `sequence` was renamed to `loaded_asset`.
+    pickle bypasses from_dict(), so __setstate__ carries the old attribute across."""
+    ensemble = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    objects = PulseObjects()
+    restored_state = {'sequence': ensemble, 'ensembles': {}, 'blocks': {}}
+    objects.__setstate__(restored_state)
+
+    assert objects.loaded_asset is ensemble
+    assert objects.loaded_ensemble is ensemble
+    assert not hasattr(objects, 'sequence')
+
+
+def test_sampling_information_refuses_generation_parameters():
+    """Generation parameters belong to SequenceGeneratorSettings and nowhere else. They used to
+    arrive here by accident, via analyze_block_ensemble()'s result being dumped field-by-field
+    into from_dict(), and then diverge from the live settings with nothing reading them back."""
+    info = SamplingInformation.from_dict(
+        {'waveforms': ['wfm_ch1'], 'generation_parameters': {'rabi_period': 1e-7}}
+    )
+    assert info.waveforms == ['wfm_ch1']
+    assert 'generation_parameters' not in info._legacy_data
+    assert 'generation_parameters' not in info.to_dict()
+
+    # Also stripped when it arrives nested under an explicit '_legacy_data' key, which is how a
+    # YAML round trip presents it.
+    info = SamplingInformation.from_dict({'_legacy_data': {'generation_parameters': {'x': 1}}})
+    assert info._legacy_data == {}
+
+    # And it cannot be put back through the dict-style setter.
+    info['generation_parameters'] = {'rabi_period': 1e-7}
+    assert 'generation_parameters' not in info._legacy_data
+
+    # An unrelated unknown key still lands in _legacy_data as before - this is a targeted refusal,
+    # not a general tightening.
+    info['something_else'] = 42
+    assert info._legacy_data == {'something_else': 42}
+
+
+def test_analysis_results_carry_no_generation_parameters():
+    """The field is gone from both analysis results, so _dataclass_to_dict() cannot reintroduce
+    the second copy into SamplingInformation."""
+    from qudi.logic.pulsed.pulsed_data.sequence_generator_logic_data import (
+        EnsembleAnalysisResult,
+        SequenceAnalysisResult,
+    )
+
+    for cls in (EnsembleAnalysisResult, SequenceAnalysisResult):
+        assert 'generation_parameters' not in {f.name for f in dataclasses.fields(cls)}
+
+
+def test_asset_from_dict_tolerates_trimmed_metadata_dict():
+    """to_metadata_dict() deliberately leaves containers out, so reading its output back must give
+    a partial object rather than raising - convention 3 in this package's README."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ensemble = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    ensemble.generation_method_parameters = GenerationMethodParameters({'xy8_order': 8})
+    objects = PulseObjects(loaded_asset=ensemble, blocks={'blk_1': blk})
+
+    trimmed = objects.to_metadata_dict(omit_generation_method_parameters=True)
+    restored = PulseObjects.from_dict(trimmed)
+
+    assert isinstance(restored.loaded_asset, PulseBlockEnsemble)
+    assert restored.loaded_asset.name == 'ens_a'
+    assert restored.loaded_asset.generation_method_parameters == {}
+
+    # Down to the bare minimum: only the structural keys.
+    minimal = PulseBlockEnsemble.ensemble_from_dict({'name': 'x', 'block_list': [('blk_1', 0)]})
+    assert minimal.name == 'x'
+    assert minimal.rotating_frame is False
+    assert not minimal.sampling_information  # __bool__ -> "not sampled"
+
+    minimal_seq = PulseSequence.sequence_from_dict(
+        {'name': 'y', 'ensemble_list': [{'ensemble': 'ens_a'}]}
+    )
+    assert minimal_seq.name == 'y'
+    assert minimal_seq.generation_method_parameters == {}
+
+
+def test_to_plain_metadata_converts_non_finite_floats():
+    """repr(float('nan')) is the bare token 'nan', which the eval()-based header parser cannot
+    resolve - and Python has no literal for nan, so the value has to become a string."""
+    for value, expected in ((float('nan'), 'nan'), (float('inf'), 'inf'), (float('-inf'), '-inf')):
+        out = to_plain_metadata(value)
+        assert out == expected
+        assert isinstance(out, str)
+        recovered = float(out)  # how a reader gets the number back
+        assert math.isnan(recovered) if expected == 'nan' else recovered == value
+
+    # numpy non-finite scalars land in the same branch - the np.generic branch recurses for this.
+    assert to_plain_metadata(np.float64('nan')) == 'nan'
+    assert to_plain_metadata(np.float32('inf')) == 'inf'
+
+    # Finite values are untouched, including numpy scalars (which still become Python builtins).
+    assert to_plain_metadata(1.5) == 1.5
+    assert to_plain_metadata(np.float64(2.5)) == 2.5
+    assert to_plain_metadata(np.int64(5)) == 5
+    assert isinstance(to_plain_metadata(np.int64(5)), int)
+
+
+def test_non_finite_floats_survive_nesting_and_eval():
+    """A single nan used to poison the whole metadata key it sat in, however deeply nested."""
+    nested = {'levels': {'a_ch1': float('nan')}, 'series': [0.0, 1.0, float('nan'), 3.0]}
+    text = repr(to_plain_metadata(nested))
+    restored = eval(text)  # exactly what qudi.util.datastorage does on read-back
+
+    assert restored['levels']['a_ch1'] == 'nan'
+    assert restored['series'] == [0.0, 1.0, 'nan', 3.0]
+
+    # An array full of nan also survives, at a length past numpy's repr-truncation threshold.
+    big = np.full(1500, np.nan)
+    restored = eval(repr(to_plain_metadata(big)))
+    assert len(restored) == 1500
+    assert set(restored) == {'nan'}
+
+
+def test_finalize_metadata_writes_every_value_on_one_line():
+    """Saved headers no longer pretty-print. qudi.util.datastorage renders each metadata value
+    with repr() and prefixes every physical line with the comment marker, so a value whose repr()
+    spans lines is what produced multi-line header entries."""
+    metadata = PulsedMeasurementLogic._finalize_metadata(
+        {
+            'fast counter settings': {'bin_width': 1e-9, 'record_length': 3e-6, 'is_gated': False},
+            'Controlled variable': np.linspace(0.0, 1.0, 1500),
+            'alternating': np.bool_(True),
+        }
+    )
+
+    for key, value in metadata.items():
+        assert type(value) in (dict, list, bool, int, float, str), key
+        assert '\n' not in repr(value), key
+
+    # to_plain_metadata() is untouched and still doing its job: the >1000-element array is written
+    # out in full rather than reaching the header already summarised by numpy's repr.
+    assert len(metadata['Controlled variable']) == 1500
+    assert '...' not in repr(metadata['Controlled variable'])
+
+
+def test_settings_to_metadata_dict_omits_containers_written_flat():
+    """One copy of a container per file: a settings container the header already writes out flat
+    at its top level is dropped from the nested 'pulsed measurement settings' block, so the two
+    cannot drift apart."""
+    settings = Settings(
+        measurement_settings=_default_measurement_settings(),
+        generator_settings=_default_generator_settings(),
+    )
+
+    full = settings.to_dict()
+    assert 'fast_counter_settings' in full['measurement_settings']
+    assert 'generation_parameters' in full['generator_settings']
+
+    trimmed = settings.to_metadata_dict(omit=PulsedMeasurementLogic._SIGNAL_METADATA_OMIT)
+    assert 'fast_counter_settings' not in trimmed['measurement_settings']
+    assert 'extraction_parameters' not in trimmed['measurement_settings']
+    assert 'analysis_parameters' not in trimmed['measurement_settings']
+    assert 'generation_parameters' not in trimmed['generator_settings']
+    # Containers no header writes flat are untouched, so each file stays complete on its own.
+    assert 'microwave_settings' in trimmed['measurement_settings']
+    assert 'readout_settings' in trimmed['measurement_settings']
+    assert 'pulse_generator_settings' in trimmed['generator_settings']
+
+    # The laser file writes only 'extraction parameters' flat, so only that one goes.
+    trimmed = settings.to_metadata_dict(omit=PulsedMeasurementLogic._LASER_METADATA_OMIT)
+    assert 'extraction_parameters' not in trimmed['measurement_settings']
+    assert 'fast_counter_settings' in trimmed['measurement_settings']
+
+    # The raw file writes no whole container flat, so its block is the complete settings dump.
+    # Compared key-wise: readout_settings.controlled_variable is a numpy array, so a deep == on
+    # these nested dicts raises rather than returning a bool.
+    raw = settings.to_metadata_dict(omit=PulsedMeasurementLogic._RAW_METADATA_OMIT)
+    assert set(raw['measurement_settings']) == set(full['measurement_settings'])
+    assert set(raw['generator_settings']) == set(full['generator_settings'])
+
+    # to_dict() itself stays lossless - the .pulsedmeasurement snapshot round trip depends on it,
+    # and to_metadata_dict() must not have mutated the containers it trims from.
+    fresh = settings.to_dict()
+    assert set(fresh['measurement_settings']) == set(full['measurement_settings'])
+    assert set(fresh['generator_settings']) == set(full['generator_settings'])
+
+
+def test_settings_to_metadata_dict_tolerates_absent_paths():
+    """generator_settings is None whenever PulsedMeasurementLogic is driven without
+    PulsedMasterLogic, so the signal file's omit list names paths that do not exist."""
+    settings = Settings(measurement_settings=_default_measurement_settings())
+    trimmed = settings.to_metadata_dict(omit=PulsedMeasurementLogic._SIGNAL_METADATA_OMIT)
+
+    assert trimmed['generator_settings'] is None
+    assert 'fast_counter_settings' not in trimmed['measurement_settings']
+
+
+def _logic_for_metadata(loaded_asset=None, ensembles=None, blocks=None, controlled_variable=None):
+    """A PulsedMeasurementLogic built without __init__, wired up with just enough state to drive the
+    real _get_*_metadata() builders. Everything they touch reads through _pulsed_measurement except
+    analysis/extraction settings, which come off the analyzer/extractor - stubbed here."""
+    # PulsedMeasurementLogic.__new__ rather than object.__new__: the Qt metaclass refuses the
+    # latter. __init__ is skipped on purpose - the builders need no Connectors.
+    logic = PulsedMeasurementLogic.__new__(PulsedMeasurementLogic)
+    data = _sample_data()
+    if controlled_variable is not None:
+        data.signal_data = np.vstack([controlled_variable, np.zeros(len(controlled_variable))])
+    logic._pulsed_measurement = PulsedMeasurement(
+        settings=Settings(
+            measurement_settings=_default_measurement_settings(),
+            generator_settings=_default_generator_settings(),
+        ),
+        data=PulsedData(measurement_data=data),
+        objects=PulseObjects(
+            loaded_asset=loaded_asset, ensembles=ensembles or {}, blocks=blocks or {}
+        ),
+    )
+    logic._pulseanalyzer = types.SimpleNamespace(analysis_settings={'method': 'mean_norm'})
+    logic._pulseextractor = types.SimpleNamespace(
+        extraction_settings={'method': 'conv_deriv', 'conv_std_dev': 10.0}
+    )
+    return logic
+
+
+def test_saved_header_round_trips_through_real_data_storage(tmp_path):
+    """End to end across the save boundary: the real _get_signal_metadata() -> TextDataStorage ->
+    a file on disk -> TextDataStorage.load_data(). Guards both the nan fix and the removal of
+    pretty-printing, since either regressing turns a metadata value back into an unparsed str."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ensemble = PulseBlockEnsemble(name='rabi', block_list=[('blk_1', 0)])
+    ensemble.generation_method_parameters = GenerationMethodParameters({'xy8_order': 8})
+    # Past numpy's 1000-element repr-truncation threshold, and carrying a nan.
+    controlled_variable = np.linspace(0.0, 1.0, 1500)
+    controlled_variable[7] = np.nan
+
+    logic = _logic_for_metadata(
+        loaded_asset=ensemble, blocks={'blk_1': blk}, controlled_variable=controlled_variable
+    )
+    metadata = logic._get_signal_metadata(
+        generator_settings=logic._pulsed_measurement.settings.generator_settings,
+        blocks={'blk_1': blk},
+    )
+
+    storage = TextDataStorage(root_dir=str(tmp_path))
+    file_path, _timestamp, _headers = storage.save_data(
+        np.zeros((3, 2)), metadata=metadata, nametag='pulsed'
+    )
+
+    _data, restored, _general = TextDataStorage.load_data(file_path)
+
+    # Every container comes back as a real dict, not a str. 'pulsed measurement settings' is the
+    # one that used to fail, on every file, because of a single nan buried in upload_speed.
+    for key in ('fast counter settings', 'generation parameters', 'generation method parameters',
+                'pulsed measurement settings', 'loaded asset objects'):
+        assert isinstance(restored[key], dict), f'{key} came back as {type(restored[key]).__name__}'
+
+    pgs = restored['pulsed measurement settings']['generator_settings']['pulse_generator_settings']
+    assert pgs['upload_speed'] == 'nan'
+    assert math.isnan(float(pgs['upload_speed']))
+
+    # The raw file carries the controlled variable; check it survives in full there - nan included
+    # and nothing truncated away by numpy's repr.
+    raw_metadata = logic._get_raw_metadata(
+        generator_settings=logic._pulsed_measurement.settings.generator_settings,
+        blocks={'blk_1': blk},
+    )
+    raw_path, _ts, _hdrs = storage.save_data(
+        np.zeros((3, 2)), metadata=raw_metadata, nametag='pulsed_raw'
+    )
+    _d, raw_restored, _g = TextDataStorage.load_data(raw_path)
+
+    assert isinstance(raw_restored['pulsed measurement settings'], dict)
+    cv = raw_restored['controlled variable']  # ConfigParser lowercases option names
+    assert len(cv) == 1500
+    assert cv[7] == 'nan'
+    assert cv[0] == 0.0
+
+    # The saved asset keeps its kind-named key and reconstructs.
+    objs = restored['loaded asset objects']
+    assert 'loaded_ensemble' in objs and 'loaded_sequence' not in objs
+    assert 'ensembles' not in objs  # bare ensemble resolves nothing one level up
+    assert isinstance(PulseObjects.from_dict(objs).loaded_asset, PulseBlockEnsemble)
+
+    # And the dedup holds in a real file: fast_counter_settings appears flat, not also nested.
+    assert 'fast_counter_settings' not in restored['pulsed measurement settings']['measurement_settings']
+
+
+def test_saved_header_shows_ensembles_only_for_a_sequence(tmp_path):
+    sequence, _ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
+
+    class _FakeLog:
+        def warning(self, msg):
+            pass
+
+    ensembles, blocks = _resolve_asset_closure(sequence, saved_ensembles, saved_blocks, _FakeLog())
+    logic = _logic_for_metadata(loaded_asset=sequence, ensembles=ensembles, blocks=blocks)
+    metadata = logic._get_signal_metadata(
+        generator_settings=logic._pulsed_measurement.settings.generator_settings,
+        ensembles=ensembles,
+        blocks=blocks,
+    )
+
+    storage = TextDataStorage(root_dir=str(tmp_path))
+    file_path, _timestamp, _headers = storage.save_data(
+        np.zeros((3, 2)), metadata=metadata, nametag='pulsed_seq'
+    )
+    _data, restored, _general = TextDataStorage.load_data(file_path)
+
+    objs = restored['loaded asset objects']
+    assert 'loaded_sequence' in objs and 'loaded_ensemble' not in objs
+    assert set(objs['ensembles']) == {'ens_a', 'ens_b'}
+    assert restored['loaded asset type'] == 'PulseSequence'
+    assert isinstance(PulseObjects.from_dict(objs).loaded_asset, PulseSequence)
+
+
+def test_pulse_objects_metadata_dict_can_omit_generation_method_parameters():
+    """The signal file writes 'generation method parameters' flat, so the loaded asset's own copy
+    is dropped there - but only the loaded asset's, never a nested ensemble's."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ensemble = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    ensemble.generation_method_parameters = GenerationMethodParameters({'xy8_order': 8})
+    sequence = PulseSequence(name='seq_main', ensemble_list=[{'ensemble': 'ens_a'}])
+    sequence.generation_method_parameters = GenerationMethodParameters({'tau_step': 1e-9})
+    objects = PulseObjects(
+        loaded_asset=sequence, ensembles={'ens_a': ensemble}, blocks={'blk_1': blk}
+    )
+
+    kept = objects.to_metadata_dict()
+    assert kept['loaded_sequence']['generation_method_parameters'] == {'tau_step': 1e-9}
+
+    dropped = objects.to_metadata_dict(omit_generation_method_parameters=True)
+    assert 'generation_method_parameters' not in dropped['loaded_sequence']
+    # The nested ensemble's own parameters are not duplicated anywhere, so they stay.
+    assert dropped['ensembles']['ens_a']['generation_method_parameters'] == {'xy8_order': 8}

--- a/tests/test_pulsed_measurement.py
+++ b/tests/test_pulsed_measurement.py
@@ -481,10 +481,11 @@ def test_pulsed_measurement_closure_round_trip():
     )
 
     as_dict = measurement.to_dict()
-    # A PulseSequence is loaded, so it is written under 'loaded_sequence' - never 'loaded_ensemble'
-    # - and 'ensembles' is shown, because for a sequence they mean something.
-    assert as_dict['objects']['loaded_sequence']['type'] == 'PulseSequence'
-    assert 'loaded_ensemble' not in as_dict['objects']
+    # A PulseSequence is loaded, so 'sequence' is populated. The three keys are always the same
+    # ones - see test_pulse_objects_dict_keys_are_the_same_for_both_asset_kinds.
+    assert set(as_dict['objects']) == {'sequence', 'ensembles', 'blocks'}
+    assert as_dict['objects']['sequence']['name'] == 'seq_main'
+    assert 'type' not in as_dict['objects']['sequence']  # the kind is not encoded any more
     assert len(as_dict['objects']['ensembles']) == 2
     assert len(as_dict['objects']['blocks']) == 3  # blk_2 shared between ens_a/ens_b, deduped
 
@@ -518,12 +519,12 @@ def test_pulsed_measurement_bare_ensemble_closure_round_trip():
     )
 
     as_dict = measurement.to_dict()
-    # A bare ensemble is written under 'loaded_ensemble', and 'ensembles' is left out entirely
-    # rather than written as an empty dict - an empty 'ensembles' beside an ensemble is exactly
-    # the reading that used to confuse people.
-    assert as_dict['objects']['loaded_ensemble']['type'] == 'PulseBlockEnsemble'
-    assert 'loaded_sequence' not in as_dict['objects']
-    assert 'ensembles' not in as_dict['objects']
+    # A bare ensemble leaves 'sequence' empty and is filed under 'ensembles' instead. That
+    # emptiness is the only kind marker: no key rename, no 'type' tag.
+    assert set(as_dict['objects']) == {'sequence', 'ensembles', 'blocks'}
+    assert as_dict['objects']['sequence'] == {}
+    assert set(as_dict['objects']['ensembles']) == {'ens_a'}
+    assert 'type' not in as_dict['objects']['ensembles']['ens_a']
 
     restored = PulsedMeasurement.from_dict(as_dict)
     assert isinstance(restored.objects.loaded_asset, PulseBlockEnsemble)
@@ -532,6 +533,84 @@ def test_pulsed_measurement_bare_ensemble_closure_round_trip():
     assert restored.objects.loaded_asset.name == 'ens_a'
     assert restored.objects.ensembles == {}
     assert set(restored.objects.blocks) == {'blk_1', 'blk_2'}
+
+
+def test_pulse_objects_dict_keys_are_the_same_for_both_asset_kinds():
+    """The whole point of the layout: evaluation code reads one fixed set of keys and never has to
+    test which ones are present. Only whether 'sequence' is empty differs."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ens_a = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    sequence = PulseSequence(name='seq_main', ensemble_list=[{'ensemble': 'ens_a'}])
+
+    from_sequence = PulseObjects(loaded_asset=sequence, ensembles={'ens_a': ens_a},
+                                 blocks={'blk_1': blk}).to_dict()
+    from_ensemble = PulseObjects(loaded_asset=ens_a, blocks={'blk_1': blk}).to_dict()
+    from_nothing = PulseObjects().to_dict()
+
+    expected = {'sequence', 'ensembles', 'blocks'}
+    assert set(from_sequence) == set(from_ensemble) == set(from_nothing) == expected
+
+    # The kind is reconstructed, not stated.
+    assert from_sequence['sequence']
+    assert from_ensemble['sequence'] == {}
+    assert set(from_ensemble['ensembles']) == {'ens_a'}
+
+
+def test_pulse_objects_empty_sequence_is_not_mistaken_for_an_ensemble():
+    """PulseSequence(name='x') has an empty ensemble_list but is still a sequence. The kind test is
+    on the whole 'sequence' value - which always carries at least a name - not on ensemble_list."""
+    empty_sequence = PulseSequence(name='seq_empty')
+    assert empty_sequence.ensemble_list == []
+
+    as_dict = PulseObjects(loaded_asset=empty_sequence).to_dict()
+    assert as_dict['sequence'], "an empty-but-real sequence must still read as truthy"
+    assert as_dict['sequence']['ensemble_list'] == []
+
+    restored = PulseObjects.from_dict(as_dict)
+    assert isinstance(restored.loaded_asset, PulseSequence)
+    assert restored.loaded_ensemble is None
+
+
+def test_pulse_objects_refuses_to_guess_the_loaded_asset_when_ambiguous():
+    """An empty 'sequence' beside several ensembles cannot come from to_dict(); the loaded asset is
+    then genuinely ambiguous, so from_dict() leaves it unset rather than picking one."""
+    ens_a = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    ens_b = PulseBlockEnsemble(name='ens_b', block_list=[('blk_1', 0)])
+
+    restored = PulseObjects.from_dict({
+        'sequence': {},
+        'ensembles': {'ens_a': ens_a.get_dict_representation(),
+                      'ens_b': ens_b.get_dict_representation()},
+        'blocks': {},
+    })
+    assert restored.loaded_asset is None
+    assert set(restored.ensembles) == {'ens_a', 'ens_b'}  # kept, not discarded
+
+
+def test_pulse_objects_reads_the_post_split_key_names():
+    """Files written between the split and the unification named the key after the kind. from_dict()
+    still reads those - see also test_pulse_objects_reads_pre_split_sequence_key for the one before."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ens_a = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    sequence = PulseSequence(name='seq_main', ensemble_list=[{'ensemble': 'ens_a'}])
+
+    split_sequence = {
+        'blocks': {'blk_1': blk.get_dict_representation()},
+        'ensembles': {'ens_a': ens_a.get_dict_representation()},
+        'loaded_sequence': dict({'type': 'PulseSequence'}, **sequence.get_dict_representation()),
+    }
+    restored = PulseObjects.from_dict(split_sequence)
+    assert isinstance(restored.loaded_asset, PulseSequence)
+    assert set(restored.ensembles) == {'ens_a'}
+
+    split_ensemble = {
+        'blocks': {'blk_1': blk.get_dict_representation()},
+        'loaded_ensemble': dict({'type': 'PulseBlockEnsemble'},
+                                **ens_a.get_dict_representation()),
+    }
+    restored = PulseObjects.from_dict(split_ensemble)
+    assert isinstance(restored.loaded_asset, PulseBlockEnsemble)
+    assert restored.loaded_sequence is None
 
 
 def test_pulse_objects_elements_property_reflects_blocks_live():
@@ -822,7 +901,7 @@ def test_saved_header_round_trips_through_real_data_storage(tmp_path):
     # Every container comes back as a real dict, not a str. 'pulsed measurement settings' is the
     # one that used to fail, on every file, because of a single nan buried in upload_speed.
     for key in ('fast counter settings', 'generation parameters', 'generation method parameters',
-                'pulsed measurement settings', 'loaded asset objects'):
+                'pulsed measurement settings', 'pulse objects'):
         assert isinstance(restored[key], dict), f'{key} came back as {type(restored[key]).__name__}'
 
     pgs = restored['pulsed measurement settings']['generator_settings']['pulse_generator_settings']
@@ -846,17 +925,22 @@ def test_saved_header_round_trips_through_real_data_storage(tmp_path):
     assert cv[7] == 'nan'
     assert cv[0] == 0.0
 
-    # The saved asset keeps its kind-named key and reconstructs.
-    objs = restored['loaded asset objects']
-    assert 'loaded_ensemble' in objs and 'loaded_sequence' not in objs
-    assert 'ensembles' not in objs  # bare ensemble resolves nothing one level up
+    # The saved asset comes back through the fixed three-key shape and reconstructs. A bare
+    # ensemble leaves 'sequence' empty and sits under 'ensembles'.
+    objs = restored['pulse objects']
+    assert set(objs) == {'sequence', 'ensembles', 'blocks'}
+    assert not objs['sequence']
+    assert set(objs['ensembles']) == {'rabi'}
     assert isinstance(PulseObjects.from_dict(objs).loaded_asset, PulseBlockEnsemble)
+    # The redundant sibling is gone; the name stays, since it is not reconstructable.
+    assert 'loaded asset type' not in restored
+    assert restored['loaded asset name'] == 'rabi'
 
     # And the dedup holds in a real file: fast_counter_settings appears flat, not also nested.
     assert 'fast_counter_settings' not in restored['pulsed measurement settings']['measurement_settings']
 
 
-def test_saved_header_shows_ensembles_only_for_a_sequence(tmp_path):
+def test_saved_header_uses_the_same_keys_for_a_sequence(tmp_path):
     sequence, _ens_a, saved_ensembles, saved_blocks = _build_closure_fixtures()
 
     class _FakeLog:
@@ -877,11 +961,15 @@ def test_saved_header_shows_ensembles_only_for_a_sequence(tmp_path):
     )
     _data, restored, _general = TextDataStorage.load_data(file_path)
 
-    objs = restored['loaded asset objects']
-    assert 'loaded_sequence' in objs and 'loaded_ensemble' not in objs
+    # Same three keys a bare ensemble produces (see the test above); only 'sequence' being
+    # populated distinguishes them, which is what lets evaluation code skip the branching.
+    objs = restored['pulse objects']
+    assert set(objs) == {'sequence', 'ensembles', 'blocks'}
+    assert objs['sequence']['name'] == 'seq_main'
     assert set(objs['ensembles']) == {'ens_a', 'ens_b'}
-    assert restored['loaded asset type'] == 'PulseSequence'
     assert isinstance(PulseObjects.from_dict(objs).loaded_asset, PulseSequence)
+    assert 'loaded asset type' not in restored
+    assert restored['loaded asset name'] == 'seq_main'
 
 
 def test_pulse_objects_metadata_dict_can_omit_generation_method_parameters():
@@ -897,9 +985,24 @@ def test_pulse_objects_metadata_dict_can_omit_generation_method_parameters():
     )
 
     kept = objects.to_metadata_dict()
-    assert kept['loaded_sequence']['generation_method_parameters'] == {'tau_step': 1e-9}
+    assert kept['sequence']['generation_method_parameters'] == {'tau_step': 1e-9}
 
     dropped = objects.to_metadata_dict(omit_generation_method_parameters=True)
-    assert 'generation_method_parameters' not in dropped['loaded_sequence']
+    assert 'generation_method_parameters' not in dropped['sequence']
     # The nested ensemble's own parameters are not duplicated anywhere, so they stay.
     assert dropped['ensembles']['ens_a']['generation_method_parameters'] == {'xy8_order': 8}
+
+
+def test_metadata_dict_omit_follows_a_bare_ensemble_into_ensembles():
+    """A loaded bare ensemble lives under 'ensembles', so the omit flag has to reach it there -
+    otherwise the signal header regains the duplicate the flag exists to drop."""
+    blk = PulseBlock(name='blk_1', element_list=[PulseBlockElement(init_length_s=1e-6)])
+    ensemble = PulseBlockEnsemble(name='ens_a', block_list=[('blk_1', 0)])
+    ensemble.generation_method_parameters = GenerationMethodParameters({'xy8_order': 8})
+    objects = PulseObjects(loaded_asset=ensemble, blocks={'blk_1': blk})
+
+    kept = objects.to_metadata_dict()
+    assert kept['ensembles']['ens_a']['generation_method_parameters'] == {'xy8_order': 8}
+
+    dropped = objects.to_metadata_dict(omit_generation_method_parameters=True)
+    assert 'generation_method_parameters' not in dropped['ensembles']['ens_a']

--- a/tests/test_pulsed_measurement_logic_data.py
+++ b/tests/test_pulsed_measurement_logic_data.py
@@ -1,19 +1,20 @@
 import numpy as np
 
 from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
-    AnalysisSettings,
+    AnalysisParameters,
     DataStashCache,
     ExecutionState,
-    ExtractionSettings,
+    ExtractionParameters,
 )
 
 
 def test_execution_state_tracks_pause_and_timing():
+    # elapsed_sweeps is not part of ExecutionState - it's tracked exclusively on
+    # PulsedMeasurementData (the acquired-data side), not here (the timing/pause-state side).
     state = ExecutionState()
     state.start()
     assert state.is_paused is False
     assert state.elapsed_time == 0.0
-    assert state.elapsed_sweeps == 0
 
     state.pause()
     assert state.is_paused is True
@@ -35,8 +36,8 @@ def test_data_stash_cache_round_trip():
 
 
 def test_analysis_and_extraction_settings_round_trip():
-    analysis = AnalysisSettings.from_dict({'foo': 'bar'})
-    extraction = ExtractionSettings.from_dict({'baz': 3})
+    analysis = AnalysisParameters.from_dict({'foo': 'bar'})
+    extraction = ExtractionParameters.from_dict({'baz': 3})
 
     assert analysis.to_dict() == {'foo': 'bar'}
     assert extraction.to_dict() == {'baz': 3}

--- a/tests/test_pulsed_measurement_logic_data.py
+++ b/tests/test_pulsed_measurement_logic_data.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from qudi.logic.pulsed.pulsed_data.pulsed_measurement_logic_data import (
+    AnalysisSettings,
+    DataStashCache,
+    ExecutionState,
+    ExtractionSettings,
+)
+
+
+def test_execution_state_tracks_pause_and_timing():
+    state = ExecutionState()
+    state.start()
+    assert state.is_paused is False
+    assert state.elapsed_time == 0.0
+    assert state.elapsed_sweeps == 0
+
+    state.pause()
+    assert state.is_paused is True
+
+    state.unpause()
+    assert state.is_paused is False
+
+
+def test_data_stash_cache_round_trip():
+    cache = DataStashCache()
+    data = np.array([1, 2, 3], dtype=np.int64)
+    cache.stash('tag', data, sweeps=5, time_elapsed=1.25)
+
+    recalled = cache.recall('tag')
+    assert recalled is not None
+    assert recalled['elapsed_sweeps'] == 5
+    assert recalled['elapsed_time'] == 1.25
+    assert np.array_equal(recalled['data'], data)
+
+
+def test_analysis_and_extraction_settings_round_trip():
+    analysis = AnalysisSettings.from_dict({'foo': 'bar'})
+    extraction = ExtractionSettings.from_dict({'baz': 3})
+
+    assert analysis.to_dict() == {'foo': 'bar'}
+    assert extraction.to_dict() == {'baz': 3}

--- a/tests/test_pulsed_measurement_logic_data.py
+++ b/tests/test_pulsed_measurement_logic_data.py
@@ -14,7 +14,11 @@ def test_execution_state_tracks_pause_and_timing():
     state = ExecutionState()
     state.start()
     assert state.is_paused is False
-    assert state.elapsed_time == 0.0
+    # Not `== 0.0`: elapsed_time is `time.time() - start_time`, and on Windows Python 3.13+ switched
+    # time.time() to GetSystemTimePreciseAsFileTime (100 ns resolution, was 15.625 ms). Two calls
+    # either side of start() used to return the identical value and now usually do not, so the exact
+    # comparison passed on 3.10 and fails on 3.14. Assert it is merely near zero instead.
+    assert 0.0 <= state.elapsed_time < 0.1
 
     state.pause()
     assert state.is_paused is True


### PR DESCRIPTION
Replaces the loose dictionaries and ~20 per-module `StatusVar`s in the pulsed
toolchain with a typed `pulsed_data` package. Previously a typo in a settings key
was silently accepted, and a missing key in a saved file could reset every setting.

## Containment — what holds what

`PulsedMeasurement` is the root of everything describing one measurement.

```
PulsedMeasurement                                       [mutable]  ← root
│
├── settings : Settings                                 [frozen]
│   ├── measurement_settings : PulsedMeasurementSettings         [frozen]
│   │   ├── microwave_settings        : MicrowaveSettings        [frozen]
│   │   ├── fast_counter_settings     : FastCounterSettings      [frozen]
│   │   ├── readout_settings          : ReadoutSettings          [frozen]
│   │   ├── alternate_signal_settings : AlternativeSignalSettings   (shared, mutable)
│   │   ├── extraction_parameters     : ExtractionParameters        (dict subclass, shared)
│   │   └── analysis_parameters       : AnalysisParameters          (dict subclass, shared)
│   │
│   └── generator_settings : SequenceGeneratorSettings | None    [frozen]
│       ├── generation_parameters    : GenerationParameters      [frozen, built at import]
│       └── pulse_generator_settings : PulseGeneratorSettings    [frozen]
│           ├── activation_config : ActivationConfig             [frozen]
│           ├── analog_levels     : AnalogLevels                 [frozen]
│           ├── digital_levels    : DigitalLevels                [frozen]
│           └── sample_rate / interleave / flags / upload_speed
│
├── data : PulsedData | None                            [mutable]
│   ├── measurement_data : PulsedMeasurementData        [mutable]  raw/laser/signal arrays
│   ├── fit_result       : lmfit ModelResult | None                (one-way export only)
│   └── fit_result_alt   : lmfit ModelResult | None                (one-way export only)
│
└── objects : PulseObjects                              [mutable]
    ├── sequence  : PulseBlockEnsemble | PulseSequence | None
    ├── ensembles : {name: PulseBlockEnsemble}          independent copies
    └── blocks    : {name: PulseBlock}                  independent copies
```

Each pulse object carries three more containers, attached as plain attributes:

```
PulseBlockEnsemble / PulseSequence              (pulse_objects.py)
├── .sampling_information         : SamplingInformation         [mutable, dict-like]
├── .measurement_information      : MeasurementInformation      [mutable, dict-like]
└── .generation_method_parameters : GenerationMethodParameters  (dict subclass)
```

Standing on their own, owned directly by a logic module:

```
SequenceGeneratorLogic              PulsedMeasurementLogic      PulsedMasterLogic
├── pulser_benchmarks               ├── __execution_state       ├── status_dict
│   : PulserBenchmarks              │   : ExecutionState        │   : PulsedMasterStatus
│   ├── write : BenchmarkTool       └── _data_stash             └── fit_containers
│   └── load  : BenchmarkTool           : DataStashCache            : FitContainers
└── (per-run) SequenceSamplingState
```

Inheritance is deliberately almost absent — these are containers, not a hierarchy.
The one exception is the lab-extension hook:

```
BaseGenerationParameters                     generation_parameter_extensions.py
├── CoreGenerationParameters                 built-in, 14 fields
└── <your lab's class here>                  ← the only file you need to touch
        └──► merged at import by _build_generation_parameters()
```

## Conventions

Settings classes are `frozen=True` — thread-safe, and safe to pickle into saved
`.ensemble`/`.sequence` files. Every persisted class implements `to_dict` / `from_dict` /
`update_from_dict`, where `from_dict` falls back to field defaults and `update_from_dict`
keeps current values for missing keys.

Some classes are mutable **on purpose**: `AnalysisParameters`, `ExtractionParameters` and
`AlternativeSignalSettings` are held and mutated in place by `PulseAnalyzer` /
`PulseExtractor` / `AltPlotAnalyzer` as their live state.

Backwards compatible: `status_dict['flag']` access in `pulsed_maingui.py` still works via
property getters/setters, and `_migrate_legacy_settings_if_needed()` rebuilds old-format
status files via `from_legacy_dict()`.
Tests: `pytest tests/test_pulsed_measurement.py tests/test_pulsed_measurement_logic_data.py`