### PR TITLE
Module finder

### DIFF
--- a/src/qudi/logic/pulsed/pulse_alt_plot.py
+++ b/src/qudi/logic/pulsed/pulse_alt_plot.py
@@ -24,13 +24,10 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-import sys
 import inspect
-import importlib
 
-from qudi.util.helpers import natural_sort, iter_modules_recursive
-
+from qudi.util.helpers import natural_sort
+from qudi.util.module_finder import get_modules_from_ns, get_modules_from_path
 
 class AltPlotMethodBase:
     """ Base class for alternative plot methods. Must be inherited from *exclusively*.
@@ -132,20 +129,13 @@ class AltPlotAnalyzer(AltPlotMethodBase):
 
         # Import from the default namespace package
         import qudi.logic.pulsed.alt_plot_methods as default_ns
-        method_classes = list()
-        for mod_finder in iter_modules_recursive(default_ns.__path__, default_ns.__name__ + '.'):
-            try:
-                module = importlib.import_module(mod_finder.name)
-                method_classes.extend(c for _, c in inspect.getmembers(module, self.is_alt_plot_class))
-            except:
-                self.log.exception(f'Exception while importing alt_plot_methods sub-module '
-                                   f'"{mod_finder.name}":')
-
+        method_classes = list(get_modules_from_ns(default_ns, self.is_alt_plot_class,
+                                                    logger=self.log).values())
         # Import from the optional additional directory
         import_path = getattr(pulsedmeasurementlogic, 'alt_plot_import_path', None)
         if isinstance(import_path, str):
             try:
-                method_classes.extend(self.__import_external_methods(import_path))
+                method_classes.extend(get_modules_from_path(import_path, self.is_alt_plot_class))
             except:
                 self.log.exception(f'Unable to import alternative plot methods from '
                                    f'"{import_path}":')
@@ -250,16 +240,6 @@ class AltPlotAnalyzer(AltPlotMethodBase):
             stored = self._parameters.get(name)
             kwargs[name] = stored if type(stored) == type(param.default) else param.default
         return kwargs
-
-    def __import_external_methods(self, path):
-        if path not in sys.path:
-            sys.path.append(path)
-        class_list = list()
-        for name in os.listdir(path):
-            if name.endswith('.py') and os.path.isfile(os.path.join(path, name)):
-                module = importlib.reload(importlib.import_module(name[:-3]))
-                class_list.extend(c for _, c in inspect.getmembers(module, self.is_alt_plot_class))
-        return class_list
 
     @staticmethod
     def is_alt_plot_class(obj):

--- a/src/qudi/logic/pulsed/pulse_analyzer.py
+++ b/src/qudi/logic/pulsed/pulse_analyzer.py
@@ -19,12 +19,12 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-import sys
 import inspect
 import importlib
 
-from qudi.util.helpers import natural_sort, iter_modules_recursive
+from qudi.util.helpers import natural_sort
+from qudi.util.module_finder import get_modules_from_ns, get_modules_from_path
+
 
 
 class PulseAnalyzerBase:
@@ -99,27 +99,16 @@ class PulseAnalyzer(PulseAnalyzerBase):
             import qudi.logic.pulsed.pulsed_analysis_methods as _default_analysis_ns
 
         # Import analysis modules and get a dict of analysis classes
-        analysis_classes = list()
-        for mod_finder in iter_modules_recursive(_default_analysis_ns.__path__,
-                                                 _default_analysis_ns.__name__ + '.'):
-            try:
-                analysis_classes.extend(
-                    [cls for _, cls in inspect.getmembers(importlib.import_module(mod_finder.name),
-                                                          self.is_analyzer_class)]
-                )
-            except:
-                self.log.exception(
-                    f'Exception while importing qudi.logic.pulsed.pulsed_analysis_methods '
-                    f'sub-module "{mod_finder.name}":'
-                )
+        analysis_classes = list(get_modules_from_ns(_default_analysis_ns,
+                                                      self.is_analyzer_class,
+                                                      logger=self.log).values())
 
         # Get analysis modules from non-default directory if a path has been given
         if isinstance(pulsedmeasurementlogic.analysis_import_path, str):
             try:
                 analysis_classes.extend(
-                    self.__import_external_analyzers(
-                        path=pulsedmeasurementlogic.analysis_import_path
-                    )
+                    get_modules_from_path(pulsedmeasurementlogic.analysis_import_path,
+                                          self.is_analyzer_class)
                 )
             except:
                 self.log.exception(
@@ -258,36 +247,6 @@ class PulseAnalyzer(PulseAnalyzerBase):
             else:
                 kwargs_dict[name] = default
         return kwargs_dict
-
-    def __import_external_analyzers(self, path):
-        """ Helper method to import all modules from given directory path.
-        Find all classes in those modules that inherit exclusively from PulseAnalyzerBase class
-        and return a list of them.
-
-        @param str path: Paths to import modules from
-        @return list: A list of imported valid analyzer classes
-        """
-        class_list = list()
-        # Get all python modules to import from.
-        # The assumption is that in the directory pulse_analysis_methods, there are
-        # *.py files, which contain only analyzer classes!
-        module_list = [name[:-3] for name in os.listdir(path) if
-                       os.path.isfile(os.path.join(path, name)) and name.endswith('.py')]
-
-        # append import path to sys.path
-        if path not in sys.path:
-            sys.path.append(path)
-
-        # Go through all modules and create instances of each class found.
-        for module_name in module_list:
-            # import module
-            mod = importlib.import_module(str(module_name))
-            importlib.reload(mod)
-            # get all analyzer class references defined in the module
-            tmp_list = [m[1] for m in inspect.getmembers(mod, self.is_analyzer_class)]
-            # append to class_list
-            class_list.extend(tmp_list)
-        return class_list
 
     def __populate_method_dict(self, instance_list):
         """

--- a/src/qudi/logic/pulsed/pulse_extractor.py
+++ b/src/qudi/logic/pulsed/pulse_extractor.py
@@ -19,12 +19,11 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-import sys
 import inspect
 import importlib
 
-from qudi.util.helpers import natural_sort, iter_modules_recursive
+from qudi.util.helpers import natural_sort
+from qudi.util.module_finder import get_modules_from_ns, get_modules_from_path
 
 
 class PulseExtractorBase:
@@ -100,27 +99,16 @@ class PulseExtractor(PulseExtractorBase):
             import qudi.logic.pulsed.pulse_extraction_methods as _default_extraction_ns
 
         # Import extraction modules and get a dict of extractor classes
-        extractor_classes = list()
-        for mod_finder in iter_modules_recursive(_default_extraction_ns.__path__,
-                                                 _default_extraction_ns.__name__ + '.'):
-            try:
-                extractor_classes.extend(
-                    [cls for _, cls in inspect.getmembers(importlib.import_module(mod_finder.name),
-                                                          self.is_extractor_class)]
-                )
-            except:
-                self.log.exception(
-                    f'Exception while importing qudi.logic.pulse_extraction_methods sub-module '
-                    f'"{mod_finder.name}":'
-                )
+        extractor_classes = list(get_modules_from_ns(_default_extraction_ns,
+                                                       self.is_extractor_class,
+                                                       logger=self.log).values())
 
         # Get extraction modules from non-default directory if a path has been given
         if isinstance(pulsedmeasurementlogic.extraction_import_path, str):
             try:
                 extractor_classes.extend(
-                    self.__import_external_extractors(
-                        path=pulsedmeasurementlogic.extraction_import_path
-                    )
+                    get_modules_from_path(pulsedmeasurementlogic.extraction_import_path,
+                                          self.is_extractor_class)
                 )
             except:
                 self.log.exception(
@@ -275,36 +263,6 @@ class PulseExtractor(PulseExtractorBase):
             else:
                 kwargs_dict[name] = default
         return kwargs_dict
-
-    def __import_external_extractors(self, path):
-        """ Helper method to import all modules from a given directory.
-        Find all classes in those modules that inherit exclusively from PulseExtractorBase and
-        return a list of them.
-
-        @param str path: Path to import modules from
-        @return list: A list of imported valid extractor classes
-        """
-        class_list = list()
-        # Get all python modules to import from.
-        # The assumption is that in the directory pulse_extraction_methods, there are
-        # *.py files, which contain only extractor classes!
-        module_list = [name[:-3] for name in os.listdir(path) if
-                       os.path.isfile(os.path.join(path, name)) and name.endswith('.py')]
-
-        # append import path to sys.path
-        if path not in sys.path:
-            sys.path.append(path)
-
-        # Go through all modules and create instances of each class found.
-        for module_name in module_list:
-            # import module
-            mod = importlib.import_module(str(module_name))
-            importlib.reload(mod)
-            # get all extractor class references defined in the module
-            tmp_list = [m[1] for m in inspect.getmembers(mod, self.is_extractor_class)]
-            # append to class_list
-            class_list.extend(tmp_list)
-        return class_list
 
     def __populate_method_dicts(self, instance_list):
         """

--- a/src/qudi/logic/pulsed/pulse_objects.py
+++ b/src/qudi/logic/pulsed/pulse_objects.py
@@ -21,15 +21,14 @@ If not, see <https://www.gnu.org/licenses/>.
 """
 
 import copy
-import os
-import sys
 import inspect
 import importlib
 import numpy as np
 import warnings
 
 from qudi.logic.pulsed.sampling_functions import SamplingFunctions, PulseEnvelope, PulseEnvelopeType
-from qudi.util.helpers import natural_sort, iter_modules_recursive
+from qudi.util.helpers import natural_sort
+from qudi.util.module_finder import get_modules_from_ns, get_modules_from_path
 
 
 class PulseBlockElement(object):
@@ -1781,28 +1780,15 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
             import qudi.logic.pulsed.predefined_generate_methods as _default_generator_ns
 
         # Import predefined generator modules and get a list of generator classes
-        generator_classes = list()
-        for mod_finder in iter_modules_recursive(_default_generator_ns.__path__, _default_generator_ns.__name__ + '.'):
-            try:
-                generator_classes.extend(
-                    [
-                        cls
-                        for _, cls in inspect.getmembers(
-                            importlib.import_module(mod_finder.name), self.is_generator_class
-                        )
-                    ]
-                )
-            except:
-                self.log.exception(
-                    f'Exception while importing qudi.logic.pulsed.predefined_generate_methods '
-                    f'sub-module "{mod_finder.name}":'
-                )
+        generator_classes = list(get_modules_from_ns(
+            _default_generator_ns, self.is_generator_class, logger=self.log
+        ).values())
 
         # Get predefined generator modules from non-default directory if a path has been given
         if isinstance(sequencegeneratorlogic.predefined_methods_import_path, (tuple, list, set)):
             for path in sequencegeneratorlogic.predefined_methods_import_path:
                 try:
-                    generator_classes.extend(self.__import_external_generators(path=path))
+                    generator_classes.extend(get_modules_from_path(path, self.is_generator_class))
                 except:
                     self.log.exception(f'Unable to import predefined generator from "{path}":')
 
@@ -1823,37 +1809,6 @@ class PulseObjectGenerator(PredefinedGeneratorBase):
     @property
     def predefined_method_parameters(self):
         return self._generate_method_parameters.copy()
-
-    def __import_external_generators(self, path):
-        """Helper method to import all modules from given directory path.
-        Find all classes in those modules that inherit exclusively from PredefinedGeneratorBase
-        class and return a list of them.
-
-        @param str path: Path to import modules from
-        @return list: A list of imported valid generator classes
-        """
-        class_list = list()
-        # Get all python modules to import from.
-        # The assumption is that in the path, there are *.py files,
-        # which contain only generator classes!
-        module_list = [
-            name[:-3] for name in os.listdir(path) if os.path.isfile(os.path.join(path, name)) and name.endswith('.py')
-        ]
-
-        # append import path to sys.path
-        if path not in sys.path:
-            sys.path.append(path)
-
-        # Go through all modules and create instances of each class found.
-        for module_name in module_list:
-            # import module
-            mod = importlib.import_module('{0}'.format(module_name))
-            importlib.reload(mod)
-            # get all generator class references defined in the module
-            tmp_list = [m[1] for m in inspect.getmembers(mod, self.is_generator_class)]
-            # append to class_list
-            class_list.extend(tmp_list)
-        return class_list
 
     def __populate_method_dict(self, instance_list):
         """

--- a/src/qudi/logic/pulsed/sampling_functions.py
+++ b/src/qudi/logic/pulsed/sampling_functions.py
@@ -22,7 +22,6 @@ If not, see <https://www.gnu.org/licenses/>.
 
 import os
 import importlib
-import sys
 import inspect
 import copy
 import logging
@@ -30,8 +29,7 @@ import numpy as np
 from enum import Enum, EnumMeta
 from dataclasses import dataclass, field
 
-from qudi.util.helpers import iter_modules_recursive
-
+from qudi.util.module_finder import get_module_names_from_ns, iter_directory_module_names
 ##############################################################
 # Helper class for everything that need dynamical decoupling #
 ##############################################################
@@ -171,24 +169,15 @@ class SamplingFunctions:
         except NameError:
             import qudi.logic.pulsed.sampling_function_defs as _default_sf_ns
 
-        for mod_finder in iter_modules_recursive(_default_sf_ns.__path__,
-                                                 _default_sf_ns.__name__ + '.'):
+        for module_name in get_module_names_from_ns(_default_sf_ns):
+            module_names.append(module_name)
 
-            module_names.append(mod_finder.name)
 
         # Import from additional directories
         for path in path_list:
             if not os.path.exists(path):
                 continue
-            # Get all python modules to import from.
-            module_list = [name[:-3] for name in os.listdir(path) if
-                           os.path.isfile(os.path.join(path, name)) and name.endswith('.py')]
-
-            # append import path to sys.path
-            if path not in sys.path:
-                sys.path.append(path)
-
-            module_names.extend(str(name) for name in module_list)
+            module_names.extend(iter_directory_module_names(path))
 
         # Go through all modules and get all sampling function classes.
         param_dict = dict()

--- a/src/qudi/logic/pulsed/sequence_generator_logic.py
+++ b/src/qudi/logic/pulsed/sequence_generator_logic.py
@@ -39,6 +39,7 @@ from qudi.util.paths import get_home_dir
 from qudi.util.helpers import natural_sort
 from qudi.util.network import netobtain
 from qudi.core.module import LogicBase
+from qudi.util.module_finder import normalize_import_paths
 from qudi.logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from qudi.logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElement
 from qudi.logic.pulsed.sampling_functions import PulseEnvelope, PulseEnvelopeType, SamplingFunctions
@@ -179,46 +180,19 @@ class SequenceGeneratorLogic(LogicBase):
             os.makedirs(self._assets_storage_dir)
 
         # additional import paths for generator modules
-        self._predefined_path_list = list()
-        if self._additional_methods_import_path:
-            if isinstance(self._additional_methods_import_path, str):
-                self._additional_methods_import_path = [self._additional_methods_import_path]
-
-            if isinstance(self._additional_methods_import_path, (list, tuple, set)):
-                for method_import_path in self._additional_methods_import_path:
-                    if not os.path.exists(method_import_path):
-                        self.log.error(
-                            'Specified path "{0}" for import of additional generate methods does not exist.'.format(
-                                method_import_path
-                            )
-                        )
-                    else:
-                        self._predefined_path_list.append(method_import_path)
-            else:
-                self.log.error(
-                    'ConfigOption additional_predefined_methods_path needs to either be a string or a list of strings.'
-                )
+        self._predefined_path_list = normalize_import_paths(
+            self._additional_methods_import_path,
+            option_name='additional_predefined_methods_path',
+            logger=self.log,
+        )
 
         # Initialize SamplingFunctions class by handing over a list of paths to import additional
         # sampling functions from.
-        sf_path_list = list()
-        if self._sampling_functions_import_path:
-            if isinstance(self._sampling_functions_import_path, str):
-                self._sampling_functions_import_path = [self._sampling_functions_import_path]
-
-            if isinstance(self._sampling_functions_import_path, (list, tuple, set)):
-                for functions_import_path in self._sampling_functions_import_path:
-                    if not os.path.exists(functions_import_path):
-                        self.log.error(
-                            'Specified path "{0}" for import of additional_sampling_functions_path '
-                            'does not exist.'.format(functions_import_path)
-                        )
-                    else:
-                        sf_path_list.append(functions_import_path)
-            else:
-                self.log.error(
-                    'ConfigOption additional_sampling_functions_path needs to either be a string or a list of strings.'
-                )
+        sf_path_list = normalize_import_paths(
+            self._sampling_functions_import_path,
+            option_name='additional_sampling_functions_path',
+            logger=self.log,
+        )
         SamplingFunctions.import_sampling_functions(sf_path_list)
 
         # Read back settings from device and update instance variables accordingly


### PR DESCRIPTION

## Description
This PR refactors some of Pulsed modules to use the module finder and changes introduced in the  [Qudi core's Module finder PR](https://github.com/Ulm-IQO/qudi-core/pull/169)

## Motivation and Context
It aims to reduce redundant code - to iterate and find modules in a namespace and directory, and normalize the paths.

## How Has This Been Tested?
This has been test locally with the testing framework.


## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
